### PR TITLE
interceptor/opencensus: skip TestEnsureRecordedMetrics

### DIFF
--- a/interceptor/opencensus/observability_test.go
+++ b/interceptor/opencensus/observability_test.go
@@ -44,6 +44,8 @@ import (
 // test is to ensure exactness, but with the mentioned views registered, the
 // output will be quite noisy.
 func TestEnsureRecordedMetrics(t *testing.T) {
+	t.Skip("Depends on precising timing in OpenCensus-Go's stats worker but that timing is thrown off by slower -race binaries")
+
 	sappender := newSpanAppender()
 
 	_, port, doneFn := ocInterceptorOnGRPCServer(t, sappender, ocinterceptor.WithSpanBufferPeriod(2*time.Millisecond))


### PR DESCRIPTION
`go test -race` produces a slowdown in the program by
between 2-20X yet this test depends on precise timings
in the OpenCensus-Go stats worker. Disable it as it is
very flaky and causing unrelated failures in PRs.