### PR TITLE
cmd/ocagent: OpenCensus interceptor bind address configurable via config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,18 +160,21 @@ backend (e.g Jaeger Thrift Span), and then push them to corresponding backend or
 
 First, install ocagent if you haven't.
 
-```
+```shell
 $ go get github.com/census-instrumentation/opencensus-service/cmd/ocagent
 ```
 
+### Configuration file
+
 Create a config.yaml file in the current directory and modify
-it with the exporter configuration. For example, following
-configuration exports both to Stackdriver and Zipkin.
+it with the exporter and interceptor configurations.
 
 
-config.yaml:
+#### Exporters
 
-```
+For example, to allow trace exporting to Stackdriver and Zipkin:
+
+```yaml
 stackdriver:
   project: "your-project-id"
   enableTraces: true
@@ -180,22 +183,37 @@ zipkin:
   endpoint: "http://localhost:9411/api/v2/spans"
 ```
 
-Run the example application that collects traces and exports
-to the daemon if it is running.
+#### Interceptors
 
-```
-$ go run "$(go env GOPATH)/src/github.com/census-instrumentation/opencensus-service/example/main.go"
+To modify the address that the OpenCensus interceptor runs on, please use the
+YAML field name `opencensus_interceptor` and it takes fields like `address`.
+For example:
+
+```yaml
+opencensus_interceptor:
+    address: "localhost:55678"
 ```
 
-Run ocagent:
+### Running an end-to-end example/demo
 
-```
+Run the example application that collects traces and exports them
+to the daemon.
+
+Firstly run ocagent:
+
+```shell
 $ ocagent
 ```
 
+Next run the demo application:
+
+```shell
+$ go run "$(go env GOPATH)/src/github.com/census-instrumentation/opencensus-service/example/main.go"
+```
+
 You should be able to see the traces in Stackdriver and Zipkin.
-If you stop the ocagent, example application will stop exporting.
-If you run it again, it will start exporting again.
+If you stop the ocagent, the example application will stop exporting.
+If you run it again, exporting will resume.
 
 ## OpenCensus Collector
 
@@ -281,8 +299,9 @@ $ go run "$(go env GOPATH)/src/github.com/census-instrumentation/opencensus-serv
 
 Run ocagent:
 
-```
+```shell
 $ ocagent
+2018/10/08 21:38:00 Running OpenCensus interceptor as a gRPC service at "127.0.0.1:55678"
 ```
 
 You should be able to see the traces in the configured tracing backend.

--- a/cmd/ocagent/config.go
+++ b/cmd/ocagent/config.go
@@ -1,0 +1,45 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	yaml "gopkg.in/yaml.v2"
+)
+
+const defaultOCInterceptorAddress = "localhost:55678"
+
+type topLevelConfig struct {
+	OpenCensusInterceptorConfig *config `yaml:"opencensus_interceptor"`
+}
+
+type config struct {
+	// The address to which the OpenCensus interceptor will be bound and run on.
+	Address string `yaml:"address"`
+}
+
+func (tcfg *topLevelConfig) openCensusInterceptorAddressOrDefault() string {
+	if tcfg == nil || tcfg.OpenCensusInterceptorConfig == nil || tcfg.OpenCensusInterceptorConfig.Address == "" {
+		return defaultOCInterceptorAddress
+	}
+	return tcfg.OpenCensusInterceptorConfig.Address
+}
+
+func parseOCAgentConfig(yamlBlob []byte) (*topLevelConfig, error) {
+	cfg := new(topLevelConfig)
+	if err := yaml.Unmarshal(yamlBlob, cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/cmd/ocagent/config.yaml
+++ b/cmd/ocagent/config.yaml
@@ -1,3 +1,6 @@
+opencensus_interceptor:
+  address: "127.0.0.1:55678"
+
 stackdriver:
   project: "project-id"
   enableTraces: true


### PR DESCRIPTION
Use the config.yaml file to configure the OpenCensus
interceptor listener's address, instead of using commandline flags.
This is because all the other configurations are performed
using the config.yaml file so an extra option is just confusing.

The default port to run on is 55678 if unspecified, but otherwise
YAML parseable by key `opencensus_interceptor`, and then using the
field name `address`. For example:

```yaml
opencensus_interceptor:
  address: ":55777"
```

and when run with
```shell
ocagent
```

which will then produce:
```shell
2018/10/08 16:36:47 Running OpenCensus interceptor as a gRPC service at "localhost:55777"
```

Fixes #23