### PR TITLE
exporter/exporterparse: metrics for exported spans

### DIFF
--- a/exporter/exporterparser/datadog.go
+++ b/exporter/exporterparser/datadog.go
@@ -81,5 +81,5 @@ func (dde *datadogExporter) ExportSpanData(ctx context.Context, node *commonpb.N
 	// TODO: Examine the Datadog exporter to see
 	// if trace.ExportSpan was constraining and if perhaps the
 	// upload can use the context and information from the Node.
-	return exportSpans(dde.exporter, spandata)
+	return exportSpans(ctx, node, "datadog", dde.exporter, spandata)
 }

--- a/exporter/exporterparser/exparser.go
+++ b/exporter/exporterparser/exparser.go
@@ -22,16 +22,25 @@
 package exporterparser
 
 import (
+	"context"
 	"fmt"
 
 	"go.opencensus.io/trace"
 	yaml "gopkg.in/yaml.v2"
+
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	"github.com/census-instrumentation/opencensus-service/internal"
 )
 
-func exportSpans(te trace.Exporter, spandata []*trace.SpanData) error {
+func exportSpans(ctx context.Context, node *commonpb.Node, exporterName string, te trace.Exporter, spandata []*trace.SpanData) error {
 	for _, sd := range spandata {
 		te.ExportSpan(sd)
 	}
+
+	// And finally record metrics on the number of exported spans.
+	nSpansCounter := internal.NewExportedSpansRecorder(exporterName)
+	nSpansCounter(ctx, node, spandata)
+
 	return nil
 }
 

--- a/exporter/exporterparser/stackdriver.go
+++ b/exporter/exporterparser/stackdriver.go
@@ -77,5 +77,5 @@ func (sde *stackdriverExporter) ExportSpanData(ctx context.Context, node *common
 	// TODO: Examine "contrib.go.opencensus.io/exporter/stackdriver" to see
 	// if trace.ExportSpan was constraining and if perhaps the Stackdriver
 	// upload can use the context and information from the Node.
-	return exportSpans(sde.exporter, spandata)
+	return exportSpans(ctx, node, "stackdriver", sde.exporter, spandata)
 }

--- a/exporter/exporterparser/zipkin.go
+++ b/exporter/exporterparser/zipkin.go
@@ -78,5 +78,5 @@ func (ze *zipkinExporter) ExportSpanData(ctx context.Context, node *commonpb.Nod
 	// TODO: Examine "contrib.go.opencensus.io/exporter/zipkin" to see
 	// if trace.ExportSpan was constraining and if perhaps the Zipkin
 	// upload can use the context and information from the Node.
-	return exportSpans(ze.exporter, spandata)
+	return exportSpans(ctx, node, "zipkin", ze.exporter, spandata)
 }

--- a/internal/observability.go
+++ b/internal/observability.go
@@ -27,6 +27,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"go.opencensus.io/trace"
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
@@ -92,10 +93,10 @@ func NewReceivedSpansRecorderStreaming(lifetimeCtx context.Context, interceptorN
 // NewExportedSpansRecorder creates a helper function that'll add the name of the
 // creating exporter as a tag value in the context that will be used to count the
 // the number of spans exported.
-func NewExportedSpansRecorder(exporterName string) func(context.Context, *commonpb.Node, []*tracepb.Span) {
-	return func(ctx context.Context, ni *commonpb.Node, spans []*tracepb.Span) {
+func NewExportedSpansRecorder(exporterName string) func(context.Context, *commonpb.Node, []*trace.SpanData) {
+	return func(ctx context.Context, ni *commonpb.Node, spandata []*trace.SpanData) {
 		ctx, _ = tag.New(ctx, tag.Upsert(tagKeyExporterName, exporterName))
-		stats.Record(ctx, mExportedSpans.M(int64(len(spans))))
+		stats.Record(ctx, mExportedSpans.M(int64(len(spandata))))
 	}
 }
 


### PR DESCRIPTION
After each exporter has exported spans, record the
number of spans exported with tag:
    "opencensus_exporter": <name>

Updates #64