### PR TITLE
cmd/ocagent: retrofitted with new protocol

### DIFF
--- a/cmd/ocagent/exporterparser/stackdriver.go
+++ b/cmd/ocagent/exporterparser/stackdriver.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporter
+package exporterparser
 
 import (
 	"log"
@@ -24,10 +24,9 @@ import (
 )
 
 type stackdriverConfig struct {
-	Stackdriver struct {
+	Stackdriver *struct {
 		ProjectID     string `yaml:"project,omitempty"`
-		EnableMetrics bool   `yaml:"enableMetrics,omitempty"`
-		EnableTraces  bool   `yaml:"enableTraces,omitempty"`
+		EnableTracing bool   `yaml:"enable_tracing,omitempty"`
 	} `yaml:"stackdriver,omitempty"`
 }
 
@@ -38,24 +37,25 @@ func (s *stackdriverExporter) MakeExporters(config []byte) (se view.Exporter, te
 	if err := yaml.Unmarshal(config, &c); err != nil {
 		log.Fatalf("Cannot unmarshal data: %v", err)
 	}
-	if s := c.Stackdriver; s.EnableMetrics || s.EnableTraces {
-		// TODO(jbd): Add monitored resources.
-		if s.ProjectID == "" {
-			log.Fatal("Stackdriver config requires a project ID")
-		}
-		exporter, err := stackdriver.NewExporter(stackdriver.Options{
-			ProjectID: s.ProjectID,
-		})
-		if err != nil {
-			log.Fatalf("Cannot configure Stackdriver exporter: %v", err)
-		}
-		if s.EnableMetrics {
-			se = exporter
-		}
-		if s.EnableTraces {
-			te = exporter
-		}
-		closer = exporter.Flush
+	sc := c.Stackdriver
+	if sc == nil {
+		return nil, nil, nil
 	}
-	return se, te, closer
+	if !sc.EnableTracing {
+		return nil, nil, nil
+	}
+
+	// TODO(jbd): Add monitored resources.
+	if sc.ProjectID == "" {
+		log.Fatal("Stackdriver config requires a project ID")
+	}
+	sde, err := stackdriver.NewExporter(stackdriver.Options{
+		ProjectID: sc.ProjectID,
+	})
+	if err != nil {
+		log.Fatalf("Cannot configure Stackdriver exporter: %v", err)
+	}
+
+	closer = sde.Flush
+	return nil, sde, closer
 }


### PR DESCRIPTION
With this change, cmd/ocagent now adheres
to the new protocol and currently runs
the OpenCensus interceptor while exporting
received spans to the various and previously
already created YAML configured exporters such as:
* Stackdriver Tracing
* DataDog
* Zipkin

which are statically imported.

Now any program that has an ocagent-exporter
can send traces to this service. The service's
OpenCensus Interceptor Port can be configured by
```shell
ocagent -oci-port=<value>
```
which by default is `55678`

After this change we can add both more trace exporters
and more trace interceptors.

Essentially this can be our v0.0.1 of the new trace
agent/service.