### PR TITLE
Update Stackdriver configuration parser enableTraces field

### DIFF
--- a/exporter/exporterparser/datadog.go
+++ b/exporter/exporterparser/datadog.go
@@ -40,7 +40,7 @@ type dataDogConfig struct {
 		// Tags specifies a set of global tags to attach to each metric.
 		Tags []string `yaml:"tags,omitempty"`
 
-		EnableTracing bool `yaml:"enable_tracing,omitempty"`
+		EnableTracing bool `yaml:"enableTraces,omitempty"`
 	} `yaml:"datadog,omitempty"`
 }
 

--- a/exporter/exporterparser/stackdriver.go
+++ b/exporter/exporterparser/stackdriver.go
@@ -28,7 +28,7 @@ import (
 type stackdriverConfig struct {
 	Stackdriver *struct {
 		ProjectID     string `yaml:"project,omitempty"`
-		EnableTracing bool   `yaml:"enable_tracing,omitempty"`
+		EnableTracing bool   `yaml:"enableTraces,omitempty"`
 	} `yaml:"stackdriver,omitempty"`
 }
 


### PR DESCRIPTION
[Relevant issue](https://github.com/census-instrumentation/opencensus-service/issues/113)

Fix that updates the `enableTraces` field in the parser for the Stackdriver and Datadog config. I was not able to find other places that needed updating.