### PR TITLE
receiver/jaeger: Jaeger Agent running on UDP ports

### DIFF
--- a/cmd/ocagent/main.go
+++ b/cmd/ocagent/main.go
@@ -196,7 +196,14 @@ func runOCReceiver(acfg *config.Config, sr receiver.TraceReceiverSink, mr receiv
 }
 
 func runJaegerReceiver(collectorThriftPort, collectorHTTPPort int, sr receiver.TraceReceiverSink) (doneFn func() error, err error) {
-	jtr, err := jaeger.New(context.Background(), collectorThriftPort, collectorHTTPPort)
+	jtr, err := jaeger.New(context.Background(), &jaeger.Configuration{
+		CollectorThriftPort: collectorThriftPort,
+		CollectorHTTPPort:   collectorHTTPPort,
+
+		// TODO: (@odeke-em, @pjanotti) send a change
+		// to dynamically retrieve the Jaeger Agent's ports
+		// and not use their defaults of 5778, 6831, 6832
+	})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create new Jaeger receiver: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/jaegertracing/jaeger v1.7.0
+	github.com/jaegertracing/jaeger v1.8.2
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/jaegertracing/jaeger v1.7.0 h1:RVpmOTj7Zb9QRFHI5CYvkYSTR8Cdn/PhM5kBxA4pZBM=
 github.com/jaegertracing/jaeger v1.7.0/go.mod h1:LUWPSnzNPGRubM8pk0inANGitpiMOOxihXx0+53llXI=
 github.com/jaegertracing/jaeger v1.8.0 h1:8nWwXtXFqCVyEPjKczfnB1Yj9s7DmaDHYbqnfNBORMY=
+github.com/jaegertracing/jaeger v1.8.2 h1:VNrL7qDS7IUJtjSJ3aa3+UU2Shhk26n4B/xi7A99mQc=
+github.com/jaegertracing/jaeger v1.8.2/go.mod h1:LUWPSnzNPGRubM8pk0inANGitpiMOOxihXx0+53llXI=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Aowv3l/EQUlocDHW2Cp4G9WJVH7uyH8QFJE=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=

--- a/internal/collector/jaeger/receiver.go
+++ b/internal/collector/jaeger/receiver.go
@@ -41,7 +41,10 @@ func Run(logger *zap.Logger, v *viper.Viper, spanProc processor.SpanProcessor) (
 	}
 
 	ctx := context.Background()
-	jtr, err := jaeger.New(ctx, rOpts.ThriftTChannelPort, rOpts.ThriftHTTPPort)
+	jtr, err := jaeger.New(ctx, &jaeger.Configuration{
+		CollectorThriftPort: rOpts.ThriftTChannelPort,
+		CollectorHTTPPort:   rOpts.ThriftHTTPPort,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* Update receiver/jaeger.New to take in a Configuration
that now allows specifying the Jaeger agent UDP ports
* Separated out startCollector and startAgent helpers
for the Jaeger receiver
* Agent now runs on UDP ports:
+ Thrift Compact: by default 6831
+ Thrift Binary: by default 6832
+ Agent server: by default 5778