### PR TITLE
receiver: use TraceData and MetricsData in receivers.

### DIFF
--- a/exporter/trace_exporter.go
+++ b/exporter/trace_exporter.go
@@ -19,6 +19,7 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/receiver"
 )
 
@@ -53,15 +54,15 @@ func (tes traceExporters) ExportSpans(ctx context.Context, node *commonpb.Node, 
 	return nil
 }
 
-// ReceiveSpans receives the span data in the protobuf format, translates it, and forwards the transformed
+// ReceiveTraceData receives the span data in the protobuf format, translates it, and forwards the transformed
 // span data to all trace exporters wrapped by the current one.
-func (tes traceExporters) ReceiveSpans(ctx context.Context, node *commonpb.Node, spans ...*tracepb.Span) (*receiver.TraceReceiverAcknowledgement, error) {
+func (tes traceExporters) ReceiveTraceData(ctx context.Context, td data.TraceData) (*receiver.TraceReceiverAcknowledgement, error) {
 	for _, te := range tes {
-		_ = te.ExportSpans(ctx, node, spans...)
+		_ = te.ExportSpans(ctx, td.Node, td.Spans...)
 	}
 
 	ack := &receiver.TraceReceiverAcknowledgement{
-		SavedSpans: uint64(len(spans)),
+		SavedSpans: uint64(len(td.Spans)),
 	}
 	return ack, nil
 }

--- a/internal/collector/processor/exporter_processor.go
+++ b/internal/collector/processor/exporter_processor.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
+	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/exporter"
 )
 
@@ -33,7 +34,7 @@ func NewTraceExporterProcessor(traceExporters ...exporter.TraceExporter) SpanPro
 }
 
 func (sp *exporterSpanProcessor) ProcessSpans(batch *agenttracepb.ExportTraceServiceRequest, spanFormat string) (uint64, error) {
-	ack, err := sp.tes.ReceiveSpans(context.Background(), batch.Node, batch.Spans...)
+	ack, err := sp.tes.ReceiveTraceData(context.Background(), data.TraceData{Node: batch.Node, Resource: batch.Resource, Spans: batch.Spans})
 	if err != nil {
 		return ack.DroppedSpans, err
 	}

--- a/internal/collector/processor/processor_to_sink.go
+++ b/internal/collector/processor/processor_to_sink.go
@@ -17,9 +17,8 @@ package processor
 import (
 	"context"
 
-	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
-	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/receiver"
 )
 
@@ -38,10 +37,10 @@ func WrapWithSpanSink(format string, p SpanProcessor) receiver.TraceReceiverSink
 	}
 }
 
-func (ps *protoProcessorSink) ReceiveSpans(ctx context.Context, node *commonpb.Node, spans ...*tracepb.Span) (*receiver.TraceReceiverAcknowledgement, error) {
+func (ps *protoProcessorSink) ReceiveTraceData(ctx context.Context, td data.TraceData) (*receiver.TraceReceiverAcknowledgement, error) {
 	batch := &agenttracepb.ExportTraceServiceRequest{
-		Node:  node,
-		Spans: spans,
+		Node:  td.Node,
+		Spans: td.Spans,
 	}
 
 	failures, err := ps.protoProcessor.ProcessSpans(batch, ps.sourceFormat)

--- a/receiver/end_to_end_test.go
+++ b/receiver/end_to_end_test.go
@@ -23,8 +23,7 @@ import (
 	"contrib.go.opencensus.io/exporter/ocagent"
 	"go.opencensus.io/trace"
 
-	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
-	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/receiver"
 	"github.com/census-instrumentation/opencensus-service/receiver/opencensus"
 )
@@ -95,9 +94,9 @@ type logSpanSink int
 
 var _ receiver.TraceReceiverSink = (*logSpanSink)(nil)
 
-func (lsr *logSpanSink) ReceiveSpans(ctx context.Context, node *commonpb.Node, spans ...*tracepb.Span) (*receiver.TraceReceiverAcknowledgement, error) {
-	spansBlob, _ := json.MarshalIndent(spans, " ", "  ")
-	log.Printf("\n****\nNode: %#v\nSpans: %s\n****\n", node, spansBlob)
+func (lsr *logSpanSink) ReceiveTraceData(ctx context.Context, td data.TraceData) (*receiver.TraceReceiverAcknowledgement, error) {
+	spansBlob, _ := json.MarshalIndent(td.Spans, " ", "  ")
+	log.Printf("\n****\nNode: %#v\nSpans: %s\n****\n", td.Node, spansBlob)
 
-	return &receiver.TraceReceiverAcknowledgement{SavedSpans: uint64(len(spans))}, nil
+	return &receiver.TraceReceiverAcknowledgement{SavedSpans: uint64(len(td.Spans))}, nil
 }

--- a/receiver/jaeger/trace_receiver.go
+++ b/receiver/jaeger/trace_receiver.go
@@ -29,6 +29,7 @@ import (
 	tchannel "github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/thrift"
 
+	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/receiver"
 	"github.com/census-instrumentation/opencensus-service/translator/trace"
 )
@@ -177,7 +178,7 @@ func (jr *jReceiver) SubmitBatches(ctx thrift.Context, batches []*jaeger.Batch) 
 
 		if err == nil && octrace != nil {
 			ok = true
-			jr.spanSink.ReceiveSpans(ctx, octrace.Node, octrace.Spans...)
+			jr.spanSink.ReceiveTraceData(ctx, data.TraceData{Node: octrace.Node, Spans: octrace.Spans})
 		}
 
 		jbsr = append(jbsr, &jaeger.BatchSubmitResponse{

--- a/receiver/jaeger/trace_receiver_test.go
+++ b/receiver/jaeger/trace_receiver_test.go
@@ -30,6 +30,7 @@ import (
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/internal"
 	"github.com/census-instrumentation/opencensus-service/receiver"
 	jaegerreceiver "github.com/census-instrumentation/opencensus-service/receiver/jaeger"
@@ -207,17 +208,17 @@ type concurrentSpanSink struct {
 
 var _ receiver.TraceReceiverSink = (*concurrentSpanSink)(nil)
 
-func (css *concurrentSpanSink) ReceiveSpans(ctx context.Context, node *commonpb.Node, spans ...*tracepb.Span) (*receiver.TraceReceiverAcknowledgement, error) {
+func (css *concurrentSpanSink) ReceiveTraceData(ctx context.Context, td data.TraceData) (*receiver.TraceReceiverAcknowledgement, error) {
 	css.mu.Lock()
 	defer css.mu.Unlock()
 
 	css.traces = append(css.traces, &agenttracepb.ExportTraceServiceRequest{
-		Node:  node,
-		Spans: spans,
+		Node:  td.Node,
+		Spans: td.Spans,
 	})
 
 	ack := &receiver.TraceReceiverAcknowledgement{
-		SavedSpans: uint64(len(spans)),
+		SavedSpans: uint64(len(td.Spans)),
 	}
 
 	return ack, nil

--- a/receiver/opencensus/ocmetrics/opencensus_test.go
+++ b/receiver/opencensus/ocmetrics/opencensus_test.go
@@ -34,7 +34,7 @@ import (
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/internal"
 	"github.com/census-instrumentation/opencensus-service/receiver"
 	"github.com/census-instrumentation/opencensus-service/receiver/opencensus/ocmetrics"
@@ -327,13 +327,13 @@ func newMetricAppender() *metricAppender {
 
 var _ receiver.MetricsReceiverSink = (*metricAppender)(nil)
 
-func (sa *metricAppender) ReceiveMetrics(ctx context.Context, node *commonpb.Node, resource *resourcepb.Resource, metrics ...*metricspb.Metric) (*receiver.MetricsReceiverAcknowledgement, error) {
+func (sa *metricAppender) ReceiveMetricsData(ctx context.Context, md data.MetricsData) (*receiver.MetricsReceiverAcknowledgement, error) {
 	sa.Lock()
 	defer sa.Unlock()
 
-	sa.metricsPerNode[node] = append(sa.metricsPerNode[node], metrics...)
+	sa.metricsPerNode[md.Node] = append(sa.metricsPerNode[md.Node], md.Metrics...)
 
-	return &receiver.MetricsReceiverAcknowledgement{SavedMetrics: uint64(len(metrics))}, nil
+	return &receiver.MetricsReceiverAcknowledgement{SavedMetrics: uint64(len(md.Metrics))}, nil
 }
 
 func ocReceiverOnGRPCServer(t *testing.T, sr receiver.MetricsReceiverSink, opts ...ocmetrics.Option) (oci *ocmetrics.Receiver, port int, done func()) {

--- a/receiver/opencensus/octrace/opencensus_test.go
+++ b/receiver/opencensus/octrace/opencensus_test.go
@@ -36,6 +36,7 @@ import (
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/internal"
 	"github.com/census-instrumentation/opencensus-service/receiver"
 	"github.com/census-instrumentation/opencensus-service/receiver/opencensus/octrace"
@@ -447,13 +448,13 @@ func newSpanAppender() *spanAppender {
 
 var _ receiver.TraceReceiverSink = (*spanAppender)(nil)
 
-func (sa *spanAppender) ReceiveSpans(ctx context.Context, node *commonpb.Node, spans ...*tracepb.Span) (*receiver.TraceReceiverAcknowledgement, error) {
+func (sa *spanAppender) ReceiveTraceData(ctx context.Context, td data.TraceData) (*receiver.TraceReceiverAcknowledgement, error) {
 	sa.Lock()
 	defer sa.Unlock()
 
-	sa.spansPerNode[node] = append(sa.spansPerNode[node], spans...)
+	sa.spansPerNode[td.Node] = append(sa.spansPerNode[td.Node], td.Spans...)
 
-	return &receiver.TraceReceiverAcknowledgement{SavedSpans: uint64(len(spans))}, nil
+	return &receiver.TraceReceiverAcknowledgement{SavedSpans: uint64(len(td.Spans))}, nil
 }
 
 func ocReceiverOnGRPCServer(t *testing.T, sr receiver.TraceReceiverSink, opts ...octrace.Option) (oci *octrace.Receiver, port int, done func()) {

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -17,12 +17,8 @@ package receiver
 import (
 	"context"
 
+	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/internal"
-
-	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
-	metricpb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 )
 
 // A TraceReceiver is an "arbitrary data"-to-"trace proto span" converter.
@@ -42,13 +38,13 @@ type TraceReceiver interface {
 	StopTraceReception(ctx context.Context) error
 }
 
-// TraceReceiverSink is an interface that receives spans from a Node identifier.
+// TraceReceiverSink is an interface that receives TraceData.
 type TraceReceiverSink interface {
-	ReceiveSpans(ctx context.Context, node *commonpb.Node, spans ...*tracepb.Span) (*TraceReceiverAcknowledgement, error)
+	ReceiveTraceData(ctx context.Context, tracedata data.TraceData) (*TraceReceiverAcknowledgement, error)
 }
 
 // TraceReceiverAcknowledgement struct reports the number of saved and dropped spans in a
-// ReceiveSpans call.
+// ReceiveTraceData call.
 type TraceReceiverAcknowledgement struct {
 	SavedSpans   uint64
 	DroppedSpans uint64
@@ -66,13 +62,13 @@ type MetricsReceiver interface {
 	StopMetricsReception(ctx context.Context) error
 }
 
-// MetricsReceiverSink is an interface that receives metrics from a Node identifier.
+// MetricsReceiverSink is an interface that receives MetricsData.
 type MetricsReceiverSink interface {
-	ReceiveMetrics(ctx context.Context, node *commonpb.Node, resource *resourcepb.Resource, metrics ...*metricpb.Metric) (*MetricsReceiverAcknowledgement, error)
+	ReceiveMetricsData(ctx context.Context, metricsdata data.MetricsData) (*MetricsReceiverAcknowledgement, error)
 }
 
-// MetricsReceiverAcknowledgement struct reports the number of saved and dropped spans in a
-// ReceiveSpans call.
+// MetricsReceiverAcknowledgement struct reports the number of saved and dropped metrics in a
+// ReceiveMetricsData call.
 type MetricsReceiverAcknowledgement struct {
 	SavedMetrics   uint64
 	DroppedMetrics uint64

--- a/receiver/zipkin/trace_receiver.go
+++ b/receiver/zipkin/trace_receiver.go
@@ -38,6 +38,7 @@ import (
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 
+	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/internal"
 	"github.com/census-instrumentation/opencensus-service/receiver"
 )
@@ -247,9 +248,9 @@ func (zr *ZipkinReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	spansMetricsFn := internal.NewReceivedSpansRecorderStreaming(ctx, "zipkin")
-	// Now translate them into tracepb.Span
+	// Now translate them into TraceData
 	for _, ereq := range ereqs {
-		zr.spanSink.ReceiveSpans(ctx, ereq.Node, ereq.Spans...)
+		zr.spanSink.ReceiveTraceData(ctx, data.TraceData{Node: ereq.Node, Spans: ereq.Spans})
 		// We MUST unconditionally record metrics from this reception.
 		spansMetricsFn(ereq.Node, ereq.Spans)
 	}

--- a/receiver/zipkin/trace_receiver_test.go
+++ b/receiver/zipkin/trace_receiver_test.go
@@ -33,6 +33,7 @@ import (
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/internal"
 	"github.com/census-instrumentation/opencensus-service/internal/testutils"
 	"github.com/census-instrumentation/opencensus-service/receiver"
@@ -395,6 +396,6 @@ type noopSink int
 
 var _ receiver.TraceReceiverSink = (*noopSink)(nil)
 
-func (ns *noopSink) ReceiveSpans(ctx context.Context, node *commonpb.Node, spans ...*tracepb.Span) (*receiver.TraceReceiverAcknowledgement, error) {
+func (ns *noopSink) ReceiveTraceData(ctx context.Context, td data.TraceData) (*receiver.TraceReceiverAcknowledgement, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-service/issues/182.
Updates https://github.com/census-instrumentation/opencensus-service/issues/215. 

~~Blocked by https://github.com/census-instrumentation/opencensus-service/pull/223.~~