### PR TITLE
Add a minimal Makefile and set Travis to use it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - 1.10.x
+  - 1.11.x
 
 install:
   - go get -t -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,5 @@ language: go
 go:
   - 1.10.x
 
-before_script:
-  - GO_FILES=$(find . -iname '*.go' | grep -v /vendor/)  # All the .go files, excluding vendor/ if any
-
-script:
-  - if [ -n "$(gofmt -s -l $GO_FILES)" ]; then echo "gofmt the following files:"; gofmt -s -l $GO_FILES; exit 1; fi
-  - go test -v -race ./...            # Run all the tests with the race detector enabled
-  - 'if [[ $TRAVIS_GO_VERSION = 1.8* ]]; then ! golint ./... | grep -vE "(_mock|_string|\.pb)\.go:"; fi'
+install:
+  - go get -t -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 go:
   - 1.10.x
-  - 1.11.x
-
+ 
 install:
   - go get -t -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: go
 
+go_import_path: github.com/census-instrumentation/opencensus-service
+
 go:
   - 1.10.x
  
 install:
+  - make install-tools
   - go get -t -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ go:
   - 1.10.x
  
 install:
-  - make install-tools
   - go get -t -v ./...

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ ALL_SRC := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 GOTEST_OPT=-v -race
 GOTEST=go test
-GOLINT=golint
 GOFMT=gofmt
 GOOS=$(shell go env GOOS)
 
@@ -32,15 +31,6 @@ fmt:
 		exit 1; \
 	fi
 
-.PHONY: lint
-lint:
-	@LINTOUT=`$(GOLINT) ./... 2>&1`; \
-	if [ "$$LINTOUT" ]; then \
-		echo "$(GOLINT) FAILED => clean the following lint errors:\n"; \
-		echo "$$LINTOUT\n"; \
-		exit 1; \
-	fi
-
 .PHONY: agent
 agent:
 	CGO_ENABLED=0 go build -o ./bin/ocagent_$(GOOS) $(BUILD_INFO) ./cmd/ocagent
@@ -50,7 +40,3 @@ agent-all-platforms:
 	GOOS=darwin $(MAKE) agent
 	GOOS=linux $(MAKE) agent
 	GOOS=windows $(MAKE) agent
-
-.PHONY: install-tools
-install-tools:
-	go get -u golang.org/x/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BUILD_INFO=-ldflags "-X $(BUILD_INFO_IMPORT_PATH).GitHash=$(GIT_SHA)"
 .DEFAULT_GOAL := default_goal
 
 .PHONY: default_goal
-default_goal: fmt lint test
+default_goal: fmt test
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+ALL_SRC := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+
+GOTEST_OPT=-v -race
+GOTEST=go test
+GOLINT=golint
+GOFMT=gofmt
+GOOS=$(shell go env GOOS)
+
+GIT_SHA=$(shell git rev-parse --short HEAD)
+BUILD_INFO_IMPORT_PATH=github.com/census-instrumentation/opencensus-service/internal/version
+BUILD_INFO=-ldflags "-X $(BUILD_INFO_IMPORT_PATH).GitHash=$(GIT_SHA)"
+
+.DEFAULT_GOAL := default_goal
+
+.PHONY: default_goal
+default_goal: fmt test
+
+.PHONY: clean
+clean:
+	rm -rf bin/ 
+
+.PHONY: test
+test:
+	$(GOTEST) $(GOTEST_OPT) ./...
+
+.PHONY: fmt
+fmt:
+	@FMTOUT=`$(GOFMT) -s -l $(ALL_SRC) 2>&1`; \
+	if [ "$$FMTOUT" ]; then \
+		echo "$(GOFMT) FAILED => gofmt the following files:\n"; \
+		echo "$$FMTOUT\n"; \
+		exit 1; \
+	fi
+
+.PHONY: lint
+lint:
+	@LINTOUT=`$(GOLINT) ./... 2>&1`; \
+	if [ "$$LINTOUT" ]; then \
+		echo "$(GOLINT) FAILED => clean the following lint errors:\n"; \
+		echo "$$LINTOUT\n"; \
+		exit 1; \
+	fi
+
+.PHONY: agent
+agent:
+	CGO_ENABLED=0 go build -o ./bin/ocagent_$(GOOS) $(BUILD_INFO) ./cmd/ocagent
+
+.PHONY: agent-all-sys
+agent-all-platforms:
+	GOOS=darwin $(MAKE) agent
+	GOOS=linux $(MAKE) agent
+	GOOS=windows $(MAKE) agent

--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,7 @@ agent-all-platforms:
 	GOOS=darwin $(MAKE) agent
 	GOOS=linux $(MAKE) agent
 	GOOS=windows $(MAKE) agent
+
+.PHONY: install-tools
+install-tools:
+	go get -u golang.org/x/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BUILD_INFO=-ldflags "-X $(BUILD_INFO_IMPORT_PATH).GitHash=$(GIT_SHA)"
 .DEFAULT_GOAL := default_goal
 
 .PHONY: default_goal
-default_goal: fmt test
+default_goal: fmt lint test
 
 .PHONY: clean
 clean:

--- a/interceptor/zipkin/trace_interceptor_test.go
+++ b/interceptor/zipkin/trace_interceptor_test.go
@@ -62,7 +62,7 @@ func TestConvertSpansToTraceSpans(t *testing.T) {
 			Name: "frontend",
 		},
 		Attributes: map[string]string{
-			"ipv6": "7::80:807f",
+			"ipv6":                       "7::80:807f",
 			"zipkin.remoteEndpoint.ipv4": "192.168.99.101",
 			"zipkin.remoteEndpoint.port": "9000",
 		},
@@ -170,7 +170,7 @@ func TestConversionRoundtrip(t *testing.T) {
 			Node: &commonpb.Node{
 				ServiceInfo: &commonpb.ServiceInfo{Name: "frontend"},
 				Attributes: map[string]string{
-					"ipv6": "7::80:807f",
+					"ipv6":                       "7::80:807f",
 					"zipkin.remoteEndpoint.ipv4": "192.168.99.101",
 					"zipkin.remoteEndpoint.port": "9000",
 				},

--- a/interceptor/zipkin/trace_interceptor_test.go
+++ b/interceptor/zipkin/trace_interceptor_test.go
@@ -62,7 +62,7 @@ func TestConvertSpansToTraceSpans(t *testing.T) {
 			Name: "frontend",
 		},
 		Attributes: map[string]string{
-			"ipv6":                       "7::80:807f",
+			"ipv6": "7::80:807f",
 			"zipkin.remoteEndpoint.ipv4": "192.168.99.101",
 			"zipkin.remoteEndpoint.port": "9000",
 		},
@@ -170,7 +170,7 @@ func TestConversionRoundtrip(t *testing.T) {
 			Node: &commonpb.Node{
 				ServiceInfo: &commonpb.ServiceInfo{Name: "frontend"},
 				Attributes: map[string]string{
-					"ipv6":                       "7::80:807f",
+					"ipv6": "7::80:807f",
 					"zipkin.remoteEndpoint.ipv4": "192.168.99.101",
 					"zipkin.remoteEndpoint.port": "9000",
 				},


### PR DESCRIPTION
This is very minimalistic: it adds a Makefile and switches Travis
to use it. The Makefile tries to do the same things as the previous
script (golint is not enabled yet since it is breaking the build). 