### PR TITLE
cmd/ocagent: add OpenCensus Metrics receiver + noopMetricsSink

### DIFF
--- a/cmd/ocagent/main.go
+++ b/cmd/ocagent/main.go
@@ -171,24 +171,14 @@ func runOCReceiver(acfg *config.Config, sr receiver.TraceReceiverSink, mr receiv
 
 	ctx := context.Background()
 
-	switch {
-	case acfg.CanRunAllOpenCensusReceivers():
-		if err := ocr.StartTraceReception(ctx, sr); err != nil {
-			return nil, fmt.Errorf("Failed to start OpenCensus Trace receiver: %v", err)
-		}
-		if err := ocr.StartMetricsReception(ctx, mr); err != nil {
-			ocr.Stop()
-			return nil, fmt.Errorf("Failed to start OpenCensus Metrics receiver: %v", err)
-		}
-		log.Printf("Running OpenCensus Trace and Metrics receivers as a gRPC service at %q", addr)
-
-	case acfg.CanRunOpenCensusTraceReceiver():
+	if acfg.CanRunOpenCensusTraceReceiver() {
 		if err := ocr.StartTraceReception(ctx, sr); err != nil {
 			return nil, fmt.Errorf("Failed to start TraceReceiver: %v", err)
 		}
 		log.Printf("Running OpenCensus Trace receiver as a gRPC service at %q", addr)
+	}
 
-	case acfg.CanRunOpenCensusMetricsReceiver():
+	if acfg.CanRunOpenCensusMetricsReceiver() {
 		if err := ocr.StartMetricsReception(ctx, mr); err != nil {
 			return nil, fmt.Errorf("Failed to start MetricsReceiver: %v", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,12 +113,6 @@ func (c *Config) OpenCensusReceiverAddress() string {
 	return inCfg.OpenCensus.Address
 }
 
-// CanRunAllOpenCensusReceivers returns true if the configuration
-// permits running both the OpenCensus Metrics and Trace receivers.
-func (c *Config) CanRunAllOpenCensusReceivers() bool {
-	return c.CanRunOpenCensusTraceReceiver() && c.CanRunOpenCensusMetricsReceiver()
-}
-
 // CanRunOpenCensusTraceReceiver returns true if the configuration
 // permits running the OpenCensus Trace receiver.
 func (c *Config) CanRunOpenCensusTraceReceiver() bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,11 @@ type ReceiverConfig struct {
 	Address             string `yaml:"address"`
 	CollectorHTTPPort   int    `yaml:"collector_http_port"`
 	CollectorThriftPort int    `yaml:"collector_thrift_port"`
+
+	// DisableTracing disables trace receiving and is only applicable to trace receivers.
+	DisableTracing bool `yaml:"disable_tracing"`
+	// DisableMetrics disables metrics receiving and is only applicable to metrics receivers.
+	DisableMetrics bool `yaml:"disable_metrics"`
 }
 
 // Exporters denotes the configurations for the various backends
@@ -106,6 +111,24 @@ func (c *Config) OpenCensusReceiverAddress() string {
 		return defaultOCReceiverAddress
 	}
 	return inCfg.OpenCensus.Address
+}
+
+// CanRunAllOpenCensusReceivers returns true if the configuration
+// permits running both the OpenCensus Metrics and Trace receivers.
+func (c *Config) CanRunAllOpenCensusReceivers() bool {
+	return c.CanRunOpenCensusTraceReceiver() && c.CanRunOpenCensusMetricsReceiver()
+}
+
+// CanRunOpenCensusTraceReceiver returns true if the configuration
+// permits running the OpenCensus Trace receiver.
+func (c *Config) CanRunOpenCensusTraceReceiver() bool {
+	return c != nil && c.Receivers != nil && !c.Receivers.OpenCensus.DisableTracing
+}
+
+// CanRunOpenCensusMetricsReceiver returns true if the configuration
+// permits running the OpenCensus Metrics receiver.
+func (c *Config) CanRunOpenCensusMetricsReceiver() bool {
+	return c != nil && c.Receivers != nil && !c.Receivers.OpenCensus.DisableMetrics
 }
 
 // ZPagesDisabled returns true if zPages have not been enabled.


### PR DESCRIPTION
For now before any OpenCensus Metrics exporter is created, just
hook it up. This will allow applications such as the OpenCensus-PHP
stats backend to send content.

Fixes #216