### PR TITLE
Add dynamic support for VERSION and default to latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ GOOS=$(shell go env GOOS)
 GIT_SHA=$(shell git rev-parse --short HEAD)
 BUILD_INFO_IMPORT_PATH=github.com/census-instrumentation/opencensus-service/internal/version
 BUILD_INFO=-ldflags "-X $(BUILD_INFO_IMPORT_PATH).GitHash=$(GIT_SHA)"
+ifdef VERSION
+BUILD_INFO+=" -X $(BUILD_INFO_IMPORT_PATH).version=$(VERSION)"
+endif
 
 .DEFAULT_GOAL := default_goal
 

--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -37,7 +37,7 @@ fi
 VERSION="$2"
 if [[ "$VERSION" == "" ]]
 then
-    VERSION="undefined"
+    VERSION="latest"
 fi
 
 function build() {

--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -30,13 +30,20 @@
 
 if [[ $# -lt 1 ]]
 then
-    echo -e "Usage: $0 <cmd>\nwhere <cmd> is any of 'docker' 'binaries' or GOOS such as:\ndarwin\nlinux\nwindows"
+    echo -e "Usage: $0 <cmd> <version>\nwhere <cmd> is any of 'docker' 'binaries' or GOOS such as:\ndarwin\nlinux\nwindows"
     exit
+fi
+
+VERSION="$2"
+if [[ "$VERSION" == "" ]]
+then
+    VERSION="undefined"
 fi
 
 function build() {
     GOOS="$1"
-    LDFLAGS="\"-X github.com/census-instrumentation/opencensus-service/internal/version.GitHash=`git rev-parse --short HEAD`\""
+    LDFLAGS="\"-X github.com/census-instrumentation/opencensus-service/internal/version.GitHash=`git rev-parse --short HEAD` \
+        -X github.com/census-instrumentation/opencensus-service/internal/version.version=$VERSION\""
     CMD="GOOS=$GOOS go build -ldflags $LDFLAGS -o bin/ocagent_$GOOS ./cmd/ocagent"
     echo $CMD
     eval $CMD
@@ -50,12 +57,6 @@ function buildAll() {
 
 function dockerBuild() {
     build linux
-    VERSION="$1"
-    if [[ "$VERSION" == "" ]]
-    then
-        VERSION="v0.0.1"
-    fi
-
     CMD="docker build -t ocagent:$VERSION ."
     echo $CMD
     eval $CMD

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,7 +21,7 @@ import (
 )
 
 // version variable will be replaced at link time after `make` has been run.
-var version = "undefined"
+var version = "latest"
 
 // GitHash variable will be replaced at link time after `make` has been run.
 var GitHash = "<NOT PROPERLY GENERATED>"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -20,8 +20,8 @@ import (
 	"runtime"
 )
 
-// Please increment this value per release.
-const version = "0.0.1"
+// version variable will be replaced at link time after `make` has been run.
+var version = "undefined"
 
 // GitHash variable will be replaced at link time after `make` has been run.
 var GitHash = "<NOT PROPERLY GENERATED>"


### PR DESCRIPTION
As we complete milestones we plan to cut versions. Today, this requires
editing two separate files and committing them. Instead, default to a
version of "latest" and allow the version to be passed as part of
build_binaries or make.

Thought process here is that if a user builds from source they will have latest and the githash is included as well. Today, a hard-coded version is included, which can be confusing as changes may have been made since the release. Long term, we should consider having dedicated branches for stable releases (and could hard-code the version into these branches if desired). In addition, we should discourage building from source if possible and provide binaries as well as Docker images.