### PR TITLE
Make endpoint file a JSON

### DIFF
--- a/cmd/opencensusd/main.go
+++ b/cmd/opencensusd/main.go
@@ -20,12 +20,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
 	"os/signal"
-	"path/filepath"
 
 	pb "github.com/census-instrumentation/opencensus-proto/gen-go/exporterproto"
 	"github.com/census-instrumentation/opencensus-service/internal"
@@ -41,12 +39,12 @@ func main() {
 		log.Fatalf("Cannot listen: %v", err)
 	}
 
-	endpointFile := internal.DefaultEndpointFile()
-	if err := os.MkdirAll(filepath.Dir(endpointFile), 0755); err != nil {
-		log.Fatalf("Cannot make directory for the endpoint file: %v", err)
+	service := &internal.Service{
+		Endpoint: ls.Addr().String(),
 	}
-	if err := ioutil.WriteFile(endpointFile, []byte(ls.Addr().String()), 0777); err != nil {
-		log.Fatalf("Cannot write the endpoint file: %v", err)
+	endpointFile, err := service.WriteToEndpointFile()
+	if err != nil {
+		log.Fatalf("Cannot write to the endpoint file: %v", err)
 	}
 
 	c := make(chan os.Signal, 1)

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -65,8 +64,7 @@ func (e *Exporter) lookup() {
 	}()
 
 	debugPrintf("Looking for the endpoint file")
-	file := internal.DefaultEndpointFile()
-	ep, err := ioutil.ReadFile(file)
+	service, err := internal.ParseEndpointFile()
 	if os.IsNotExist(err) {
 		e.deleteClient()
 		debugPrintf("Endpoint file doesn't exist; disabling exporting")
@@ -81,7 +79,7 @@ func (e *Exporter) lookup() {
 	oldendpoint := e.clientEndpoint
 	e.clientMu.Unlock()
 
-	endpoint := string(ep)
+	endpoint := service.Endpoint
 	if oldendpoint == endpoint {
 		debugPrintf("Endpoint hasn't changed, doing nothing")
 		return


### PR DESCRIPTION
It allows us to extend what else we are going to store
as metadata in the file.

Fixes #5.