### PR TITLE
Remove broken checksums now caught by go 1.11.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go_import_path: github.com/census-instrumentation/opencensus-service
 
 go:
-  - 1.11.2
+  - 1.11.x
  
 env:
   global:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ $ git push fork feature
 
 ## General Notes
 
-This project uses go 1.11 and Travis for CI.
+This project uses Go 1.11.4 and Travis for CI.
 
 Travis CI uses the Makefile with the default target, it is recommended to
 run it before submitting your PR. It runs `gofmt -s` (simplify) and `golint`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-FROM golang:1.11-alpine3.7 as builder
+FROM golang:1.11.4-alpine3.7 as builder
 
 RUN apk update && apk upgrade && \
-    apk add --no-cache bash git openssh
+    apk add --no-cache bash git openssh gcc libc-dev
 
 ENV GOPKG github.com/census-instrumentation/opencensus-service
-
 COPY . /go/src/$GOPKG/
 
-RUN go get $GOPKG/...
 RUN cd /go/src/$GOPKG/ && ./build_binaries.sh linux && cp /go/src/$GOPKG/bin/ocagent_linux /ocagent
 
 FROM alpine:3.7

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Architecture amd64
 
 The ocagent can be run directly from sources, binary, or a Docker image.
 
-The minimum Go version required for this project is Go1.11.
+The minimum Go version required for this project is Go 1.11.4.
 
 1. Run from sources:
 
@@ -293,7 +293,7 @@ agent/client health information/inventory metadata to downstream exporters.
 
 The collector can be run directly from sources, binary, or a Docker image.
 
-The minimum Go version required for this project is Go1.11.
+The minimum Go version required for this project is Go 1.11.4.
 
 1. Run from sources:
 ```shell

--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -44,7 +44,7 @@ function build() {
     GOOS="$1"
     LDFLAGS="\"-X github.com/census-instrumentation/opencensus-service/internal/version.GitHash=`git rev-parse --short HEAD` \
         -X github.com/census-instrumentation/opencensus-service/internal/version.version=$VERSION\""
-    CMD="GOOS=$GOOS go build -ldflags $LDFLAGS -o bin/ocagent_$GOOS ./cmd/ocagent"
+    CMD="GO111MODULE=on GOOS=$GOOS go build -ldflags $LDFLAGS -o bin/ocagent_$GOOS ./cmd/ocagent"
     echo $CMD
     eval $CMD
 }
@@ -56,7 +56,6 @@ function buildAll() {
 }
 
 function dockerBuild() {
-    build linux
     CMD="docker build -t ocagent:$VERSION ."
     echo $CMD
     eval $CMD

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,6 @@ contrib.go.opencensus.io/exporter/stackdriver v0.7.0 h1:pmo1ol3uPcrLmvOET8bEbu5s
 contrib.go.opencensus.io/exporter/stackdriver v0.7.0/go.mod h1:hNe5qQofPbg6bLQY5wHCvQ7o+2E5P8PkegEuQ+MyRw0=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999 h1:sihTnRgTOUSCQz0iS0pjZuFQy/z7GXCJgSBg3+rZKHw=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-git.apache.org/thrift.git v0.0.0-20181101003639-92be4f312b88 h1:km2LQYVCbsEbT7HCJ/nrMopI5CvJUkniCcSf9ZP5+iQ=
 git.apache.org/thrift.git v0.0.0-20181101003639-92be4f312b88/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -24,8 +23,6 @@ github.com/Shopify/toxiproxy v2.1.3+incompatible h1:awiJqUYH4q4OmoBiRccJykjd7B+w
 github.com/Shopify/toxiproxy v2.1.3+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
-github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 h1:CZI8h5fmYwCCvd2RMSsjLqHN6OqABlWJweFKxz4vdEs=
-github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 h1:CZI8h5fmYwCCvd2RMSsjLqHN6OqABlWJweFKxz4vdEs=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/aws/aws-sdk-go v1.15.31/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=


### PR DESCRIPTION
I was in contact with someone trying to build the repo and his golang was a new install (via brew). So he hit the same issue as Travis w/ go 1.11.4 (see https://github.com/census-instrumentation/opencensus-service/pull/272): invalid checksum. 

The problem for us is that the recommendation for this issue is to remove the old checksum, this fixes the build for go 1.11.4. However, any previous go version is going to re-introduce the incorrect checksums (I tested only with go 1.11.1). So if we merge this change and don't upgrade go to 1.11.4 on our boxes we are going to keep getting a modified go.sum (re-introducing the wrong checksums), which is fine as long as people are aware of the issue and don't commit the go.sum - in other words if this PR is merged any changes to go.mod/go.sum need to be done using go 1.11.4 and above.

See https://github.com/golang/go/issues/29278 for more info about the change in golang.

Creating as DO NOT MERGE so we can discuss and perhaps adopt some other alternative, however, notice that someone setting up a brand new go env is likely to hit the issue and be unable to build the repo. 

PS.: I remember in the past using brew to switch between go 1.10 and 1.11 but I am not sure if we can easily do the same for minor versions.

