### PR TITLE
fixup improper closure usage

### DIFF
--- a/interceptor/opencensus/opencensus.go
+++ b/interceptor/opencensus/opencensus.go
@@ -103,13 +103,13 @@ func (oci *OCInterceptor) Export(tes agenttracepb.TraceService_ExportServer) err
 
 	processReceivedSpans := func(ni *commonpb.Node, spans []*tracepb.Span) {
 		// Firstly, we'll add them to the bundler.
-		if len(recv.Spans) > 0 {
-			bundlerPayload := &spansAndNode{node: ni, spans: recv.Spans}
+		if len(spans) > 0 {
+			bundlerPayload := &spansAndNode{node: ni, spans: spans}
 			traceBundler.Add(bundlerPayload, len(bundlerPayload.spans))
 		}
 
 		// We MUST unconditionally record metrics from this reception.
-		spansMetricsFn(ni, recv.Spans)
+		spansMetricsFn(ni, spans)
 	}
 
 	var lastNonNilNode *commonpb.Node


### PR DESCRIPTION
I think there is an improper use of closure between [opencensus.go#L104](https://github.com/census-instrumentation/opencensus-service/blob/master/interceptor/opencensus/opencensus.go#L104) and [opencensus.go#L113](https://github.com/census-instrumentation/opencensus-service/blob/master/interceptor/opencensus/opencensus.go#L113)

```golang
	processReceivedSpans := func(ni *commonpb.Node, spans []*tracepb.Span) {
		// Firstly, we'll add them to the bundler.
		if len(recv.Spans) > 0 {
			bundlerPayload := &spansAndNode{node: ni, spans: recv.Spans}
			traceBundler.Add(bundlerPayload, len(bundlerPayload.spans))
		}

		// We MUST unconditionally record metrics from this reception.
		spansMetricsFn(ni, recv.Spans)
	}
```

This PR makes code changes as follow:

```golang
	processReceivedSpans := func(ni *commonpb.Node, spans []*tracepb.Span) {
		// Firstly, we'll add them to the bundler.
		if len(spans) > 0 {
			bundlerPayload := &spansAndNode{node: ni, spans: spans}
			traceBundler.Add(bundlerPayload, len(bundlerPayload.spans))
		}

		// We MUST unconditionally record metrics from this reception.
		spansMetricsFn(ni, spans)
	}
```