### PR TITLE
Use grpc-gateway to add HTTP/JSON endpoint option

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -37,6 +37,7 @@
 [[projects]]
   name = "github.com/golang/protobuf"
   packages = [
+    "jsonpb",
     "proto",
     "protoc-gen-go/descriptor",
     "ptypes",
@@ -55,6 +56,16 @@
   packages = ["."]
   revision = "317e0006254c44a0ac427cc52a0e083ff0b9622f"
   version = "v2.0.0"
+
+[[projects]]
+  name = "github.com/grpc-ecosystem/grpc-gateway"
+  packages = [
+    "runtime",
+    "runtime/internal",
+    "utilities"
+  ]
+  revision = "92583770e3f01b09a0d3e9bdf64321d8bebd48f2"
+  version = "v1.4.1"
 
 [[projects]]
   name = "github.com/openzipkin/zipkin-go"
@@ -256,6 +267,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9c63df1e8e813c490dce3f098964a0f5ec7e65f9dbcaa44342816583d1e2e1de"
+  inputs-digest = "813ea8341ef8b22e442fb44c8e96a3c2a6484ac3c3d3c2c5809425a0e69bb661"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/opencensusd/main.go
+++ b/cmd/opencensusd/main.go
@@ -36,8 +36,8 @@ import (
 )
 
 func main() {
-	listen := flag.String("listen", "127.0.0.1:", "")
-	listenHttp := flag.String("listen_http", "127.0.0.1:", "")
+	listen := flag.String("listen", "127.0.0.1:", "IP/port for gRPC")
+	listenHttp := flag.String("listen_http", "", "(Optional) IP/port for HTTP/JSON")
 	flag.Parse()
 
 	const configFile = "config.yaml"
@@ -84,7 +84,6 @@ func main() {
 }
 
 func serveHttpGateway(listenHttp string, grpcEndpoint string) {
-	fmt.Printf("Starting HTTP listen..")
 	ctx := context.Background()
 	mux := runtime.NewServeMux()
 	opts := []grpc.DialOption{grpc.WithInsecure()}
@@ -92,9 +91,8 @@ func serveHttpGateway(listenHttp string, grpcEndpoint string) {
 		log.Fatalf("Failed to register HTTP gateway: %v", err)
 	}
 	if err := http.ListenAndServe(listenHttp, mux); err != nil {
-		log.Fatalf("Failed to listen/service HTTP gateway: %v", err)
+		log.Fatalf("Failed to listen/serve HTTP gateway: %v", err)
 	}
-	fmt.Printf("Listening for http..")
 }
 
 type server struct{}

--- a/cmd/opencensusd/main.go
+++ b/cmd/opencensusd/main.go
@@ -19,21 +19,25 @@ package main
 import (
 	"flag"
 	"fmt"
+	"golang.org/x/net/context"
 	"io"
 	"io/ioutil"
 	"log"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 
 	pb "github.com/census-instrumentation/opencensus-proto/gen-go/exporterproto"
 	"github.com/census-instrumentation/opencensus-service/cmd/opencensusd/exporter"
 	"github.com/census-instrumentation/opencensus-service/internal"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"
 )
 
 func main() {
 	listen := flag.String("listen", "127.0.0.1:", "")
+	listenHttp := flag.String("listen_http", "127.0.0.1:", "")
 	flag.Parse()
 
 	const configFile = "config.yaml"
@@ -68,11 +72,29 @@ func main() {
 		os.Exit(0)
 	}()
 
+	if *listenHttp != "" {
+		go serveHttpGateway(*listenHttp, service.Endpoint)
+	}
+
 	s := grpc.NewServer()
 	pb.RegisterExportServer(s, &server{})
 	if err := s.Serve(ls); err != nil {
 		log.Fatalf("Failed to serve: %v", err)
 	}
+}
+
+func serveHttpGateway(listenHttp string, grpcEndpoint string) {
+	fmt.Printf("Starting HTTP listen..")
+	ctx := context.Background()
+	mux := runtime.NewServeMux()
+	opts := []grpc.DialOption{grpc.WithInsecure()}
+	if err := pb.RegisterExportHandlerFromEndpoint(ctx, mux, grpcEndpoint, opts); err != nil {
+		log.Fatalf("Failed to register HTTP gateway: %v", err)
+	}
+	if err := http.ListenAndServe(listenHttp, mux); err != nil {
+		log.Fatalf("Failed to listen/service HTTP gateway: %v", err)
+	}
+	fmt.Printf("Listening for http..")
 }
 
 type server struct{}


### PR DESCRIPTION
This depends on https://github.com/census-instrumentation/opencensus-proto/pull/77 but wanted to put this out early to show the concept of how it would be used.

If the `listen_http` argument is passed to `opencensusd` it will accept HTTP/JSON requests and proxy them to its own gRPC endpoint.

This would enable clients who do not have gRPC support (older systems, languages with no gRPC compilation) and also browser clients (some authentication middle layer / API gateway would be a best practice too, but just allowing HTTP is a start, and users could use API gateways from a cloud provider).