### PR TITLE
Add docker scratch for agent and collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ bin/
 # Miscellaneous files
 *.sw[op]
 *.DS_Store
+
+# Binaries are copied (as needed) to the same location as their respective Dockerfile in
+# order to simplify docker build commands. Ignore these files if proper clean up fails.
+cmd/ocagent/ocagent_linux
+cmd/occollector/occollector_linux

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ GOTEST=go test
 GOFMT=gofmt
 GOOS=$(shell go env GOOS)
 
-OUT_DIR?=./bin/
-
 GIT_SHA=$(shell git rev-parse --short HEAD)
 BUILD_INFO_IMPORT_PATH=github.com/census-instrumentation/opencensus-service/internal/version
 BUILD_INFO=-ldflags "-X $(BUILD_INFO_IMPORT_PATH).GitHash=$(GIT_SHA)"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 ALL_SRC := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
-GOTEST_OPT=-v -race
+GOTEST_OPT?=-v -race
 GOTEST=go test
 GOFMT=gofmt
 GOOS=$(shell go env GOOS)
+
+OUT_DIR?=./bin/
 
 GIT_SHA=$(shell git rev-parse --short HEAD)
 BUILD_INFO_IMPORT_PATH=github.com/census-instrumentation/opencensus-service/internal/version
@@ -13,10 +15,6 @@ BUILD_INFO=-ldflags "-X $(BUILD_INFO_IMPORT_PATH).GitHash=$(GIT_SHA)"
 
 .PHONY: default_goal
 default_goal: fmt test
-
-.PHONY: clean
-clean:
-	rm -rf bin/ 
 
 .PHONY: test
 test:
@@ -38,6 +36,28 @@ agent:
 .PHONY: collector
 collector:
 	CGO_ENABLED=0 go build -o ./bin/occollector_$(GOOS) $(BUILD_INFO) ./cmd/occollector
+
+.PHONY: docker-component # Not intended to be used directly
+docker-component: check-component
+	GOOS=linux $(MAKE) $(COMPONENT)
+	cp ./bin/oc$(COMPONENT)_linux ./cmd/oc$(COMPONENT)/
+	docker build -t oc$(COMPONENT) ./cmd/oc$(COMPONENT)/
+	rm ./cmd/oc$(COMPONENT)/oc$(COMPONENT)_linux
+
+.PHONY: check-component
+check-component:
+ifndef COMPONENT
+	$(error COMPONENT variable was not defined)
+endif
+
+.PHONY: docker-agent
+docker-agent:
+	COMPONENT=agent $(MAKE) docker-component
+
+.PHONY: docker-collector
+docker-collector: 
+	COMPONENT=collector $(MAKE) docker-component
+
 
 .PHONY: binaries
 binaries: agent collector

--- a/cmd/ocagent/Dockerfile
+++ b/cmd/ocagent/Dockerfile
@@ -1,0 +1,9 @@
+# Use a helper to create an emtpy configuration since the agent requires such file
+FROM alpine:3.7 as helper
+RUN touch ./config.yaml
+
+FROM scratch
+COPY ocagent_linux /
+COPY --from=helper ./config.yaml config.yaml
+ENTRYPOINT ["/ocagent_linux"]
+EXPOSE 55678 55679

--- a/cmd/ocagent/config.go
+++ b/cmd/ocagent/config.go
@@ -47,7 +47,7 @@ import (
 //      port: 55679
 
 const (
-	defaultOCInterceptorAddress = "localhost:55678"
+	defaultOCInterceptorAddress = ":55678"
 	defaultZPagesPort           = 55679
 )
 

--- a/cmd/ocagent/main.go
+++ b/cmd/ocagent/main.go
@@ -124,7 +124,7 @@ func runZPages(port int) func() error {
 	srv := http.Server{Handler: zPagesMux}
 	go func() {
 		log.Printf("Running zPages at %q", addr)
-		if err := srv.Serve(ln); err != nil && err.Error() != "http: Server closed" {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("Failed to serve zPages: %v", err)
 		}
 	}()

--- a/cmd/ocagent/main.go
+++ b/cmd/ocagent/main.go
@@ -121,14 +121,15 @@ func runZPages(port int) func() error {
 		log.Fatalf("Failed to bind to run zPages on %q: %v", addr, err)
 	}
 
+	srv := http.Server{Handler: zPagesMux}
 	go func() {
 		log.Printf("Running zPages at %q", addr)
-		if err := http.Serve(ln, zPagesMux); err != nil {
+		if err := srv.Serve(ln); err != nil && err.Error() != "http: Server closed" {
 			log.Fatalf("Failed to serve zPages: %v", err)
 		}
 	}()
 
-	return ln.Close
+	return srv.Close
 }
 
 func runOCInterceptor(addr string, sr spanreceiver.SpanReceiver) (doneFn func() error, err error) {
@@ -152,13 +153,14 @@ func runOCInterceptor(addr string, sr spanreceiver.SpanReceiver) (doneFn func() 
 	agenttracepb.RegisterTraceServiceServer(srv, oci)
 	go func() {
 		log.Printf("Running OpenCensus interceptor as a gRPC service at %q", addr)
-
-		// Not using log.Fatalf(srv.Serve(ln)) because CTRL-C will close the listener as the user requested
-		// and that log.Fatalf will produce an unrelated but misleading error:
-		//     "Failed to run OpenCensus interceptor: accept tcp 127.0.0.1:55678: use of closed network connection"
-		_ = srv.Serve(ln)
+		if err := srv.Serve(ln); err != nil {
+			log.Fatalf("Failed to run OpenCensus interceptor: %v", err)
+		}
 	}()
-	doneFn = ln.Close
+	doneFn = func() error {
+		srv.Stop()
+		return nil
+	}
 	return doneFn, nil
 }
 

--- a/cmd/occollector/Dockerfile
+++ b/cmd/occollector/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+COPY occollector_linux /
+ENTRYPOINT ["/occollector_linux"]
+EXPOSE 55678

--- a/cmd/occollector/main.go
+++ b/cmd/occollector/main.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	defaultOCAddress = "localhost:55678"
+	defaultOCAddress = ":55678"
 )
 
 func main() {
@@ -103,7 +103,12 @@ func runOCServerWithInterceptor(addr string, logger *zap.Logger) (func() error, 
 		}
 	}()
 
-	return lis.Close, nil
+	closeFn := func() error {
+		grpcSrv.Stop()
+		return nil
+	}
+
+	return closeFn, nil
 }
 
 type fakeSpanReceiver struct {


### PR DESCRIPTION
* Adds the scratch docker for agent and collector
* Opportunistically change some close functions to close the server 
instead of the listener that they depend on (a somewhat cleaner shutdown),
the servers close take care of closing the listeners
