### PR TITLE
Change Jaeger exporter from collector-endpoint to endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ exporters:
     endpoint: "http://localhost:10001"
 
   jaeger:
-    collector_endpoint: "http://localhost:14268/api/traces"
+    endpoint: "http://localhost:14268/api/traces"
 
   kafka:
     brokers: ["localhost:9092"]

--- a/cmd/occollector/app/builder/builder_test.go
+++ b/cmd/occollector/app/builder/builder_test.go
@@ -92,9 +92,9 @@ func TestMultiAndQueuedSpanProcessorConfig(t *testing.T) {
 	snd.BackoffDelay = 3 * time.Second
 	snd.SenderType = ThriftHTTPSenderType
 	snd.SenderConfig = &JaegerThriftHTTPSenderCfg{
-		CollectorEndpoint: "https://somedomain.com/api/traces",
-		Headers:           map[string]string{"x-header-key": "00000000-0000-0000-0000-000000000001"},
-		Timeout:           time.Second * 5,
+		Endpoint: "https://somedomain.com/api/traces",
+		Headers:  map[string]string{"x-header-key": "00000000-0000-0000-0000-000000000001"},
+		Timeout:  time.Second * 5,
 	}
 
 	wCfg := &MultiSpanProcessorCfg{

--- a/cmd/occollector/app/builder/processor_builder.go
+++ b/cmd/occollector/app/builder/processor_builder.go
@@ -50,9 +50,9 @@ func NewJaegerThriftTChannelSenderCfg() *JaegerThriftTChannelSenderCfg {
 
 // JaegerThriftHTTPSenderCfg holds configuration for Jaeger Thrift HTTP sender
 type JaegerThriftHTTPSenderCfg struct {
-	CollectorEndpoint string            `mapstructure:"collector-endpoint"`
-	Timeout           time.Duration     `mapstructure:"timeout"`
-	Headers           map[string]string `mapstructure:"headers"`
+	Endpoint string            `mapstructure:"endpoint"`
+	Timeout  time.Duration     `mapstructure:"timeout"`
+	Headers  map[string]string `mapstructure:"headers"`
 }
 
 // NewJaegerThriftHTTPSenderCfg returns an instance of JaegerThriftHTTPSenderCfg with default values

--- a/cmd/occollector/app/builder/testdata/processor_config.yaml
+++ b/cmd/occollector/app/builder/testdata/processor_config.yaml
@@ -13,7 +13,7 @@ processors:
     backoff-delay: 3s
     sender-type: thrift-http
     thrift-http:
-      collector-endpoint: https://somedomain.com/api/traces
+      endpoint: https://somedomain.com/api/traces
       headers: { "x-header-key":"00000000-0000-0000-0000-000000000001" }
       timeout: 5s
 

--- a/cmd/occollector/app/collector/collector.go
+++ b/cmd/occollector/app/collector/collector.go
@@ -255,9 +255,9 @@ func buildQueuedSpanProcessor(logger *zap.Logger, opts *builder.QueuedSpanProces
 	case builder.ThriftHTTPSenderType:
 		thriftHTTPSenderOpts := opts.SenderConfig.(*builder.JaegerThriftHTTPSenderCfg)
 		logger.Info("Initializing thrift-HTTP sender",
-			zap.String("url", thriftHTTPSenderOpts.CollectorEndpoint))
+			zap.String("url", thriftHTTPSenderOpts.Endpoint))
 		spanSender = sender.NewJaegerThriftHTTPSender(
-			thriftHTTPSenderOpts.CollectorEndpoint,
+			thriftHTTPSenderOpts.Endpoint,
 			thriftHTTPSenderOpts.Headers,
 			logger,
 			sender.HTTPTimeout(thriftHTTPSenderOpts.Timeout),

--- a/exporter/exporterparser/README.md
+++ b/exporter/exporterparser/README.md
@@ -19,11 +19,11 @@ processors:
     # sender-type is the type of sender used by this processor, the default is an invalid sender so it forces one to be specified
     sender-type: thrift-http
     # configuration of the selected sender-type, in this example Jaeger thrift-http. Which supports 3 settings:
-    # collector-endpoint: address of Jaeger collector thrift-http endpoint
+    # endpoint: address of Jaeger collector thrift-http endpoint
     # headers: a map of any additional headers to be sent with each batch (e.g.: api keys, etc)
     # timeout: the timeout for the sender to consider the operation as failed
     thrift-http:
-      collector-endpoint: "https://ingest.omnition.io"
+      endpoint: "https://ingest.omnition.io"
       headers: { "x-omnition-api-key": "00000000-0000-0000-0000-000000000001" }
       timeout: 5s
   jaeger: # A second processor with its own configuration options
@@ -33,6 +33,6 @@ processors:
     backoff-delay: 3s
     sender-type: thrift-http
     thrift-http:
-      collector-endpoint: "http://jaeger.local:14268/api/traces"
+      endpoint: "http://jaeger.local:14268/api/traces"
       timeout: 5s
 ```

--- a/exporter/exporterparser/jaeger.go
+++ b/exporter/exporterparser/jaeger.go
@@ -24,10 +24,10 @@ import (
 
 // Slight modified version of go/src/go.opencensus.io/exporter/jaeger/jaeger.go
 type jaegerConfig struct {
-	CollectorEndpoint string `yaml:"collector_endpoint,omitempty"`
-	Username          string `yaml:"username,omitempty"`
-	Password          string `yaml:"password,omitempty"`
-	ServiceName       string `yaml:"service_name,omitempty"`
+	Endpoint    string `yaml:"endpoint,omitempty"`
+	Username    string `yaml:"username,omitempty"`
+	Password    string `yaml:"password,omitempty"`
+	ServiceName string `yaml:"service_name,omitempty"`
 }
 
 type jaegerExporter struct {
@@ -55,9 +55,9 @@ func JaegerExportersFromYAML(config []byte) (tes []exporter.TraceExporter, doneF
 
 	// jaeger.NewExporter performs configurqtion validation
 	je, err := jaeger.NewExporter(jaeger.Options{
-		CollectorEndpoint: jc.CollectorEndpoint,
-		Username:          jc.Username,
-		Password:          jc.Password,
+		Endpoint: jc.Endpoint,
+		Username: jc.Username,
+		Password: jc.Password,
 		Process: jaeger.Process{
 			ServiceName: jc.ServiceName,
 		},

--- a/receiver/jaeger/trace_receiver_test.go
+++ b/receiver/jaeger/trace_receiver_test.go
@@ -69,7 +69,7 @@ func TestReception(t *testing.T) {
 				jaeger.Int64Tag("int64", 1e7),
 			},
 		},
-		CollectorEndpoint: fmt.Sprintf("http://localhost:%d/api/traces", collectorHTTPPort),
+		Endpoint: fmt.Sprintf("http://localhost:%d/api/traces", collectorHTTPPort),
 	})
 	if err != nil {
 		t.Fatalf("Failed to create the Jaeger OpenCensus exporter for the live application: %v", err)


### PR DESCRIPTION
All other exporters are using endpoint as the configuration parameter.
To standardize, update Jaeger to follow the same pattern.