### PR TITLE
Receive jaeger-agent tchannel on port 14267

### DIFF
--- a/receiver/jaeger/trace_receiver.go
+++ b/receiver/jaeger/trace_receiver.go
@@ -94,11 +94,14 @@ func (jr *jReceiver) StartTraceReception(ctx context.Context, spanSink receiver.
 
 	var err = errAlreadyStarted
 	jr.startOnce.Do(func() {
-		tch, terr := tchannel.NewChannel("recv", new(tchannel.ChannelOptions))
+		tch, terr := tchannel.NewChannel("jaeger-collector", new(tchannel.ChannelOptions))
 		if terr != nil {
 			err = fmt.Errorf("Failed to create NewTChannel: %v", terr)
 			return
 		}
+
+		server := thrift.NewServer(tch)
+		server.Register(jaeger.NewTChanCollectorServer(jr))
 
 		taddr := jr.tchannelAddr()
 		tln, terr := net.Listen("tcp", taddr)


### PR DESCRIPTION
Enable the TChannel receiver for Jaeger.

@odeke-em per our earlier conversation I don't have bandwidth rightnow to write a test for it. I also see that is going to conflict with the PR that you have open, either one can go first since the fix is simple. It will be good if we get this in before we cut another version.

Fixes #245