### PR TITLE
translator/trace: OCSpanDataToProtoSpan

### DIFF
--- a/translator/trace/spandata_to_protospan.go
+++ b/translator/trace/spandata_to_protospan.go
@@ -1,0 +1,169 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package trace defines translators to convert between Trace proto spans and OpenCensus-Go SpanData
+*/
+package tracetranslator
+
+import (
+	"errors"
+	"time"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/tracestate"
+
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes/timestamp"
+)
+
+var errNilSpanData = errors.New("expected a non-nil spandata")
+
+func OCSpanDataToProtoSpan(sd *trace.SpanData) (*tracepb.Span, error) {
+	if sd == nil {
+		return nil, errNilSpanData
+	}
+	var namePtr *tracepb.TruncatableString
+	if sd.Name != "" {
+		namePtr = &tracepb.TruncatableString{Value: sd.Name}
+	}
+	span := &tracepb.Span{
+		TraceId:      sd.TraceID[:],
+		SpanId:       sd.SpanID[:],
+		ParentSpanId: sd.ParentSpanID[:],
+		Status:       ocStatusToProtoStatus(sd.Status),
+		StartTime:    timeToTimestamp(sd.StartTime),
+		EndTime:      timeToTimestamp(sd.EndTime),
+		Links:        ocLinksToProtoLinks(sd.Links),
+		Kind:         ocSpanKindToProtoSpanKind(sd.SpanKind),
+		Name:         namePtr,
+		Attributes:   ocAttributesToProtoAttributes(sd.Attributes),
+		Tracestate:   ocTracestateToProtoTracestate(sd.Tracestate),
+	}
+	return span, nil
+}
+
+var blankStatus trace.Status
+
+func ocStatusToProtoStatus(status trace.Status) *tracepb.Status {
+	if status == blankStatus {
+		return nil
+	}
+	return &tracepb.Status{
+		Code:    status.Code,
+		Message: status.Message,
+	}
+}
+
+func ocLinksToProtoLinks(links []trace.Link) *tracepb.Span_Links {
+	if len(links) == 0 {
+		return nil
+	}
+
+	sl := make([]*tracepb.Span_Link, 0, len(links))
+	for _, ocLink := range links {
+		// This redefinition is necessary to prevent ocLink.*ID[:] copies
+		// being reused -- in short we need a new ocLink per iteration.
+		ocLink := ocLink
+
+		sl = append(sl, &tracepb.Span_Link{
+			TraceId: ocLink.TraceID[:],
+			SpanId:  ocLink.SpanID[:],
+			Type:    ocLinkTypeToProtoLinkType(ocLink.Type),
+		})
+	}
+
+	return &tracepb.Span_Links{
+		Link: sl,
+	}
+}
+
+func ocLinkTypeToProtoLinkType(oct trace.LinkType) tracepb.Span_Link_Type {
+	switch oct {
+	case trace.LinkTypeChild:
+		return tracepb.Span_Link_CHILD_LINKED_SPAN
+	case trace.LinkTypeParent:
+		return tracepb.Span_Link_PARENT_LINKED_SPAN
+	default:
+		return tracepb.Span_Link_TYPE_UNSPECIFIED
+	}
+}
+
+func ocAttributesToProtoAttributes(attrs map[string]interface{}) *tracepb.Span_Attributes {
+	if len(attrs) == 0 {
+		return nil
+	}
+	outMap := make(map[string]*tracepb.AttributeValue)
+	for k, v := range attrs {
+		switch v := v.(type) {
+		case bool:
+			outMap[k] = &tracepb.AttributeValue{Value: &tracepb.AttributeValue_BoolValue{BoolValue: v}}
+
+		case int:
+			outMap[k] = &tracepb.AttributeValue{Value: &tracepb.AttributeValue_IntValue{IntValue: int64(v)}}
+
+		case int64:
+			outMap[k] = &tracepb.AttributeValue{Value: &tracepb.AttributeValue_IntValue{IntValue: v}}
+
+		case string:
+			outMap[k] = &tracepb.AttributeValue{
+				Value: &tracepb.AttributeValue_StringValue{
+					StringValue: &tracepb.TruncatableString{Value: v},
+				},
+			}
+		}
+	}
+	return &tracepb.Span_Attributes{
+		AttributeMap: outMap,
+	}
+}
+
+func timeToTimestamp(t time.Time) *timestamp.Timestamp {
+	nanoTime := t.UnixNano()
+	return &timestamp.Timestamp{
+		Seconds: nanoTime / 1e9,
+		Nanos:   int32(nanoTime % 1e9),
+	}
+}
+
+func ocSpanKindToProtoSpanKind(kind int) tracepb.Span_SpanKind {
+	switch kind {
+	case trace.SpanKindClient:
+		return tracepb.Span_CLIENT
+	case trace.SpanKindServer:
+		return tracepb.Span_SERVER
+	default:
+		return tracepb.Span_SPAN_KIND_UNSPECIFIED
+	}
+}
+
+func ocTracestateToProtoTracestate(ts *tracestate.Tracestate) *tracepb.Span_Tracestate {
+	if ts == nil {
+		return nil
+	}
+	return &tracepb.Span_Tracestate{
+		Entries: ocTracestateEntriesToProtoTracestateEntries(ts.Entries()),
+	}
+}
+
+func ocTracestateEntriesToProtoTracestateEntries(entries []tracestate.Entry) []*tracepb.Span_Tracestate_Entry {
+	protoEntries := make([]*tracepb.Span_Tracestate_Entry, 0, len(entries))
+	for _, entry := range entries {
+		protoEntries = append(protoEntries, &tracepb.Span_Tracestate_Entry{
+			Key:   entry.Key,
+			Value: entry.Value,
+		})
+	}
+	return protoEntries
+}

--- a/translator/trace/spandata_to_protospan_test.go
+++ b/translator/trace/spandata_to_protospan_test.go
@@ -1,0 +1,147 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracetranslator_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/tracestate"
+
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	tracetranslator "github.com/census-instrumentation/opencensus-service/translator/trace"
+)
+
+func TestOCSpanDataToProtoSpan_endToEnd(t *testing.T) {
+	// The goal of this test is to ensure that each
+	// spanData is transformed and exported correctly!
+	ocTracestate, err := tracestate.New(new(tracestate.Tracestate), tracestate.Entry{Key: "foo", Value: "bar"},
+		tracestate.Entry{Key: "a", Value: "b"})
+	if err != nil || ocTracestate == nil {
+		t.Fatalf("Failed to create ocTracestate: %v", err)
+	}
+
+	startTime := time.Now()
+	endTime := startTime.Add(10 * time.Second)
+	ocSpanData := &trace.SpanData{
+		SpanContext: trace.SpanContext{
+			TraceID:    trace.TraceID{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
+			SpanID:     trace.SpanID{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8},
+			Tracestate: ocTracestate,
+		},
+		SpanKind:     trace.SpanKindServer,
+		ParentSpanID: trace.SpanID{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8},
+		Name:         "End-To-End Here",
+		StartTime:    startTime,
+		EndTime:      endTime,
+		MessageEvents: []trace.MessageEvent{
+			{Time: startTime, EventType: trace.MessageEventTypeSent, UncompressedByteSize: 1024, CompressedByteSize: 512},
+			{Time: endTime, EventType: trace.MessageEventTypeRecv, UncompressedByteSize: 1024, CompressedByteSize: 1000},
+		},
+		Links: []trace.Link{
+			{
+				TraceID: trace.TraceID{0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF},
+				SpanID:  trace.SpanID{0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7},
+				Type:    trace.LinkTypeParent,
+			},
+			{
+				TraceID: trace.TraceID{0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF},
+				SpanID:  trace.SpanID{0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7},
+				Type:    trace.LinkTypeChild,
+			},
+		},
+		Status: trace.Status{
+			Code:    trace.StatusCodeInternal,
+			Message: "This is not a drill!",
+		},
+		HasRemoteParent: true,
+		Attributes: map[string]interface{}{
+			"timeout_ns": int64(12e9),
+			"agent":      "ocagent",
+			"cache_hit":  true,
+			"ping_count": int(25), // Should be transformed into int64
+		},
+	}
+
+	// TODO: file a bug with opencensus-go because trace.Annotation.Attributes' type is map[string]interface{}
+	// yet Attribute value and key cannot be easily introspected, so we can't easily test the values.
+
+	gotSpan, err := tracetranslator.OCSpanDataToProtoSpan(ocSpanData)
+	if err != nil {
+		t.Fatalf("Failed to convert from OCSpanData to ProtoSpan: %v", err)
+	}
+	wantProtoSpan := &tracepb.Span{
+		TraceId:      []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
+		SpanId:       []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8},
+		ParentSpanId: []byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8},
+		Name:         &tracepb.TruncatableString{Value: "End-To-End Here"},
+		Kind:         tracepb.Span_SERVER,
+		StartTime:    timeToTimestamp(startTime),
+		EndTime:      timeToTimestamp(endTime),
+		Status: &tracepb.Status{
+			Code:    13,
+			Message: "This is not a drill!",
+		},
+		Links: &tracepb.Span_Links{
+			Link: []*tracepb.Span_Link{
+				{
+					TraceId: []byte{0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF},
+					SpanId:  []byte{0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7},
+					Type:    tracepb.Span_Link_PARENT_LINKED_SPAN,
+				},
+				{
+					TraceId: []byte{0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF},
+					SpanId:  []byte{0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7},
+					Type:    tracepb.Span_Link_CHILD_LINKED_SPAN,
+				},
+			},
+		},
+		Tracestate: &tracepb.Span_Tracestate{
+			Entries: []*tracepb.Span_Tracestate_Entry{
+				{Key: "foo", Value: "bar"},
+				{Key: "a", Value: "b"},
+			},
+		},
+		Attributes: &tracepb.Span_Attributes{
+			AttributeMap: map[string]*tracepb.AttributeValue{
+				"cache_hit":  {Value: &tracepb.AttributeValue_BoolValue{BoolValue: true}},
+				"timeout_ns": {Value: &tracepb.AttributeValue_IntValue{IntValue: 12e9}},
+				"ping_count": {Value: &tracepb.AttributeValue_IntValue{IntValue: 25}},
+				"agent": {Value: &tracepb.AttributeValue_StringValue{
+					StringValue: &tracepb.TruncatableString{Value: "ocagent"},
+				}},
+			},
+		},
+	}
+
+	if g, w := gotSpan, wantProtoSpan; !reflect.DeepEqual(g, w) {
+		for i := 0; i < len(w.Links.Link); i++ {
+			t.Logf("#%d:: \nGot:  %#v\nWant: %#v\n\n", i, g.Links.Link[i], w.Links.Link[i])
+		}
+		t.Fatalf("End-to-end transformed span\n\tGot  %+v\n\tWant %+v", g, w)
+	}
+}
+
+func timeToTimestamp(t time.Time) *timestamp.Timestamp {
+	nanoTime := t.UnixNano()
+	return &timestamp.Timestamp{
+		Seconds: nanoTime / 1e9,
+		Nanos:   int32(nanoTime % 1e9),
+	}
+}


### PR DESCRIPTION
Provides a function to translate OpenCensus SpanData
into *tracepb.Span, with tests. It is the first half of
the trace converters task.

Updates #26