### PR TITLE
cmd/ocagent: added zPages for overall ocagent process

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
         - [Interceptors](#agent-impl-interceptors)
         - [Agent Core](#agent-impl-agent-core)
         - [Exporters](#agent-impl-exporters)
+    - [Diagnostics](#agent-diagnostics)
+        - [zPages](#agent-zpages)
     - [Building binaries](#agent-building-binaries)
     - [Usage](#agent-usage)
     - [Configuration file](#agent-configuration-file)
@@ -178,6 +180,41 @@ streams that cannot be kept alive all the time (e.g gRPC-Python).
 Once in a while, Agent Core will push `SpanProto` with `Node` to each exporter. After
 receiving them, each exporter will translate `SpanProto` to the format supported by the
 backend (e.g Jaeger Thrift Span), and then push them to corresponding backend or service.
+
+### <a name="agent-diagnostics"></a>Diagnostics
+
+To monitor the agent itself, we provide some diagnostic tools like:
+
+#### <a name="agent-zpages"></a>zPages
+
+We provide zPages for information on ocagent's internals, running by default on port `55679`.
+These routes below contain the various diagnostic resources:
+
+Resource|Route
+---|---
+RPC stats|/debug/rpcz
+Trace information|/debug/tracez
+
+The zPages configuration can be updated in the config.yaml file with fields:
+* `disabled`: if set to true, won't run zPages
+* `port`: by default is 55679, otherwise should be set to a value between 0 an 65535
+
+For example
+```yaml
+zpages:
+    port: 8888 # To override the port from 55679 to 8888
+```
+
+To disable zPages, you can use `disabled` like this:
+```yaml
+zpages:
+    disabled: true
+```
+
+and for example navigating to http://localhost:55679/debug/tracez to debug the
+OpenCensus interceptor's traces in your browser should produce something like this
+
+![zPages](https://user-images.githubusercontent.com/4898263/47132981-892bb500-d25b-11e8-980c-08f0115ba72e.png)
 
 ### <a name="building-binaries"></a>Building binaries
 

--- a/cmd/ocagent/config.go
+++ b/cmd/ocagent/config.go
@@ -23,10 +23,14 @@ import (
 	"github.com/census-instrumentation/opencensus-service/exporter/exporterparser"
 )
 
-const defaultOCInterceptorAddress = "localhost:55678"
+const (
+	defaultOCInterceptorAddress = "localhost:55678"
+	defaultZPagesPort           = 55679
+)
 
 type config struct {
 	OpenCensusInterceptorConfig *interceptorConfig `yaml:"opencensus_interceptor"`
+	ZPagesConfig                *zPagesConfig      `yaml:"zpages"`
 }
 
 type interceptorConfig struct {
@@ -34,11 +38,34 @@ type interceptorConfig struct {
 	Address string `yaml:"address"`
 }
 
+type zPagesConfig struct {
+	Disabled bool `yaml:"disabled"`
+	Port     int  `yaml:"port"`
+}
+
 func (c *config) ocInterceptorAddress() string {
 	if c == nil || c.OpenCensusInterceptorConfig == nil || c.OpenCensusInterceptorConfig.Address == "" {
 		return defaultOCInterceptorAddress
 	}
 	return c.OpenCensusInterceptorConfig.Address
+}
+
+func (c *config) zPagesDisabled() bool {
+	if c == nil {
+		return true
+	}
+	return c.ZPagesConfig != nil && c.ZPagesConfig.Disabled
+}
+
+func (c *config) zPagesPort() (int, bool) {
+	if c.zPagesDisabled() {
+		return -1, false
+	}
+	port := defaultZPagesPort
+	if c != nil && c.ZPagesConfig != nil && c.ZPagesConfig.Port > 0 {
+		port = c.ZPagesConfig.Port
+	}
+	return port, true
 }
 
 func parseOCAgentConfig(yamlBlob []byte) (*config, error) {

--- a/cmd/ocagent/config.yaml
+++ b/cmd/ocagent/config.yaml
@@ -7,3 +7,6 @@ stackdriver:
 
 zipkin:
   endpoint: "http://localhost:9411/api/v2/spans"
+
+zpages:
+  port: 55679

--- a/example/main.go
+++ b/example/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"log"
+	"math/rand"
 	"time"
 
 	"contrib.go.opencensus.io/exporter/ocagent"
@@ -34,9 +35,10 @@ func main() {
 		DefaultSampler: trace.AlwaysSample(),
 	})
 
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for {
 		_, span := trace.StartSpan(context.Background(), "foo")
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(time.Duration(rng.Int63n(1000)) * time.Millisecond)
 		span.End()
 	}
 }

--- a/interceptor/opencensus/opencensus.go
+++ b/interceptor/opencensus/opencensus.go
@@ -154,7 +154,13 @@ func (oci *OCInterceptor) batchSpanExporting(longLivedRPCCtx context.Context, pa
 		})
 	}
 
+	nSpans := int64(0)
 	for _, spn := range spnL {
 		oci.spanSink.ReceiveSpans(ctx, spn.node, spn.spans...)
+		nSpans += int64(len(spn.spans))
 	}
+
+	span.Annotate([]trace.Attribute{
+		trace.Int64Attribute("num_spans", nSpans),
+	}, "")
 }


### PR DESCRIPTION
Added zPages as the diagnostic helper for the overall
ocagent process itself #inception

By default the zPages run at ":55679/debug". They can be
disabled in the config.yaml file by using the attribute
  `disabled`

```yaml
zpages:
   disabled: true
   port: 8888
```

Also added as an attribute the number of exported spans
for every internal interceptor span.

Fixes #83 