### PR TITLE
receiver/opencensus: provide a Start method for both Trace and Metrics

### DIFF
--- a/cmd/ocagent/main.go
+++ b/cmd/ocagent/main.go
@@ -171,14 +171,20 @@ func runOCReceiver(acfg *config.Config, sr receiver.TraceReceiverSink, mr receiv
 
 	ctx := context.Background()
 
-	if acfg.CanRunOpenCensusTraceReceiver() {
+	switch {
+	case acfg.CanRunOpenCensusTraceReceiver() && acfg.CanRunOpenCensusMetricsReceiver():
+		if err := ocr.Start(ctx, sr, mr); err != nil {
+			return nil, fmt.Errorf("Failed to start Trace and Metrics Receivers: %v", err)
+		}
+		log.Printf("Running OpenCensus Trace and Metrics receivers as a gRPC service at %q", addr)
+
+	case acfg.CanRunOpenCensusTraceReceiver():
 		if err := ocr.StartTraceReception(ctx, sr); err != nil {
 			return nil, fmt.Errorf("Failed to start TraceReceiver: %v", err)
 		}
 		log.Printf("Running OpenCensus Trace receiver as a gRPC service at %q", addr)
-	}
 
-	if acfg.CanRunOpenCensusMetricsReceiver() {
+	case acfg.CanRunOpenCensusMetricsReceiver():
 		if err := ocr.StartMetricsReception(ctx, mr); err != nil {
 			return nil, fmt.Errorf("Failed to start MetricsReceiver: %v", err)
 		}


### PR DESCRIPTION
Provide a Start method on the OpenCensus receiver to allow registering
all services before running the gRPC server.

Unfortunately gRPC's RegisterService doesn't return an error so
it has no choice but to Fatalf as per
https://github.com/grpc/grpc-go/blob/ca62c6b92c334f52c7e48b7cbf624f3b877fb092/server.go#L408-L410

By design, in Go we cannot catch a .Fatalf that invokes os.Exit(code)
so even a test is worthless to test this.

Fixes #243