### PR TITLE
interceptor/opencensus: remove redundant OCInterceptor prefix

### DIFF
--- a/interceptor/opencensus/opencensus_test.go
+++ b/interceptor/opencensus/opencensus_test.go
@@ -43,7 +43,7 @@ import (
 	"go.opencensus.io/trace/tracestate"
 )
 
-func TestOCInterceptor_endToEnd(t *testing.T) {
+func TestInterceptor_endToEnd(t *testing.T) {
 	t.Skip("This test is flaky due to timing slowdown due to -race. Will reenable in the future")
 
 	sappender := newSpanAppender()
@@ -163,7 +163,7 @@ func TestOCInterceptor_endToEnd(t *testing.T) {
 }
 
 // Issue #43. Export should support node multiplexing.
-// The goal is to ensure that OCInterceptor can always support
+// The goal is to ensure that Interceptor can always support
 // a passthrough mode where it initiates Export normally by firstly
 // receiving the initiator node. However ti should still be able to
 // accept nodes from downstream sources, but if a node isn't specified in
@@ -456,7 +456,7 @@ func (sa *spanAppender) ReceiveSpans(ctx context.Context, node *commonpb.Node, s
 	return &spanreceiver.Acknowledgement{SavedSpans: uint64(len(spans))}, nil
 }
 
-func ocInterceptorOnGRPCServer(t *testing.T, sr spanreceiver.SpanReceiver, opts ...ocinterceptor.OCOption) (oci *ocinterceptor.OCInterceptor, port int, done func()) {
+func ocInterceptorOnGRPCServer(t *testing.T, sr spanreceiver.SpanReceiver, opts ...ocinterceptor.OCOption) (oci *ocinterceptor.Interceptor, port int, done func()) {
 	ln, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatalf("Failed to find an available address to run the gRPC server: %v", err)
@@ -482,7 +482,7 @@ func ocInterceptorOnGRPCServer(t *testing.T, sr spanreceiver.SpanReceiver, opts 
 
 	oci, err = ocinterceptor.New(sr, opts...)
 	if err != nil {
-		t.Fatalf("Failed to create the OCInterceptor: %v", err)
+		t.Fatalf("Failed to create the Interceptor: %v", err)
 	}
 
 	// Now run it as a gRPC server

--- a/interceptor/opencensus/options.go
+++ b/interceptor/opencensus/options.go
@@ -17,7 +17,7 @@ package ocinterceptor
 import "time"
 
 type OCOption interface {
-	WithOCInterceptor(*OCInterceptor)
+	WithInterceptor(*Interceptor)
 }
 
 type spanBufferPeriod struct {
@@ -26,12 +26,12 @@ type spanBufferPeriod struct {
 
 var _ OCOption = (*spanBufferPeriod)(nil)
 
-func (sfd *spanBufferPeriod) WithOCInterceptor(oci *OCInterceptor) {
+func (sfd *spanBufferPeriod) WithInterceptor(oci *Interceptor) {
 	oci.spanBufferPeriod = sfd.period
 }
 
 // WithSpanBufferPeriod is an option that allows one to configure
-// the period that spans are buffered for before the OCInterceptor
+// the period that spans are buffered for before the Interceptor
 // sends them to its SpanReceiver.
 func WithSpanBufferPeriod(period time.Duration) OCOption {
 	return &spanBufferPeriod{period: period}
@@ -41,12 +41,12 @@ type spanBufferCount int
 
 var _ OCOption = (*spanBufferCount)(nil)
 
-func (spc spanBufferCount) WithOCInterceptor(oci *OCInterceptor) {
+func (spc spanBufferCount) WithInterceptor(oci *Interceptor) {
 	oci.spanBufferCount = int(spc)
 }
 
 // WithSpanBufferCount is an option that allows one to configure
-// the number of spans that are buffered before the OCInterceptor
+// the number of spans that are buffered before the Interceptor
 // send them to its SpanReceiver.
 func WithSpanBufferCount(count int) OCOption {
 	return spanBufferCount(count)


### PR DESCRIPTION
Given that the package name is already ocinterceptor, using
OCInterceptor as a prefix for the type name is now unnecessary.
That naming was because the package was one of the first ones
to be added. Now that the packaging is mature this has come up
as a better suggestion to remove that unnecessary prefix.

Fixes #88