### PR TITLE
all: move helper TimeToTimestamp to internal

### DIFF
--- a/interceptor/opencensus/opencensus_test.go
+++ b/interceptor/opencensus/opencensus_test.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"google.golang.org/grpc"
 
 	"contrib.go.opencensus.io/exporter/ocagent"
@@ -124,8 +123,8 @@ func TestOCInterceptor_endToEnd(t *testing.T) {
 			ParentSpanId: serverSpanData.ParentSpanID[:],
 			Name:         &tracepb.TruncatableString{Value: "ServerSpan"},
 			Kind:         tracepb.Span_SERVER,
-			StartTime:    timeToTimestamp(serverSpanData.StartTime),
-			EndTime:      timeToTimestamp(serverSpanData.EndTime),
+			StartTime:    internal.TimeToTimestamp(serverSpanData.StartTime),
+			EndTime:      internal.TimeToTimestamp(serverSpanData.EndTime),
 			Status:       &tracepb.Status{Code: int32(serverSpanData.Status.Code), Message: serverSpanData.Status.Message},
 			Tracestate:   &tracepb.Span_Tracestate{},
 			Links: &tracepb.Span_Links{
@@ -144,8 +143,8 @@ func TestOCInterceptor_endToEnd(t *testing.T) {
 			ParentSpanId: clientSpanData.ParentSpanID[:],
 			Name:         &tracepb.TruncatableString{Value: "ClientSpan"},
 			Kind:         tracepb.Span_CLIENT,
-			StartTime:    timeToTimestamp(clientSpanData.StartTime),
-			EndTime:      timeToTimestamp(clientSpanData.EndTime),
+			StartTime:    internal.TimeToTimestamp(clientSpanData.StartTime),
+			EndTime:      internal.TimeToTimestamp(clientSpanData.EndTime),
 			Status:       &tracepb.Status{Code: int32(clientSpanData.Status.Code), Message: clientSpanData.Status.Message},
 		},
 	}
@@ -511,13 +510,5 @@ func (sa *spanAppender) forEachEntry(fn func(*commonpb.Node, []*tracepb.Span)) {
 
 	for node, spans := range sa.spansPerNode {
 		fn(node, spans)
-	}
-}
-
-func timeToTimestamp(t time.Time) *timestamp.Timestamp {
-	nanoTime := t.UnixNano()
-	return &timestamp.Timestamp{
-		Seconds: nanoTime / 1e9,
-		Nanos:   int32(nanoTime % 1e9),
 	}
 }

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -21,6 +21,9 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
 )
 
 // Service contains metadata about the exporter service.
@@ -80,4 +83,12 @@ func guessUnixHomeDir() string {
 		return u.HomeDir
 	}
 	return ""
+}
+
+func TimeToTimestamp(t time.Time) *timestamp.Timestamp {
+	nanoTime := t.UnixNano()
+	return &timestamp.Timestamp{
+		Seconds: nanoTime / 1e9,
+		Nanos:   int32(nanoTime % 1e9),
+	}
 }

--- a/translator/trace/protospan_to_spandata_test.go
+++ b/translator/trace/protospan_to_spandata_test.go
@@ -21,27 +21,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	"go.opencensus.io/trace"
 	"go.opencensus.io/trace/tracestate"
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/census-instrumentation/opencensus-service/internal"
 	tracetranslator "github.com/census-instrumentation/opencensus-service/translator/trace"
 )
 
 func TestProtoSpanToOCSpanData_endToEnd(t *testing.T) {
 	// The goal of this test is to ensure that each
 	// tracepb.Span is transformed to its *trace.SpanData correctly!
-
-	timeToTimestamp := func(t time.Time) *timestamp.Timestamp {
-		nanoTime := t.UnixNano()
-		return &timestamp.Timestamp{
-			Seconds: nanoTime / 1e9,
-			Nanos:   int32(nanoTime % 1e9),
-		}
-	}
 
 	endTime := time.Now().Round(time.Second)
 	startTime := endTime.Add(-90 * time.Second)
@@ -52,8 +44,8 @@ func TestProtoSpanToOCSpanData_endToEnd(t *testing.T) {
 		ParentSpanId: []byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8},
 		Name:         &tracepb.TruncatableString{Value: "End-To-End Here"},
 		Kind:         tracepb.Span_SERVER,
-		StartTime:    timeToTimestamp(startTime),
-		EndTime:      timeToTimestamp(endTime),
+		StartTime:    internal.TimeToTimestamp(startTime),
+		EndTime:      internal.TimeToTimestamp(endTime),
 		Status: &tracepb.Status{
 			Code:    13,
 			Message: "This is not a drill!",
@@ -62,7 +54,7 @@ func TestProtoSpanToOCSpanData_endToEnd(t *testing.T) {
 		TimeEvents: &tracepb.Span_TimeEvents{
 			TimeEvent: []*tracepb.Span_TimeEvent{
 				{
-					Time: timeToTimestamp(startTime),
+					Time: internal.TimeToTimestamp(startTime),
 					Value: &tracepb.Span_TimeEvent_MessageEvent_{
 						MessageEvent: &tracepb.Span_TimeEvent_MessageEvent{
 							Type: tracepb.Span_TimeEvent_MessageEvent_SENT, UncompressedSize: 1024, CompressedSize: 512,
@@ -70,7 +62,7 @@ func TestProtoSpanToOCSpanData_endToEnd(t *testing.T) {
 					},
 				},
 				{
-					Time: timeToTimestamp(endTime),
+					Time: internal.TimeToTimestamp(endTime),
 					Value: &tracepb.Span_TimeEvent_MessageEvent_{
 						MessageEvent: &tracepb.Span_TimeEvent_MessageEvent{
 							Type: tracepb.Span_TimeEvent_MessageEvent_RECEIVED, UncompressedSize: 1024, CompressedSize: 1000,


### PR DESCRIPTION
Move the common helper TimeToTimestamp to internal
instead of duplicating its functionality allover
the repository. It is needed for implementing other
interceptors.