### PR TITLE
Enable queue processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,14 +327,33 @@ Usage:
   occollector [flags]
 
 Flags:
-      --add-queued-processor   Flag to wrap one processor with the queued processor (flag will be remove soon, dev helper)
-      --config string          Path to the config file
-  -h, --help                   help for occollector
-      --log-level string       Output level of logs (TRACE, DEBUG, INFO, WARN, ERROR, FATAL) (default "INFO")
-      --noop-processor         Flag to add the no-op processor (combine with log level DEBUG to log incoming spans)
-      --receive-jaeger         Flag to run the Jaeger receiver (i.e.: Jaeger Collector), default settings: {ThriftTChannelPort:14267 ThriftHTTPPort:14268}
-      --receive-oc-trace       Flag to run the OpenCensus trace receiver, default settings: {Port:55678}
-      --receive-zipkin         Flag to run the Zipkin receiver, default settings: {Port:9411}
+      --config string      Path to the config file
+      --debug-processor    Flag to add a debug processor (combine with log level DEBUG to log incoming spans)
+  -h, --help               help for occollector
+      --log-level string   Output level of logs (TRACE, DEBUG, INFO, WARN, ERROR, FATAL) (default "INFO")
+      --receive-jaeger     Flag to run the Jaeger receiver (i.e.: Jaeger Collector), default settings: {ThriftTChannelPort:14267 ThriftHTTPPort:14268}
+      --receive-oc-trace   Flag to run the OpenCensus trace receiver, default settings: {Port:55678}
+      --receive-zipkin     Flag to run the Zipkin receiver, default settings: {Port:9411}
+```
+
+5. Sample configuration file:
+```yaml
+log-level: DEBUG
+
+receivers:
+  opencensus: {} # Runs OpenCensus receiver with default configuration
+
+processors:
+  docker-composer-test: # A friendly name for the processor
+    num-workers: 2
+    queue-size: 100
+    retry-on-failure: true
+    backoff-delay: 3s
+    sender-type: thrift-http
+    thrift-http:
+      collector-endpoint: "http://svc-jaeger-collector:4268/api/traces"
+      headers: { "x-omnition-api-key": "00000000-0000-0000-0000-000000000001" }
+      timeout: 5s
 ```
 
 [travis-image]: https://travis-ci.org/census-instrumentation/opencensus-service.svg?branch=master

--- a/README.md
+++ b/README.md
@@ -344,14 +344,14 @@ receivers:
   opencensus: {} # Runs OpenCensus receiver with default configuration
 
 processors:
-  docker-composer-test: # A friendly name for the processor
+  jaeger-sender-test: # A friendly name for the processor
     num-workers: 2
     queue-size: 100
     retry-on-failure: true
     backoff-delay: 3s
     sender-type: thrift-http
     thrift-http:
-      collector-endpoint: "http://svc-jaeger-collector:4268/api/traces"
+      collector-endpoint: "http://svc-jaeger-collector:14268/api/traces"
       headers: { "x-omnition-api-key": "00000000-0000-0000-0000-000000000001" }
       timeout: 5s
 ```

--- a/cmd/occollector/Dockerfile
+++ b/cmd/occollector/Dockerfile
@@ -1,4 +1,8 @@
+FROM alpine:latest as certs
+RUN apk --update add ca-certificates
+
 FROM scratch
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY occollector_linux /
 ENTRYPOINT ["/occollector_linux"]
 EXPOSE 55678

--- a/cmd/occollector/app/builder/builder.go
+++ b/cmd/occollector/app/builder/builder.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package builder handles the options to build the OpenCensus collector
-// pipeline.
 package builder
 
 import (

--- a/cmd/occollector/app/builder/doc.go
+++ b/cmd/occollector/app/builder/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package builder handles the options to build the OpenCensus collector
+// pipeline.
+package builder

--- a/cmd/occollector/app/builder/processor_builder.go
+++ b/cmd/occollector/app/builder/processor_builder.go
@@ -1,0 +1,146 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+// SenderType indicates the type of sender
+type SenderType string
+
+const (
+	// ThriftTChannelSenderType represents a thrift-format tchannel-transport sender
+	ThriftTChannelSenderType SenderType = "thrift-tchannel"
+	// ThriftHTTPSenderType represents a thrift-format http-transport sender
+	ThriftHTTPSenderType = "thrift-http"
+	// InvalidSenderType represents an invalid sender
+	InvalidSenderType = "invalid"
+)
+
+// JaegerThriftTChannelSenderCfg holds configuration for Jaeger Thrift Tchannel sender
+type JaegerThriftTChannelSenderCfg struct {
+	CollectorHostPorts        []string      `mapstructure:"collector-host-ports"`
+	DiscoveryMinPeers         int           `mapstructure:"discovery-min-peers"`
+	DiscoveryConnCheckTimeout time.Duration `mapstructure:"discovery-conn-check-timeout"`
+}
+
+// NewJaegerThriftTChannelSenderCfg returns an instance of JaegerThriftTChannelSenderCfg with default values
+func NewJaegerThriftTChannelSenderCfg() *JaegerThriftTChannelSenderCfg {
+	opts := &JaegerThriftTChannelSenderCfg{
+		DiscoveryMinPeers:         3,
+		DiscoveryConnCheckTimeout: 250 * time.Millisecond,
+	}
+	return opts
+}
+
+// JaegerThriftHTTPSenderCfg holds configuration for Jaeger Thrift HTTP sender
+type JaegerThriftHTTPSenderCfg struct {
+	CollectorEndpoint string            `mapstructure:"collector-endpoint"`
+	Timeout           time.Duration     `mapstructure:"timeout"`
+	Headers           map[string]string `mapstructure:"headers"`
+}
+
+// NewJaegerThriftHTTPSenderCfg returns an instance of JaegerThriftHTTPSenderCfg with default values
+func NewJaegerThriftHTTPSenderCfg() *JaegerThriftHTTPSenderCfg {
+	opts := &JaegerThriftHTTPSenderCfg{
+		Timeout: 5 * time.Second,
+	}
+	return opts
+}
+
+// QueuedSpanProcessorCfg holds configuration for the queued span processor
+type QueuedSpanProcessorCfg struct {
+	// Name is the friendly name of the processor
+	Name string
+	// NumWorkers is the number of queue workers that dequeue batches and send them out
+	NumWorkers int `mapstructure:"num-workers"`
+	// QueueSize is the maximum number of batches allowed in queue at a given time
+	QueueSize int `mapstructure:"queue-size"`
+	// Retry indicates whether queue processor should retry span batches in case of processing failure
+	RetryOnFailure bool `mapstructure:"retry-on-failure"`
+	// BackoffDelay is the amount of time a worker waits after a failed send before retrying
+	BackoffDelay time.Duration `mapstructure:"backoff-delay"`
+	// SenderType indicates the type of sender to instantiate
+	SenderType   SenderType `mapstructure:"sender-type"`
+	SenderConfig interface{}
+}
+
+// NewDefaultQueuedSpanProcessorCfg returns an instance of QueuedSpanProcessorCfg with default values
+func NewDefaultQueuedSpanProcessorCfg() *QueuedSpanProcessorCfg {
+	opts := &QueuedSpanProcessorCfg{
+		Name:           "default-queued-jaeger-sender",
+		NumWorkers:     10,
+		QueueSize:      5000,
+		RetryOnFailure: true,
+		SenderType:     InvalidSenderType,
+		BackoffDelay:   5 * time.Second,
+	}
+	return opts
+}
+
+// InitFromViper initializes QueuedSpanProcessorCfg with properties from viper
+func (qOpts *QueuedSpanProcessorCfg) InitFromViper(v *viper.Viper) *QueuedSpanProcessorCfg {
+	v.Unmarshal(qOpts)
+
+	switch qOpts.SenderType {
+	case ThriftTChannelSenderType:
+		ttsopts := NewJaegerThriftTChannelSenderCfg()
+		vttsopts := v.Sub(string(ThriftTChannelSenderType))
+		if vttsopts != nil {
+			vttsopts.Unmarshal(ttsopts)
+		}
+		qOpts.SenderConfig = ttsopts
+	case ThriftHTTPSenderType:
+		thsOpts := NewJaegerThriftHTTPSenderCfg()
+		vthsOpts := v.Sub(string(ThriftHTTPSenderType))
+		if vthsOpts != nil {
+			vthsOpts.Unmarshal(thsOpts)
+		}
+		qOpts.SenderConfig = thsOpts
+	}
+	return qOpts
+}
+
+// MultiSpanProcessorCfg holds configuration for all the span processors
+type MultiSpanProcessorCfg struct {
+	Processors []*QueuedSpanProcessorCfg
+}
+
+// NewDefaultMultiSpanProcessorCfg returns an instance of MultiSpanProcessorCfg with default values
+func NewDefaultMultiSpanProcessorCfg() *MultiSpanProcessorCfg {
+	opts := &MultiSpanProcessorCfg{
+		Processors: make([]*QueuedSpanProcessorCfg, 0),
+	}
+	return opts
+}
+
+// InitFromViper initializes MultiSpanProcessorCfg with properties from viper
+func (mOpts *MultiSpanProcessorCfg) InitFromViper(v *viper.Viper) *MultiSpanProcessorCfg {
+	procsv := v.Sub("processors")
+	if procsv == nil {
+		return mOpts
+	}
+	for procName := range v.GetStringMap("processors") {
+		procv := procsv.Sub(procName)
+		procOpts := NewDefaultQueuedSpanProcessorCfg()
+		procOpts.Name = procName
+		procOpts.InitFromViper(procv)
+		mOpts.Processors = append(mOpts.Processors, procOpts)
+	}
+	return mOpts
+}

--- a/cmd/occollector/app/builder/testdata/processor_config.yaml
+++ b/cmd/occollector/app/builder/testdata/processor_config.yaml
@@ -1,0 +1,19 @@
+processors:
+  proc-tchannel:
+    num-workers: 13
+    queue-size: 1300
+    sender-type: thrift-tchannel
+    thrift-tchannel:
+      collector-host-ports: [ ":123", ":321" ]
+      discovery-min-peers: 7
+      discovery-conn-check-timeout: 7s
+
+  proc-http:
+    retry-on-failure: false
+    backoff-delay: 3s
+    sender-type: thrift-http
+    thrift-http:
+      collector-endpoint: https://somedomain.com/api/traces
+      headers: { "x-header-key":"00000000-0000-0000-0000-000000000001" }
+      timeout: 5s
+

--- a/cmd/occollector/app/sender/doc.go
+++ b/cmd/occollector/app/sender/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sender contains specialized senders to different backends. Unlike
+// exporters they do not buffer or attempt to resend that failed batches, all
+// of that is delegated to the users of the senders.
+package sender

--- a/cmd/occollector/app/sender/jaeger_thrift_http_sender.go
+++ b/cmd/occollector/app/sender/jaeger_thrift_http_sender.go
@@ -1,0 +1,126 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sender
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"go.uber.org/zap"
+
+	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
+	"github.com/census-instrumentation/opencensus-service/translator/trace"
+)
+
+// Default timeout for http request in seconds
+const defaultHTTPTimeout = time.Second * 5
+
+// JaegerThriftHTTPSender forwards spans encoded in the jaeger thrift
+// format to a http server
+type JaegerThriftHTTPSender struct {
+	url     string
+	headers map[string]string
+	client  *http.Client
+	logger  *zap.Logger
+}
+
+// HTTPOption sets a parameter for the HttpCollector
+type HTTPOption func(s *JaegerThriftHTTPSender)
+
+// HTTPTimeout sets maximum timeout for http request.
+func HTTPTimeout(duration time.Duration) HTTPOption {
+	return func(s *JaegerThriftHTTPSender) { s.client.Timeout = duration }
+}
+
+// HTTPRoundTripper configures the underlying Transport on the *http.Client
+// that is used
+func HTTPRoundTripper(transport http.RoundTripper) HTTPOption {
+	return func(s *JaegerThriftHTTPSender) {
+		s.client.Transport = transport
+	}
+}
+
+// NewJaegerThriftHTTPSender returns a new HTTP-backend span sender. url should be an http
+// url of the collector to handle POST request, typically something like:
+//     http://hostname:14268/api/traces?format=jaeger.thrift
+func NewJaegerThriftHTTPSender(
+	url string,
+	headers map[string]string,
+	zlogger *zap.Logger,
+	options ...HTTPOption,
+) *JaegerThriftHTTPSender {
+	s := &JaegerThriftHTTPSender{
+		url:     url,
+		headers: headers,
+		client:  &http.Client{Timeout: defaultHTTPTimeout},
+		logger:  zlogger,
+	}
+
+	for _, option := range options {
+		option(s)
+	}
+	return s
+}
+
+// ProcessSpans sends the received data to the configured Jaeger Thrift end-point.
+func (s *JaegerThriftHTTPSender) ProcessSpans(batch *agenttracepb.ExportTraceServiceRequest, spanFormat string) (uint64, error) {
+	// TODO: (@pjanotti) In case of failure the translation to Jaeger Thrift is going to be remade, cache it somehow.
+	if batch == nil {
+		return 0, fmt.Errorf("Jaeger sender received nil batch")
+	}
+
+	tBatch, err := tracetranslator.OCProtoToJaegerThrift(batch)
+	if err != nil {
+		return uint64(len(batch.Spans)), err
+	}
+
+	mSpans := tBatch.Spans
+	body, err := serializeThrift(tBatch)
+	if err != nil {
+		return uint64(len(mSpans)), err
+	}
+	req, err := http.NewRequest("POST", s.url, body)
+	if err != nil {
+		return uint64(len(mSpans)), err
+	}
+	req.Header.Set("Content-Type", "application/x-thrift")
+	for k, v := range s.headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return uint64(len(mSpans)), err
+	}
+	io.Copy(ioutil.Discard, resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		return uint64(len(mSpans)), fmt.Errorf("Jaeger Thirft HTTP sender error: %d", resp.StatusCode)
+	}
+	return 0, nil
+}
+
+func serializeThrift(obj thrift.TStruct) (*bytes.Buffer, error) {
+	t := thrift.NewTMemoryBuffer()
+	p := thrift.NewTBinaryProtocolTransport(t)
+	if err := obj.Write(p); err != nil {
+		return nil, err
+	}
+	return t.Buffer, nil
+}

--- a/cmd/occollector/app/sender/jaeger_thrift_tchannel_sender.go
+++ b/cmd/occollector/app/sender/jaeger_thrift_tchannel_sender.go
@@ -1,0 +1,60 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sender
+
+import (
+	"go.uber.org/zap"
+
+	reporter "github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
+
+	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
+	"github.com/census-instrumentation/opencensus-service/internal/collector/processor"
+	"github.com/census-instrumentation/opencensus-service/translator/trace"
+)
+
+// JaegerThriftTChannelSender takes span batches and sends them
+// out on tchannel in thrift encoding
+type JaegerThriftTChannelSender struct {
+	logger   *zap.Logger
+	reporter reporter.Reporter
+}
+
+var _ processor.SpanProcessor = (*JaegerThriftHTTPSender)(nil)
+
+// NewJaegerThriftTChannelSender creates new TChannel-based sender.
+func NewJaegerThriftTChannelSender(
+	reporter reporter.Reporter,
+	zlogger *zap.Logger,
+) *JaegerThriftTChannelSender {
+	return &JaegerThriftTChannelSender{
+		logger:   zlogger,
+		reporter: reporter,
+	}
+}
+
+// ProcessSpans sends the received data to the configured Jaeger Thrift end-point.
+func (s *JaegerThriftTChannelSender) ProcessSpans(batch *agenttracepb.ExportTraceServiceRequest, spanFormat string) (uint64, error) {
+	// TODO: (@pjanotti) In case of failure the translation to Jaeger Thrift is going to be remade, cache it somehow.
+	tBatch, err := tracetranslator.OCProtoToJaegerThrift(batch)
+	if err != nil {
+		return uint64(len(tBatch.Spans)), err
+	}
+
+	if err := s.reporter.EmitBatch(tBatch); err != nil {
+		s.logger.Error("Reporter failed to report span batch", zap.Error(err))
+		return uint64(len(tBatch.Spans)), err
+	}
+	return 0, nil
+}

--- a/internal/collector/processor/queued_processor.go
+++ b/internal/collector/processor/queued_processor.go
@@ -105,7 +105,7 @@ func (sp *queuedSpanProcessor) processItemFromQueue(item *queueItem) {
 	_, err := sp.sender.ProcessSpans(item.batch, item.spanFormat)
 	if err != nil {
 		batchSize := len(item.batch.Spans)
-		sp.logger.Warn("Sender failed", zap.Error(err), zap.String("spanFormat", item.spanFormat)) // TODO: this can become to noise in general failure scenarios
+		sp.logger.Warn("Sender failed", zap.Error(err), zap.String("spanFormat", item.spanFormat))
 		if !sp.retryOnProcessingFailure {
 			// throw away the batch
 			sp.logger.Error("Failed to process batch, discarding", zap.Int("batch-size", batchSize))

--- a/internal/collector/processor/queued_processor.go
+++ b/internal/collector/processor/queued_processor.go
@@ -102,11 +102,10 @@ func (sp *queuedSpanProcessor) enqueueSpanBatch(batch *agenttracepb.ExportTraceS
 }
 
 func (sp *queuedSpanProcessor) processItemFromQueue(item *queueItem) {
-	// TODO: @(pjanotti) metrics: startTime := time.Now()
-	// TODO:
 	_, err := sp.sender.ProcessSpans(item.batch, item.spanFormat)
 	if err != nil {
 		batchSize := len(item.batch.Spans)
+		sp.logger.Warn("Sender failed", zap.Error(err), zap.String("spanFormat", item.spanFormat)) // TODO: this can become to noise in general failure scenarios
 		if !sp.retryOnProcessingFailure {
 			// throw away the batch
 			sp.logger.Error("Failed to process batch, discarding", zap.Int("batch-size", batchSize))

--- a/receiver/jaeger/trace_receiver.go
+++ b/receiver/jaeger/trace_receiver.go
@@ -94,11 +94,14 @@ func (jr *jReceiver) StartTraceReception(ctx context.Context, spanSink receiver.
 
 	var err = errAlreadyStarted
 	jr.startOnce.Do(func() {
-		tch, terr := tchannel.NewChannel("recv", new(tchannel.ChannelOptions))
+		tch, terr := tchannel.NewChannel("jaeger-collector", new(tchannel.ChannelOptions))
 		if terr != nil {
 			err = fmt.Errorf("Failed to create NewTChannel: %v", terr)
 			return
 		}
+
+		server := thrift.NewServer(tch)
+		server.Register(jaeger.NewTChanCollectorServer(jr))
 
 		taddr := jr.tchannelAddr()
 		tln, terr := net.Listen("tcp", taddr)

--- a/receiver/jaeger/trace_receiver.go
+++ b/receiver/jaeger/trace_receiver.go
@@ -94,14 +94,11 @@ func (jr *jReceiver) StartTraceReception(ctx context.Context, spanSink receiver.
 
 	var err = errAlreadyStarted
 	jr.startOnce.Do(func() {
-		tch, terr := tchannel.NewChannel("jaeger-collector", new(tchannel.ChannelOptions))
+		tch, terr := tchannel.NewChannel("recv", new(tchannel.ChannelOptions))
 		if terr != nil {
 			err = fmt.Errorf("Failed to create NewTChannel: %v", terr)
 			return
 		}
-
-		server := thrift.NewServer(tch)
-		server.Register(jaeger.NewTChanCollectorServer(jr))
 
 		taddr := jr.tchannelAddr()
 		tln, terr := net.Listen("tcp", taddr)


### PR DESCRIPTION
(This is the final part for that old PR that was sliced).

Uses the processor queue to send data to Jaeger Collectors.
This allows deeper retry queues than what can be done directly with
the Jaeger exporter and also allows better handling of service information
for Jaeger backends.

Added ca certificates to collector docker scratch to support https.
