### PR TITLE
config.yaml: categorize and reorganize YAML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,12 +261,13 @@ it with the exporter and interceptor configurations.
 For example, to allow trace exporting to Stackdriver and Zipkin:
 
 ```yaml
-stackdriver:
-  project: "your-project-id"
-  enable_traces: true
+exporters:
+    stackdriver:
+        project: "your-project-id"
+        enable_traces: true
 
-zipkin:
-  endpoint: "http://localhost:9411/api/v2/spans"
+    zipkin:
+        endpoint: "http://localhost:9411/api/v2/spans"
 ```
 
 #### <a name="agent-config-interceptors"></a>Interceptors

--- a/cmd/ocagent/config.yaml
+++ b/cmd/ocagent/config.yaml
@@ -1,12 +1,14 @@
-opencensus_interceptor:
-  address: "127.0.0.1:55678"
+interceptors:
+    opencensus:
+        address: "127.0.0.1:55678"
 
-stackdriver:
-  project: "project-id"
-  enable_tracing: true
+exporters:
+    stackdriver:
+        project: "project-id"
+        enable_tracing: true
 
-zipkin:
-  endpoint: "http://localhost:9411/api/v2/spans"
+    zipkin:
+        endpoint: "http://localhost:9411/api/v2/spans"
 
 zpages:
-  port: 55679
+    port: 55679

--- a/exporter/exporterparser/datadog.go
+++ b/exporter/exporterparser/datadog.go
@@ -24,24 +24,22 @@ import (
 	"github.com/census-instrumentation/opencensus-service/exporter"
 )
 
-type dataDogConfig struct {
-	Datadog *struct {
-		// Namespace specifies the namespaces to which metric keys are appended.
-		Namespace string `yaml:"namespace,omitempty"`
+type datadogConfig struct {
+	// Namespace specifies the namespaces to which metric keys are appended.
+	Namespace string `yaml:"namespace,omitempty"`
 
-		// TraceAddr specifies the host[:port] address of the Datadog Trace Agent.
-		// It defaults to localhost:8126.
-		TraceAddr string `yaml:"trace_addr,omitempty"`
+	// TraceAddr specifies the host[:port] address of the Datadog Trace Agent.
+	// It defaults to localhost:8126.
+	TraceAddr string `yaml:"trace_addr,omitempty"`
 
-		// MetricsAddr specifies the host[:port] address for DogStatsD. It defaults
-		// to localhost:8125.
-		MetricsAddr string `yaml:"metrics_addr,omitempty"`
+	// MetricsAddr specifies the host[:port] address for DogStatsD. It defaults
+	// to localhost:8125.
+	MetricsAddr string `yaml:"metrics_addr,omitempty"`
 
-		// Tags specifies a set of global tags to attach to each metric.
-		Tags []string `yaml:"tags,omitempty"`
+	// Tags specifies a set of global tags to attach to each metric.
+	Tags []string `yaml:"tags,omitempty"`
 
-		EnableTracing bool `yaml:"enable_tracing,omitempty"`
-	} `yaml:"datadog,omitempty"`
+	EnableTracing bool `yaml:"enable_tracing,omitempty"`
 }
 
 type datadogExporter struct {
@@ -49,12 +47,19 @@ type datadogExporter struct {
 }
 
 func DatadogTraceExportersFromYAML(config []byte) (tes []exporter.TraceExporter, doneFns []func() error, err error) {
-	var c dataDogConfig
-	if err := yamlUnmarshal(config, &c); err != nil {
+	var cfg struct {
+		Exporters *struct {
+			Datadog *datadogConfig `yaml:"datadog"`
+		} `yaml:"exporters"`
+	}
+	if err := yamlUnmarshal(config, &cfg); err != nil {
 		return nil, nil, err
 	}
+	if cfg.Exporters == nil {
+		return nil, nil, nil
+	}
 
-	dc := c.Datadog
+	dc := cfg.Exporters.Datadog
 	if dc == nil {
 		return nil, nil, nil
 	}

--- a/exporter/exporterparser/stackdriver.go
+++ b/exporter/exporterparser/stackdriver.go
@@ -26,10 +26,8 @@ import (
 )
 
 type stackdriverConfig struct {
-	Stackdriver *struct {
-		ProjectID     string `yaml:"project,omitempty"`
-		EnableTracing bool   `yaml:"enable_tracing,omitempty"`
-	} `yaml:"stackdriver,omitempty"`
+	ProjectID     string `yaml:"project,omitempty"`
+	EnableTracing bool   `yaml:"enable_tracing,omitempty"`
 }
 
 type stackdriverExporter struct {
@@ -39,12 +37,18 @@ type stackdriverExporter struct {
 var _ exporter.TraceExporter = (*stackdriverExporter)(nil)
 
 func StackdriverTraceExportersFromYAML(config []byte) (tes []exporter.TraceExporter, doneFns []func() error, err error) {
-	var c stackdriverConfig
-	if err := yamlUnmarshal(config, &c); err != nil {
+	var cfg struct {
+		Exporters *struct {
+			Stackdriver *stackdriverConfig `yaml:"stackdriver"`
+		} `yaml:"exporters"`
+	}
+	if err := yamlUnmarshal(config, &cfg); err != nil {
 		return nil, nil, err
 	}
-
-	sc := c.Stackdriver
+	if cfg.Exporters == nil {
+		return nil, nil, nil
+	}
+	sc := cfg.Exporters.Stackdriver
 	if sc == nil {
 		return nil, nil, nil
 	}


### PR DESCRIPTION
Categorize namespaces of each item into:

- exporters
- interceptors
- zpages

which aesthetically looks nicer than the original but also
gives users better context and control over what the agent
does.

For example here is the new configuration file:
```yaml
interceptors:
    opencensus:
        address: "127.0.0.1:55678"

exporters:
    stackdriver:
        project: "project-id"
        enable_tracing: true

    zipkin:
        endpoint: "http://localhost:9411/api/v2/spans"

    datadog:
        enable_tracing: false

zpages:
    port: 55679
```

Fixes #90