### PR TITLE
fix the logical conflict test for zipkin

### DIFF
--- a/cmd/ocagent/config.go
+++ b/cmd/ocagent/config.go
@@ -141,7 +141,7 @@ func (c *config) checkLogicalConflicts(blob []byte) error {
 		return err
 	}
 
-	if cfg.Exporters == nil || cfg.Exporters.Zipkin == nil {
+	if cfg.Exporters == nil || cfg.Exporters.Zipkin == nil || !c.zipkinInterceptorEnabled() {
 		return nil
 	}
 


### PR DESCRIPTION
The logical conflict test was triggering a false positive in case a Zipkin exporter was enabled but a Zipkin interceptor was not.

Without the interceptor enabled, the test ran against the default Zipkin endpoint as if it was configured to run under that default Zipkin endpoint.

The test now checks if both Exporter and Interceptor are enabled before testing the endpoints.