### PR TITLE
exporterparser/zipkin: safely retrieve remoteEndpoint serviceName

### DIFF
--- a/exporter/exporterparser/zipkin.go
+++ b/exporter/exporterparser/zipkin.go
@@ -132,6 +132,13 @@ func newZipkinExporter(finalEndpointURI, defaultServiceName, defaultLocalEndpoin
 	return zle, nil
 }
 
+func lookupAttribute(node *commonpb.Node, key string) string {
+	if node == nil {
+		return ""
+	}
+	return node.Attributes[key]
+}
+
 func zipkinEndpointFromNode(node *commonpb.Node, serviceName string, endpointType zipkinDirection) (*zipkinmodel.Endpoint, error) {
 	if node == nil {
 		return nil, nil
@@ -300,7 +307,7 @@ func (ze *zipkinExporter) zipkinSpan(node *commonpb.Node, s *trace.SpanData) (zc
 		return zc, err
 	}
 
-	remoteServiceName := node.Attributes[zipkinRemoteEndpointKey]
+	remoteServiceName := lookupAttribute(node, zipkinRemoteEndpointKey)
 	remoteEndpoint, _ := zipkinEndpointFromNode(node, remoteServiceName, isRemoteEndpoint)
 
 	sc := s.SpanContext

--- a/exporter/exporterparser/zipkin_test.go
+++ b/exporter/exporterparser/zipkin_test.go
@@ -112,6 +112,15 @@ exporters:
     {"timestamp": 1472470996403000,"value": "bar"}
   ],
   "tags": {"http.path": "/api","clnt/finagle.version": "6.45.0"}
+},
+{
+  "traceId": "4d1e00c0db9010db86154a4ba6e91385",
+  "parentId": "86154a4ba6e91386",
+  "id": "4d1e00c0db9010db",
+  "kind": "SERVER",
+  "name": "put",
+  "timestamp": 1472470996199000,
+  "duration": 207000
 }]`)
 
 	// Finally we need to inspect the output
@@ -186,5 +195,14 @@ const zipkinSpansJSONJavaLibrary = `
     "http.path": "/api",
     "clnt/finagle.version": "6.45.0"
   }
+},
+{
+  "traceId": "4d1e00c0db9010db86154a4ba6e91385",
+  "parentId": "86154a4ba6e91386",
+  "id": "4d1e00c0db9010db",
+  "kind": "SERVER",
+  "name": "put",
+  "timestamp": 1472470996199000,
+  "duration": 207000
 }]
 `


### PR DESCRIPTION
Safely retrieve the servicename for the remoteEndpoint if no
endpoints were sent in the payload hence a nil Node.

A reduction of PR #229 and originally @pjanotti's endeavor.

Fixes #230