### PR TITLE
receiver/jaeger: implement and hookup Jaeger receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
         - [Receivers](#agent-config-receivers)
             - [OpenCensus](#details-receivers-opencensus)
             - [Zipkin](#details-receivers-zipkin)
+            - [Jaeger](#details-receivers-jaeger)
         - [End-to-end example](#agent-config-end-to-end-example)
     - [Diagnostics](#agent-diagnostics)
         - [zPages](#agent-zpages)
@@ -159,6 +160,21 @@ For example:
 receivers:
     zipkin:
         address: "localhost:9411"
+```
+
+#### <a name="details-receivers-jaeger"></a>Jaeger
+
+This receiver receives spans from Jaeger collector HTTP and Thrift uploads and translates them into the internal span types that are then
+sent to the collector/exporters.
+
+Its address can be configured in the YAML configuration file under section "intercpetors", subsection "jaeger" and fields "collector_http_port", "collector_thrift_port".
+
+For example:
+```yaml
+receivers:
+    jaeger
+        collector_http_port: 14268
+        collector_thrift_port: 14267
 ```
 
 ### <a name="agent-config-end-to-end-example"></a>Running an end-to-end example/demo

--- a/cmd/ocagent/config.go
+++ b/cmd/ocagent/config.go
@@ -59,11 +59,14 @@ type config struct {
 type receivers struct {
 	OpenCensus *receiverConfig `yaml:"opencensus"`
 	Zipkin     *receiverConfig `yaml:"zipkin"`
+	Jaeger     *receiverConfig `yaml:"jaeger"`
 }
 
 type receiverConfig struct {
 	// The address to which the OpenCensus receiver will be bound and run on.
-	Address string `yaml:"address"`
+	Address             string `yaml:"address"`
+	CollectorHTTPPort   int    `yaml:"collector_http_port"`
+	CollectorThriftPort int    `yaml:"collector_thrift_port"`
 }
 
 type zPagesConfig struct {
@@ -107,6 +110,13 @@ func (c *config) zipkinReceiverEnabled() bool {
 	return c.Receivers != nil && c.Receivers.Zipkin != nil
 }
 
+func (c *config) jaegerReceiverEnabled() bool {
+	if c == nil {
+		return false
+	}
+	return c.Receivers != nil && c.Receivers.Jaeger != nil
+}
+
 func (c *config) zipkinReceiverAddress() string {
 	if c == nil || c.Receivers == nil {
 		return exporterparser.DefaultZipkinEndpointHostPort
@@ -116,6 +126,18 @@ func (c *config) zipkinReceiverAddress() string {
 		return exporterparser.DefaultZipkinEndpointHostPort
 	}
 	return inCfg.Zipkin.Address
+}
+
+func (c *config) jaegerReceiverPorts() (collectorPort, thriftPort int) {
+	if c == nil || c.Receivers == nil {
+		return 0, 0
+	}
+	rCfg := c.Receivers
+	if rCfg.Jaeger == nil {
+		return 0, 0
+	}
+	jc := rCfg.Jaeger
+	return jc.CollectorHTTPPort, jc.CollectorThriftPort
 }
 
 func parseOCAgentConfig(yamlBlob []byte) (*config, error) {

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,12 @@ require (
 	github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 // indirect
 	github.com/aws/aws-sdk-go v1.15.68 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.1.0
+	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
+	github.com/gogo/googleapis v1.1.0 // indirect
+	github.com/gogo/protobuf v1.1.1 // indirect
 	github.com/golang/protobuf v1.2.0
 	github.com/gorilla/context v1.1.1 // indirect
-	github.com/gorilla/mux v1.6.2 // indirect
+	github.com/gorilla/mux v1.6.2
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jaegertracing/jaeger v1.7.0
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
@@ -27,7 +30,8 @@ require (
 	github.com/stretchr/testify v1.2.2 // indirect
 	github.com/tinylib/msgp v1.0.2 // indirect
 	github.com/uber-go/atomic v1.3.2 // indirect
-	github.com/uber/tchannel-go v1.10.0 // indirect
+	github.com/uber/jaeger-lib v1.5.0 // indirect
+	github.com/uber/tchannel-go v1.10.0
 	github.com/yancl/opencensus-go-exporter-kafka v0.0.0-20181029030031-9c471c1bfbeb
 	go.opencensus.io v0.18.0
 	go.uber.org/atomic v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/census-instrumentation/opencensus-proto v0.0.2/go.mod h1:f6KPmirojxKA
 github.com/census-instrumentation/opencensus-proto v0.1.0 h1:VwZ9smxzX8u14/125wHIX7ARV+YhR+L4JADswwxWK0Y=
 github.com/census-instrumentation/opencensus-proto v0.1.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
+github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eapache/go-resiliency v1.1.0 h1:1NtRmCAqadE2FN4ZcN6g90TP3uk8cg9rn9eNK2197aU=
@@ -42,6 +44,10 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-ini/ini v1.25.4 h1:Mujh4R/dH6YL8bxuISne3xX2+qcQ9p0IxKAP6ExWoUo=
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
+github.com/gogo/googleapis v1.1.0 h1:kFkMAZBNAn4j7K0GiZr8cRYzejq68VbheufiV3YuyFI=
+github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
+github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
+github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
@@ -59,6 +65,7 @@ github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/grpc-ecosystem/grpc-gateway v1.5.0 h1:WcmKMm43DR7RdtlkEXQJyo5ws8iTp98CyhCCbOHMvNI=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
@@ -105,6 +112,8 @@ github.com/tinylib/msgp v1.0.2 h1:DfdQrzQa7Yh2es9SuLkixqxuXS2SxsdYn0KbdrOGWD8=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/uber-go/atomic v1.3.2 h1:Azu9lPBWRNKzYXSIwRfgRuDuS0YKsK4NFhiQv98gkxo=
 github.com/uber-go/atomic v1.3.2/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
+github.com/uber/jaeger-lib v1.5.0 h1:OHbgr8l656Ub3Fw5k9SWnBfIEwvoHQ+W2y+Aa9D1Uyo=
+github.com/uber/jaeger-lib v1.5.0/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/uber/tchannel-go v1.10.0 h1:YOihLHuvkwT3nzvpgqFtexFW+pb5vD1Tz7h/bIWApgE=
 github.com/uber/tchannel-go v1.10.0/go.mod h1:Rrgz1eL8kMjW/nEzZos0t+Heq0O4LhnUJVA32OvWKHo=
 github.com/yancl/opencensus-go-exporter-kafka v0.0.0-20181029030031-9c471c1bfbeb h1:DSch+h+LW/9zO8ImnA2KzFylC/ShRAAgRPJVlx6FMSA=

--- a/receiver/jaeger/trace_receiver.go
+++ b/receiver/jaeger/trace_receiver.go
@@ -1,0 +1,189 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaeger
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/gorilla/mux"
+	"github.com/jaegertracing/jaeger/cmd/collector/app"
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/thrift"
+
+	"github.com/census-instrumentation/opencensus-service/receiver"
+	"github.com/census-instrumentation/opencensus-service/spansink"
+	"github.com/census-instrumentation/opencensus-service/translator/trace"
+)
+
+// Receiver type is used to receive spans that were originally intended to be sent to Jaeger.
+// This receiver is basically a Jaeger collector.
+type jReceiver struct {
+	// mu protects the fields of this type
+	mu sync.Mutex
+
+	spanSink spansink.Sink
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+
+	tchannelPort      int
+	collectorHTTPPort int
+
+	tchannel        *tchannel.Channel
+	collectorServer *http.Server
+}
+
+const (
+	// As per https://www.jaegertracing.io/docs/1.7/deployment/
+	// By default, the port used by jaeger-agent to send spans in jaeger.thrift format
+	defaultTChannelPort = 14267
+	// By default, can accept spans directly from clients in jaeger.thrift format over binary thrift protocol
+	defaultCollectorHTTPPort = 14268
+)
+
+// New creates a TraceReceiver that receives traffic as a collector with both Thrift and HTTP transports.
+func New(ctx context.Context, tchannelPort, collectorHTTPPort int) (receiver.TraceReceiver, error) {
+	return &jReceiver{tchannelPort: tchannelPort, collectorHTTPPort: collectorHTTPPort}, nil
+}
+
+var _ receiver.TraceReceiver = (*jReceiver)(nil)
+
+var (
+	errAlreadyStarted = errors.New("already started")
+	errAlreadyStopped = errors.New("already stopped")
+)
+
+func (jr *jReceiver) collectorAddr() string {
+	port := jr.collectorHTTPPort
+	if port <= 0 {
+		port = defaultCollectorHTTPPort
+	}
+	return fmt.Sprintf(":%d", port)
+}
+
+func (jr *jReceiver) tchannelAddr() string {
+	port := jr.tchannelPort
+	if port <= 0 {
+		port = defaultTChannelPort
+	}
+	return fmt.Sprintf(":%d", port)
+}
+
+func (jr *jReceiver) StartTraceReception(ctx context.Context, spanSink spansink.Sink) error {
+	jr.mu.Lock()
+	defer jr.mu.Unlock()
+
+	var err = errAlreadyStarted
+	jr.startOnce.Do(func() {
+		tch, terr := tchannel.NewChannel("recv", new(tchannel.ChannelOptions))
+		if terr != nil {
+			err = fmt.Errorf("Failed to create NewTChannel: %v", terr)
+			return
+		}
+
+		taddr := jr.tchannelAddr()
+		tln, terr := net.Listen("tcp", taddr)
+		if terr != nil {
+			err = fmt.Errorf("Failed to bind to TChannnel address %q: %v", taddr, terr)
+			return
+		}
+		tch.Serve(tln)
+		jr.tchannel = tch
+
+		// Now the collector that runs over HTTP
+		caddr := jr.collectorAddr()
+		cln, cerr := net.Listen("tcp", caddr)
+		if cerr != nil {
+			// Abort and close tch
+			tch.Close()
+			err = fmt.Errorf("Failed to bind to Collector address %q: %v", caddr, cerr)
+			return
+		}
+
+		nr := mux.NewRouter()
+		apiHandler := app.NewAPIHandler(jr)
+		apiHandler.RegisterRoutes(nr)
+		jr.collectorServer = &http.Server{Handler: nr}
+		go func() {
+			_ = jr.collectorServer.Serve(cln)
+		}()
+
+		// Otherwise no error was encountered,
+		// finally set the spanSink
+		jr.spanSink = spanSink
+		err = nil
+	})
+	return err
+}
+
+func (jr *jReceiver) StopTraceReception(ctx context.Context) error {
+	jr.mu.Lock()
+	defer jr.mu.Unlock()
+
+	var err = errAlreadyStopped
+	jr.stopOnce.Do(func() {
+		var errs []error
+		if jr.collectorServer != nil {
+			if cerr := jr.collectorServer.Close(); cerr != nil {
+				errs = append(errs, cerr)
+			}
+			jr.collectorServer = nil
+		}
+		if jr.tchannel != nil {
+			jr.tchannel.Close()
+			jr.tchannel = nil
+		}
+		if len(errs) == 0 {
+			err = nil
+			return
+		}
+
+		// Otherwise combine all these errors
+		buf := new(bytes.Buffer)
+		for _, err := range errs {
+			fmt.Fprintf(buf, "%s\n", err.Error())
+		}
+		err = errors.New(buf.String())
+	})
+
+	return err
+}
+
+func (jr *jReceiver) SubmitBatches(ctx thrift.Context, batches []*jaeger.Batch) ([]*jaeger.BatchSubmitResponse, error) {
+	jbsr := make([]*jaeger.BatchSubmitResponse, 0, len(batches))
+
+	for _, batch := range batches {
+		octrace, err := tracetranslator.JaegerThriftBatchToOCProto(batch)
+		// TODO: (@odeke-em) add this error for Jaeger observability
+		ok := false
+
+		if err == nil && octrace != nil {
+			ok = true
+			jr.spanSink.ReceiveSpans(ctx, octrace.Node, octrace.Spans...)
+		}
+
+		jbsr = append(jbsr, &jaeger.BatchSubmitResponse{
+			Ok: ok,
+		})
+	}
+	return jbsr, nil
+}

--- a/receiver/jaeger/trace_receiver_test.go
+++ b/receiver/jaeger/trace_receiver_test.go
@@ -1,0 +1,236 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaeger_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"go.opencensus.io/exporter/jaeger"
+	"go.opencensus.io/trace"
+
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/census-instrumentation/opencensus-service/internal"
+	jaegerreceiver "github.com/census-instrumentation/opencensus-service/receiver/jaeger"
+	"github.com/census-instrumentation/opencensus-service/spansink"
+)
+
+func TestReception(t *testing.T) {
+	// 1. Create the Jaeger receiver aka "server"
+	tchannelPort, collectorHTTPPort := 14267, 14268
+	jr, err := jaegerreceiver.New(context.Background(), tchannelPort, collectorHTTPPort)
+	if err != nil {
+		t.Fatalf("Failed to create new Jaeger Receiver: %v", err)
+	}
+	defer jr.StopTraceReception(context.Background())
+	t.Log("Starting")
+
+	sink := new(concurrentSpanSink)
+	if err := jr.StartTraceReception(context.Background(), sink); err != nil {
+		t.Fatalf("StartTraceReception failed: %v", err)
+	}
+	t.Log("StartTraceReception")
+
+	now := time.Unix(1542158650, 536343000).UTC()
+	nowPlus10min := now.Add(10 * time.Minute)
+	nowPlus10min2sec := now.Add(10 * time.Minute).Add(2 * time.Second)
+
+	// 2. Then with a "live application", send spans to the Jaeger exporter.
+	jexp, err := jaeger.NewExporter(jaeger.Options{
+		Process: jaeger.Process{
+			ServiceName: "issaTest",
+			Tags: []jaeger.Tag{
+				jaeger.BoolTag("bool", true),
+				jaeger.StringTag("string", "yes"),
+				jaeger.Int64Tag("int64", 1e7),
+			},
+		},
+		CollectorEndpoint: fmt.Sprintf("http://localhost:%d/api/traces", collectorHTTPPort),
+	})
+	if err != nil {
+		t.Fatalf("Failed to create the Jaeger OpenCensus exporter for the live application: %v", err)
+	}
+
+	// 3. Now finally send some spans
+	spandata := []*trace.SpanData{
+		{
+			SpanContext: trace.SpanContext{
+				TraceID: trace.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x80},
+				SpanID:  trace.SpanID{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8},
+			},
+			ParentSpanID: trace.SpanID{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18},
+			Name:         "DBSearch",
+			StartTime:    now,
+			EndTime:      nowPlus10min,
+			Status: trace.Status{
+				Code:    trace.StatusCodeNotFound,
+				Message: "Stale indices",
+			},
+			Links: []trace.Link{
+				{
+					TraceID: trace.TraceID{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80},
+					SpanID:  trace.SpanID{0xCF, 0xCE, 0xCD, 0xCC, 0xCB, 0xCA, 0xC9, 0xC8},
+					Type:    trace.LinkTypeChild,
+				},
+			},
+		},
+		{
+			SpanContext: trace.SpanContext{
+				TraceID: trace.TraceID{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80},
+				SpanID:  trace.SpanID{0xCF, 0xCE, 0xCD, 0xCC, 0xCB, 0xCA, 0xC9, 0xC8},
+			},
+			Name:      "ProxyFetch",
+			StartTime: nowPlus10min,
+			EndTime:   nowPlus10min2sec,
+			Status: trace.Status{
+				Code:    trace.StatusCodeInternal,
+				Message: "Frontend crash",
+			},
+			Links: []trace.Link{
+				{
+					TraceID: trace.TraceID{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80},
+					SpanID:  trace.SpanID{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8},
+					Type:    trace.LinkTypeParent,
+				},
+			},
+		},
+	}
+
+	for _, sd := range spandata {
+		jexp.ExportSpan(sd)
+	}
+	jexp.Flush()
+
+	// Simulate and account for network latency but also the reception process on the server.
+	<-time.After(500 * time.Millisecond)
+
+	jexp.Flush()
+
+	got := sink.allTraces()
+
+	want := []*agenttracepb.ExportTraceServiceRequest{
+		{
+			Node: &commonpb.Node{
+				ServiceInfo: &commonpb.ServiceInfo{Name: "issaTest"},
+				LibraryInfo: &commonpb.LibraryInfo{},
+				Identifier:  &commonpb.ProcessIdentifier{},
+				Attributes: map[string]string{
+					"bool":   "true",
+					"string": "yes",
+					"int64":  "10000000",
+				},
+			},
+
+			Spans: []*tracepb.Span{
+				{
+					TraceId:      []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x80},
+					SpanId:       []byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8},
+					ParentSpanId: []byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18},
+					Name:         &tracepb.TruncatableString{Value: "DBSearch"},
+					StartTime:    internal.TimeToTimestamp(now),
+					EndTime:      internal.TimeToTimestamp(nowPlus10min),
+					Status: &tracepb.Status{
+						Code:    trace.StatusCodeNotFound,
+						Message: "Stale indices",
+					},
+					Links: &tracepb.Span_Links{
+						Link: []*tracepb.Span_Link{
+							{
+								TraceId: []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80},
+								SpanId:  []byte{0xCF, 0xCE, 0xCD, 0xCC, 0xCB, 0xCA, 0xC9, 0xC8},
+								Type:    tracepb.Span_Link_CHILD_LINKED_SPAN,
+							},
+						},
+					},
+				},
+				{
+					TraceId:   []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80},
+					SpanId:    []byte{0xCF, 0xCE, 0xCD, 0xCC, 0xCB, 0xCA, 0xC9, 0xC8},
+					Name:      &tracepb.TruncatableString{Value: "ProxyFetch"},
+					StartTime: internal.TimeToTimestamp(nowPlus10min),
+					EndTime:   internal.TimeToTimestamp(nowPlus10min2sec),
+					Status: &tracepb.Status{
+						Code:    trace.StatusCodeInternal,
+						Message: "Frontend crash",
+					},
+					Links: &tracepb.Span_Links{
+						Link: []*tracepb.Span_Link{
+							{
+								TraceId: []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80},
+								SpanId:  []byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8},
+								// TODO: (@pjanotti, @odeke-em) contact the Jaeger maintains to inquire about
+								// Parent_Linked_Spans as currently they've only got:
+								// * Child_of
+								// * Follows_from
+								// yet OpenCensus has Parent too but Jaeger uses a zero-value for LinkCHILD.
+								Type: tracepb.Span_Link_CHILD_LINKED_SPAN,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		gj, wj := toJSON(got), toJSON(want)
+		if !bytes.Equal(gj, wj) {
+			t.Errorf("Mismatches responses\nGot:\n\t%v\n\t%s\nWant:\n\t%v\n\t%s", got, gj, want, wj)
+		}
+	}
+}
+
+type concurrentSpanSink struct {
+	mu     sync.Mutex
+	traces []*agenttracepb.ExportTraceServiceRequest
+}
+
+var _ spansink.Sink = (*concurrentSpanSink)(nil)
+
+func (css *concurrentSpanSink) ReceiveSpans(ctx context.Context, node *commonpb.Node, spans ...*tracepb.Span) (*spansink.Acknowledgement, error) {
+	css.mu.Lock()
+	defer css.mu.Unlock()
+
+	css.traces = append(css.traces, &agenttracepb.ExportTraceServiceRequest{
+		Node:  node,
+		Spans: spans,
+	})
+
+	ack := &spansink.Acknowledgement{
+		SavedSpans: uint64(len(spans)),
+	}
+
+	return ack, nil
+}
+
+func (css *concurrentSpanSink) allTraces() []*agenttracepb.ExportTraceServiceRequest {
+	css.mu.Lock()
+	defer css.mu.Unlock()
+
+	return css.traces[:]
+}
+
+func toJSON(v interface{}) []byte {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	return b
+}


### PR DESCRIPTION
Jaeger collector running on HTTP and Thrift implemented.
The configuration can be set as:
```yaml
receivers:
  jaeger:
    collector_http_port: 14268
    collector_thrift_port: 14267
```

Fixes #153