### PR TITLE
interceptor/opencensus: rename OCOption to Option

### DIFF
--- a/interceptor/opencensus/opencensus.go
+++ b/interceptor/opencensus/opencensus.go
@@ -36,7 +36,7 @@ type Interceptor struct {
 	spanBufferCount  int
 }
 
-func New(sr spanreceiver.SpanReceiver, opts ...OCOption) (*Interceptor, error) {
+func New(sr spanreceiver.SpanReceiver, opts ...Option) (*Interceptor, error) {
 	if sr == nil {
 		return nil, errors.New("needs a non-nil spanReceiver")
 	}

--- a/interceptor/opencensus/opencensus_test.go
+++ b/interceptor/opencensus/opencensus_test.go
@@ -456,7 +456,7 @@ func (sa *spanAppender) ReceiveSpans(ctx context.Context, node *commonpb.Node, s
 	return &spanreceiver.Acknowledgement{SavedSpans: uint64(len(spans))}, nil
 }
 
-func ocInterceptorOnGRPCServer(t *testing.T, sr spanreceiver.SpanReceiver, opts ...ocinterceptor.OCOption) (oci *ocinterceptor.Interceptor, port int, done func()) {
+func ocInterceptorOnGRPCServer(t *testing.T, sr spanreceiver.SpanReceiver, opts ...ocinterceptor.Option) (oci *ocinterceptor.Interceptor, port int, done func()) {
 	ln, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatalf("Failed to find an available address to run the gRPC server: %v", err)

--- a/interceptor/opencensus/options.go
+++ b/interceptor/opencensus/options.go
@@ -16,7 +16,7 @@ package ocinterceptor
 
 import "time"
 
-type OCOption interface {
+type Option interface {
 	WithInterceptor(*Interceptor)
 }
 
@@ -24,7 +24,7 @@ type spanBufferPeriod struct {
 	period time.Duration
 }
 
-var _ OCOption = (*spanBufferPeriod)(nil)
+var _ Option = (*spanBufferPeriod)(nil)
 
 func (sfd *spanBufferPeriod) WithInterceptor(oci *Interceptor) {
 	oci.spanBufferPeriod = sfd.period
@@ -33,13 +33,13 @@ func (sfd *spanBufferPeriod) WithInterceptor(oci *Interceptor) {
 // WithSpanBufferPeriod is an option that allows one to configure
 // the period that spans are buffered for before the Interceptor
 // sends them to its SpanReceiver.
-func WithSpanBufferPeriod(period time.Duration) OCOption {
+func WithSpanBufferPeriod(period time.Duration) Option {
 	return &spanBufferPeriod{period: period}
 }
 
 type spanBufferCount int
 
-var _ OCOption = (*spanBufferCount)(nil)
+var _ Option = (*spanBufferCount)(nil)
 
 func (spc spanBufferCount) WithInterceptor(oci *Interceptor) {
 	oci.spanBufferCount = int(spc)
@@ -48,6 +48,6 @@ func (spc spanBufferCount) WithInterceptor(oci *Interceptor) {
 // WithSpanBufferCount is an option that allows one to configure
 // the number of spans that are buffered before the Interceptor
 // send them to its SpanReceiver.
-func WithSpanBufferCount(count int) OCOption {
+func WithSpanBufferCount(count int) Option {
 	return spanBufferCount(count)
 }

--- a/interceptor/opencensus/trace_interceptor.go
+++ b/interceptor/opencensus/trace_interceptor.go
@@ -30,11 +30,11 @@ import (
 )
 
 // New will create a handle that runs an OCInterceptor at the provided address
-func NewTraceInterceptor(port int, opts ...OCOption) (interceptor.TraceInterceptor, error) {
+func NewTraceInterceptor(port int, opts ...Option) (interceptor.TraceInterceptor, error) {
 	return &ocInterceptorHandler{srvPort: port, interceptorOptions: opts}, nil
 }
 
-func NewTraceInterceptorOnDefaultPort(opts ...OCOption) (interceptor.TraceInterceptor, error) {
+func NewTraceInterceptorOnDefaultPort(opts ...Option) (interceptor.TraceInterceptor, error) {
 	return &ocInterceptorHandler{srvPort: defaultOCInterceptorPort, interceptorOptions: opts}, nil
 }
 
@@ -42,7 +42,7 @@ type ocInterceptorHandler struct {
 	mu      sync.RWMutex
 	srvPort int
 
-	interceptorOptions []OCOption
+	interceptorOptions []Option
 
 	ln         net.Listener
 	grpcServer *grpc.Server


### PR DESCRIPTION
OCOption is redundant within the package ocinterceptor,
hence fix that with a rename to Option.

Fixes #87