### PR TITLE
README: Update usage commands.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,11 @@ install-tools:
 
 .PHONY: agent
 agent:
-	CGO_ENABLED=0 go build -o ./bin/ocagent_$(GOOS) $(BUILD_INFO) ./cmd/ocagent
+	GO111MODULE=on CGO_ENABLED=0 go build -o ./bin/ocagent_$(GOOS) $(BUILD_INFO) ./cmd/ocagent
 
 .PHONY: collector
 collector:
-	CGO_ENABLED=0 go build -o ./bin/occollector_$(GOOS) $(BUILD_INFO) ./cmd/occollector
+	GO111MODULE=on CGO_ENABLED=0 go build -o ./bin/occollector_$(GOOS) $(BUILD_INFO) ./cmd/occollector
 
 .PHONY: docker-component # Not intended to be used directly
 docker-component: check-component

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Architecture amd64
 
 ### <a name="agent-usage"></a>Usage
 
+The minimum Go version required for this project is Go1.11.
+
 First, install ocagent if you haven't.
 
 ```shell
@@ -296,6 +298,8 @@ agent/client health information/inventory metadata to downstream exporters.
 
 The collector is in its initial development stages. It can be run directly
 from sources, binary, or a Docker image.
+
+The minimum Go version required for this project is Go1.11.
 
 1. Run from sources:
 ```shell

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ First, install ocagent if you haven't.
 $ go get github.com/census-instrumentation/opencensus-service/cmd/ocagent
 ```
 
+Alternatively you can build ocagent from binary (from the root of your repo):
+
+```shell
+$ export GO111MODULE=on && make agent
+```
+
 ### <a name="agent-configuration-file"></a>Configuration file
 
 Create a config.yaml file in the current directory and modify
@@ -297,10 +303,10 @@ $ go run github.com/census-instrumentation/opencensus-service/cmd/occollector
 ```
 2. Run from binary (from the root of your repo):
 ```shell
-$ make collector
+$ export GO111MODULE=on && make collector
 $ ./bin/occollector_$($GOOS)
 ```
-3. Build a Docker scratch image and use the appropria Docker command for your scenario:
+3. Build a Docker scratch image and use the appropriate Docker command for your scenario:
 ```shell
 $ make docker-collector
 $ docker run --rm -it -p 55678:55678 occollector

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The minimum Go version required for this project is Go1.11.
 First, install ocagent if you haven't.
 
 ```shell
-$ go get github.com/census-instrumentation/opencensus-service/cmd/ocagent
+$ GO111MODULE=on go get github.com/census-instrumentation/opencensus-service/cmd/ocagent
 ```
 
 Alternatively you can build ocagent from binary (from the root of your repo):
@@ -303,7 +303,7 @@ The minimum Go version required for this project is Go1.11.
 
 1. Run from sources:
 ```shell
-$ go run github.com/census-instrumentation/opencensus-service/cmd/occollector
+$ GO111MODULE=on go run github.com/census-instrumentation/opencensus-service/cmd/occollector
 ```
 2. Run from binary (from the root of your repo):
 ```shell

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ go get github.com/census-instrumentation/opencensus-service/cmd/ocagent
 Alternatively you can build ocagent from binary (from the root of your repo):
 
 ```shell
-$ export GO111MODULE=on && make agent
+$ make agent
 ```
 
 ### <a name="agent-configuration-file"></a>Configuration file
@@ -303,7 +303,7 @@ $ go run github.com/census-instrumentation/opencensus-service/cmd/occollector
 ```
 2. Run from binary (from the root of your repo):
 ```shell
-$ export GO111MODULE=on && make collector
+$ make collector
 $ ./bin/occollector_$($GOOS)
 ```
 3. Build a Docker scratch image and use the appropriate Docker command for your scenario:


### PR DESCRIPTION
Updates https://github.com/census-instrumentation/opencensus-service/issues/218.

Set env var `GO111MODULE` to on before make agent/collector. Otherwise users will get errors like https://github.com/census-instrumentation/opencensus-service/issues/218.

Also reported offline by @rghetia. 