### PR TITLE
Add Jaeger Exporter to Agent

### DIFF
--- a/cmd/ocagent/config.go
+++ b/cmd/ocagent/config.go
@@ -17,10 +17,9 @@ package main
 import (
 	"log"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/census-instrumentation/opencensus-service/exporter"
 	"github.com/census-instrumentation/opencensus-service/exporter/exporterparser"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // We expect the configuration.yaml file to look like this:
@@ -113,6 +112,7 @@ func exportersFromYAMLConfig(config []byte) (traceExporters []exporter.TraceExpo
 		{name: "datadog", fn: exporterparser.DatadogTraceExportersFromYAML},
 		{name: "stackdriver", fn: exporterparser.StackdriverTraceExportersFromYAML},
 		{name: "zipkin", fn: exporterparser.ZipkinExportersFromYAML},
+		{name: "jaeger", fn: exporterparser.JaegerExportersFromYAML},
 	}
 
 	for _, cfg := range parseFns {

--- a/exporter/exporterparser/jaeger.go
+++ b/exporter/exporterparser/jaeger.go
@@ -1,0 +1,87 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterparser
+
+import (
+	"context"
+	"log"
+
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	"github.com/census-instrumentation/opencensus-service/exporter"
+	"go.opencensus.io/exporter/jaeger"
+	"go.opencensus.io/trace"
+)
+
+// Slight modified version of go/src/go.opencensus.io/exporter/jaeger/jaeger.go
+type jaegerConfig struct {
+	Endpoint          string `yaml:"endpoint,omitempty"`
+	CollectorEndpoint string `yaml:"collector_endpoint,omitempty"`
+	AgentEndpoint     string `yaml:"agent_endpoint,omitempty"`
+	Username          string `yaml:"username,omitempty"`
+	Password          string `yaml:"password,omitempty"`
+	ServiceName       string `yaml:"service_name,omitempty"`
+}
+
+type jaegerExporter struct {
+	exporter *jaeger.Exporter
+}
+
+// JaegerExportersFromYAML reads any configured jaeger exporters from a yaml config
+func JaegerExportersFromYAML(config []byte) (tes []exporter.TraceExporter, doneFns []func() error, err error) {
+	var cfg struct {
+		Exporters *struct {
+			Jaeger *jaegerConfig `yaml:"jaeger"`
+		} `yaml:"exporters"`
+	}
+	if err := yamlUnmarshal(config, &cfg); err != nil {
+		return nil, nil, err
+	}
+	if cfg.Exporters == nil {
+		return nil, nil, nil
+	}
+	jc := cfg.Exporters.Jaeger
+	if jc == nil {
+		return nil, nil, nil
+	}
+
+	// jaeger.NewExporter performs configurqtion validation
+	je, err := jaeger.NewExporter(jaeger.Options{
+		Endpoint:          jc.Endpoint,
+		CollectorEndpoint: jc.CollectorEndpoint,
+		AgentEndpoint:     jc.AgentEndpoint,
+		Username:          jc.Username,
+		Password:          jc.Password,
+		Process: jaeger.Process{
+			ServiceName: jc.ServiceName,
+		},
+	})
+	if err != nil {
+		log.Fatalf("Cannot configure Jaeger exporter: %v", err)
+	}
+
+	doneFns = append(doneFns, func() error {
+		je.Flush()
+		return nil
+	})
+	tes = append(tes, &jaegerExporter{exporter: je})
+	return
+}
+
+func (je *jaegerExporter) ExportSpanData(ctx context.Context, node *commonpb.Node, spandata ...*trace.SpanData) error {
+	// TODO: Examine "contrib.go.opencensus.io/exporter/jaeger" to see
+	// if trace.ExportSpan was constraining and if perhaps the Jaeger
+	// upload can use the context and information from the Node.
+	return exportSpans(ctx, node, "jaeger", je.exporter, spandata)
+}


### PR DESCRIPTION
Add Jaeger exporter to ocagent following the same code pattern already
in use for the other exporters.