### PR TITLE
Initial commit of the exporter daemon and its Go exporter

### DIFF
--- a/cmd/opencensusd/main.go
+++ b/cmd/opencensusd/main.go
@@ -1,0 +1,93 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Program opencensusd collects OpenCensus stats and traces
+// to export to a configured backend.
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+
+	pb "github.com/census-instrumentation/opencensus-proto/gen-go/exporterproto"
+	"github.com/census-instrumentation/opencensus-service/internal"
+	"google.golang.org/grpc"
+)
+
+func main() {
+	ls, err := net.Listen("tcp", "127.0.0.1:")
+	if err != nil {
+		log.Fatalf("Cannot listen: %v", err)
+	}
+
+	endpointFile := internal.DefaultEndpointFile()
+	if err := os.MkdirAll(filepath.Dir(endpointFile), 0755); err != nil {
+		log.Fatalf("Cannot make directory for the endpoint file: %v", err)
+	}
+	if err := ioutil.WriteFile(endpointFile, []byte(ls.Addr().String()), 0777); err != nil {
+		log.Fatalf("Cannot write the endpoint file: %v", err)
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		<-c
+		os.Remove(endpointFile)
+		os.Exit(0)
+	}()
+
+	s := grpc.NewServer()
+	pb.RegisterExportServer(s, &server{})
+	if err := s.Serve(ls); err != nil {
+		log.Fatalf("Failed to serve: %v", err)
+	}
+}
+
+type server struct{}
+
+func (s *server) ExportSpan(stream pb.Export_ExportSpanServer) error {
+	for {
+		in, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		// TODO(jbd): Implement.
+		fmt.Println(in)
+	}
+}
+
+func (s *server) ExportMetrics(stream pb.Export_ExportMetricsServer) error {
+	for {
+		in, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		// TODO(jbd): Implement.
+		fmt.Println(in)
+	}
+}
+
+// TODO(jbd): Implement exporting to a backend.

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,37 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Sample contains a program that exports to the OpenCensus service.
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/census-instrumentation/opencensus-service/exporter"
+	"go.opencensus.io/trace"
+)
+
+func main() {
+	trace.RegisterExporter(&exporter.Exporter{})
+	trace.ApplyConfig(trace.Config{
+		DefaultSampler: trace.AlwaysSample(),
+	})
+
+	for {
+		_, span := trace.StartSpan(context.Background(), "foo")
+		time.Sleep(100 * time.Millisecond)
+		span.End()
+	}
+}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -1,0 +1,177 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package exporter contains an OpenCensus service exporter.
+package exporter
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"sync"
+	"time"
+
+	"go.opencensus.io/trace"
+	"google.golang.org/grpc"
+
+	"github.com/census-instrumentation/opencensus-proto/gen-go/exporterproto"
+	"github.com/census-instrumentation/opencensus-proto/gen-go/traceproto"
+	"github.com/census-instrumentation/opencensus-service/internal"
+	"github.com/golang/protobuf/ptypes/timestamp"
+)
+
+var debug bool
+
+func init() {
+	_, debug = os.LookupEnv("OPENCENSUS_DEBUG")
+}
+
+type Exporter struct {
+	OnError func(err error)
+
+	initOnce sync.Once
+
+	clientMu       sync.Mutex
+	clientEndpoint string
+	spanClient     exporterproto.Export_ExportSpanClient
+}
+
+func (e *Exporter) init() {
+	go func() {
+		for {
+			e.lookup()
+		}
+	}()
+}
+
+func (e *Exporter) lookup() {
+	defer func() {
+		debugPrintf("Sleeping for a minute...")
+		time.Sleep(60 * time.Second)
+	}()
+
+	debugPrintf("Looking for the endpoint file")
+	file := internal.DefaultEndpointFile()
+	ep, err := ioutil.ReadFile(file)
+	if os.IsNotExist(err) {
+		e.deleteClient()
+		debugPrintf("Endpoint file doesn't exist; disabling exporting")
+		return
+	}
+	if err != nil {
+		e.onError(err)
+		return
+	}
+
+	e.clientMu.Lock()
+	oldendpoint := e.clientEndpoint
+	e.clientMu.Unlock()
+
+	endpoint := string(ep)
+	if oldendpoint == endpoint {
+		debugPrintf("Endpoint hasn't changed, doing nothing")
+		return
+	}
+
+	debugPrintf("Dialing %v...", endpoint)
+	conn, err := grpc.Dial(endpoint, grpc.WithInsecure())
+	if err != nil {
+		e.onError(err)
+		return
+	}
+
+	e.clientMu.Lock()
+	defer e.clientMu.Unlock()
+
+	client := exporterproto.NewExportClient(conn)
+	e.spanClient, err = client.ExportSpan(context.Background())
+	if err != nil {
+		e.onError(err)
+		return
+	}
+}
+
+func (e *Exporter) onError(err error) {
+	if e.OnError != nil {
+		e.OnError(err)
+		return
+	}
+	log.Printf("Exporter fail: %v", err)
+}
+
+// ExportSpan exports span data to the exporter daemon.
+func (e *Exporter) ExportSpan(sd *trace.SpanData) {
+	e.initOnce.Do(e.init)
+
+	e.clientMu.Lock()
+	spanClient := e.spanClient
+	e.clientMu.Unlock()
+
+	if spanClient == nil {
+		return
+	}
+
+	debugPrintf("Exporting span [%v]", sd.SpanContext)
+	s := &traceproto.Span{
+		TraceId:      sd.SpanContext.TraceID[:],
+		SpanId:       sd.SpanContext.SpanID[:],
+		ParentSpanId: sd.ParentSpanID[:],
+		Name: &traceproto.TruncatableString{
+			Value: sd.Name,
+		},
+		StartTime: &timestamp.Timestamp{
+			Seconds: sd.StartTime.Unix(),
+			Nanos:   int32(sd.StartTime.Nanosecond()),
+		},
+		EndTime: &timestamp.Timestamp{
+			Seconds: sd.EndTime.Unix(),
+			Nanos:   int32(sd.EndTime.Nanosecond()),
+		},
+		// TODO(jbd): Add attributes and others.
+	}
+
+	if err := spanClient.Send(&exporterproto.ExportSpanRequest{
+		Spans: []*traceproto.Span{s},
+	}); err != nil {
+		if err == io.EOF {
+			debugPrintf("Connection is unavailable; will try to reconnect in a minute")
+			e.deleteClient()
+		} else {
+			e.onError(err)
+		}
+	}
+}
+
+func (e *Exporter) deleteClient() {
+	e.clientMu.Lock()
+	e.spanClient = nil
+	e.clientEndpoint = ""
+	e.clientMu.Unlock()
+}
+
+func debugPrintf(msg string, arg ...interface{}) {
+	if debug {
+		if len(arg) > 0 {
+			fmt.Printf(msg, arg)
+		} else {
+			fmt.Printf(msg)
+		}
+		fmt.Println()
+	}
+}
+
+// TODO(jbd): Add stats/metrics exporter.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,0 +1,44 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+)
+
+// DefaultEndpointFile is the location where the
+// endpoint file is at on the current platform.
+func DefaultEndpointFile() string {
+	const f = "opencensus.endpoint"
+	if runtime.GOOS == "windows" {
+		return filepath.Join(os.Getenv("APPDATA"), "opencensus", f)
+	}
+	return filepath.Join(guessUnixHomeDir(), ".config", f)
+}
+
+func guessUnixHomeDir() string {
+	// Prefer $HOME over user.Current due to glibc bug: golang.org/issue/13470
+	if v := os.Getenv("HOME"); v != "" {
+		return v
+	}
+	// Else, fall back to user.Current:
+	if u, err := user.Current(); err == nil {
+		return u.HomeDir
+	}
+	return ""
+}


### PR DESCRIPTION
This commit contains an initial prototype for the exporter daemon
that can discovered via and endpoint file on the host.

The exporter looks for the endpoint file to see the availability
of the daemon and exports if it is running.

Exporter daemon will allow OpenCensus users to export
without having to link a vendor-specific exporter in their final
binaries. We are expecting the prototype exporter is going to
be implemented in every language and registered by default.