### PR TITLE
receiver/zipkin: consolidate server starting to receiver

### DIFF
--- a/receiver/zipkin/trace_receiver_test.go
+++ b/receiver/zipkin/trace_receiver_test.go
@@ -156,11 +156,7 @@ func TestConversionRoundtrip(t *testing.T) {
   }
 }]`)
 
-	sink := new(noopSink)
-	zi, err := New(sink)
-	if err != nil {
-		t.Fatalf("Failed to create the Zipkin receiver: %v", err)
-	}
+	zi := &ZipkinReceiver{spanSink: new(noopSink)}
 	ereqs, err := zi.parseAndConvertToTraceSpans(receiverInputJSON, nil)
 	if err != nil {
 		t.Fatalf("Failed to parse and convert receiver JSON: %v", err)


### PR DESCRIPTION
Moved the server starting logic to the receiver and updated
New to
  New(address string) (*ZipkinReceiver, error)
instead of
  New(spansink.Sink) (*ZipkinReceiver, error)

This change ensures that after invoking New all the user
has to do is then just invoke:
   zr.StartTraceReception(context.Context, spansink.Sink) error

and then for cleanup
    defer zr.StopTraceReception(context.Context)

Fixes #212