### PR TITLE
spanreceiver: define SpanReceiver interface

### DIFF
--- a/spanreceiver/spanreceiver.go
+++ b/spanreceiver/spanreceiver.go
@@ -1,0 +1,30 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanreceiver
+
+import (
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+)
+
+// SpanReceiver is an interface that receives spans from a Node identifier.
+type SpanReceiver interface {
+	ReceiveSpans(node *commonpb.Node, spans ...*tracepb.Span) (*Acknowledgement, error)
+}
+
+type Acknowledgement struct {
+	SavedSpans   uint64
+	DroppedSpans uint64
+}


### PR DESCRIPTION
An interface `SpanReceiver` that receives *tracepb.Span instances
and sends back an acknowledgement and an error.

The return signature is `(*Acknowledgement, error)` because it
would useful to return to callers information about how many spans
were successful, errors that were encountered, allowing for batches
of spans to be written like we would with `io.Write`. This will allow
callers to retry, report success and failure rates too.

Fixes #30