### PR TITLE
README: fix Stackdriver trace enabling flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ For example, to allow trace exporting to Stackdriver and Zipkin:
 ```yaml
 stackdriver:
   project: "your-project-id"
-  enableTraces: true
+  enable_traces: true
 
 zipkin:
   endpoint: "http://localhost:9411/api/v2/spans"


### PR DESCRIPTION
The README was stale in regards to the Stackdriver
configuration flags in YAML.
This change updates the README to indicate that
the correct flag is `enable_traces` and not `enableTraces`

Fixes #113
Supersedes #114