### PR TITLE
interceptor: start adding metric receiver and interceptor.

### DIFF
--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -17,6 +17,7 @@ package interceptor
 import (
 	"context"
 
+	"github.com/census-instrumentation/opencensus-service/metricreceiver"
 	"github.com/census-instrumentation/opencensus-service/spanreceiver"
 )
 
@@ -30,4 +31,16 @@ import (
 type TraceInterceptor interface {
 	StartTraceInterception(ctx context.Context, destination spanreceiver.SpanReceiver) error
 	StopTraceInterception(ctx context.Context) error
+}
+
+// A MetricInterceptor is an "arbitrary data"-to-"metric proto" converter.
+// Its purpose is to translate data from the wild into metric proto accompanied
+// by a *commonpb.Node to uniquely identify where that data comes from.
+// MetricInterceptor feeds a metricreceiver.MetricReceiver with data.
+//
+// For example it could be Prometheus data source which translates
+// Prometheus into *metricpb.Metric-s.
+type MetricInterceptor interface {
+	StartMetricInterception(ctx context.Context, destination metricreceiver.MetricReceiver) error
+	StopMetricInterception(ctx context.Context) error
 }

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -17,7 +17,7 @@ package interceptor
 import (
 	"context"
 
-	"github.com/census-instrumentation/opencensus-service/metricreceiver"
+	"github.com/census-instrumentation/opencensus-service/metricsreceiver"
 	"github.com/census-instrumentation/opencensus-service/spanreceiver"
 )
 
@@ -33,14 +33,14 @@ type TraceInterceptor interface {
 	StopTraceInterception(ctx context.Context) error
 }
 
-// A MetricInterceptor is an "arbitrary data"-to-"metric proto" converter.
+// A MetricsInterceptor is an "arbitrary data"-to-"metric proto" converter.
 // Its purpose is to translate data from the wild into metric proto accompanied
 // by a *commonpb.Node to uniquely identify where that data comes from.
-// MetricInterceptor feeds a metricreceiver.MetricReceiver with data.
+// MetricsInterceptor feeds a metricsreceiver.MetricsReceiver with data.
 //
 // For example it could be Prometheus data source which translates
-// Prometheus into *metricpb.Metric-s.
-type MetricInterceptor interface {
-	StartMetricInterception(ctx context.Context, destination metricreceiver.MetricReceiver) error
+// Prometheus metrics into *metricpb.Metric-s.
+type MetricsInterceptor interface {
+	StartMetricInterception(ctx context.Context, destination metricsreceiver.MetricsReceiver) error
 	StopMetricInterception(ctx context.Context) error
 }

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -41,6 +41,6 @@ type TraceInterceptor interface {
 // For example it could be Prometheus data source which translates
 // Prometheus metrics into *metricpb.Metric-s.
 type MetricsInterceptor interface {
-	StartMetricInterception(ctx context.Context, destination metricsreceiver.MetricsReceiver) error
-	StopMetricInterception(ctx context.Context) error
+	StartMetricsInterception(ctx context.Context, destination metricsreceiver.MetricsReceiver) error
+	StopMetricsInterception(ctx context.Context) error
 }

--- a/metricreceiver/metricreceiver.go
+++ b/metricreceiver/metricreceiver.go
@@ -1,0 +1,32 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metricreceiver
+
+import (
+	"context"
+
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	metricpb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+)
+
+// MetricReceiver is an interface that receives metrics from a Node identifier.
+type MetricReceiver interface {
+	ReceiveMetrics(ctx context.Context, node *commonpb.Node, metrics ...*metricpb.Metric) (*Acknowledgement, error)
+}
+
+type Acknowledgement struct {
+	SavedMetrics   uint64
+	DroppedMetrics uint64
+}

--- a/metricsreceiver/metricsreceiver.go
+++ b/metricsreceiver/metricsreceiver.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metricreceiver
+package metricsreceiver
 
 import (
 	"context"
@@ -21,8 +21,8 @@ import (
 	metricpb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 )
 
-// MetricReceiver is an interface that receives metrics from a Node identifier.
-type MetricReceiver interface {
+// MetricsReceiver is an interface that receives metrics from a Node identifier.
+type MetricsReceiver interface {
 	ReceiveMetrics(ctx context.Context, node *commonpb.Node, metrics ...*metricpb.Metric) (*Acknowledgement, error)
 }
 


### PR DESCRIPTION
Updates https://github.com/census-instrumentation/opencensus-service/issues/99.
Fixes https://github.com/census-instrumentation/opencensus-service/issues/20.

From https://github.com/census-instrumentation/opencensus-go/issues/940#issuecomment-431929219, OC-Go is going to use the proto gen-go files for `Metrics` implementation, so I think we can start adding the metric receiver and interceptor interfaces now. Note that although the `Metrics` proto hasn't been finalized or released, any future changes will be backwards-compatible, so we should be able to use the `metricpb.Metric` for now.

Next step: add OpenCensus `metric_interceptor`, which depends on [metrics_service.proto](https://github.com/census-instrumentation/opencensus-proto/blob/master/src/opencensus/proto/agent/metrics/v1/metrics_service.proto).