### PR TITLE
Add basic telemetry to collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,13 +319,15 @@ Usage:
   occollector [flags]
 
 Flags:
-      --config string      Path to the config file
-      --debug-processor    Flag to add a debug processor (combine with log level DEBUG to log incoming spans)
-  -h, --help               Help for occollector
-      --log-level string   Output level of logs (TRACE, DEBUG, INFO, WARN, ERROR, FATAL) (default "INFO")
-      --receive-jaeger     Flag to run the Jaeger receiver (i.e.: Jaeger Collector), default settings: {ThriftTChannelPort:14267 ThriftHTTPPort:14268}
-      --receive-oc-trace   Flag to run the OpenCensus trace receiver, default settings: {Port:55678}
-      --receive-zipkin     Flag to run the Zipkin receiver, default settings: {Port:9411}
+      --config string          Path to the config file
+      --debug-processor        Flag to add a debug processor (combine with log level DEBUG to log incoming spans)
+  -h, --help                   Help for occollector
+      --log-level string       Output level of logs (TRACE, DEBUG, INFO, WARN, ERROR, FATAL) (default "INFO")
+      --metrics-level string   Output level of telemetry metrics (NONE, BASIC, NORMAL, DETAILED) (default "BASIC")
+      --metrics-port uint16    Port exposing collector telemetry. (default 8888)
+      --receive-jaeger         Flag to run the Jaeger receiver (i.e.: Jaeger Collector), default settings: {ThriftTChannelPort:14267 ThriftHTTPPort:14268}
+      --receive-oc-trace       Flag to run the OpenCensus trace receiver, default settings: {Port:55678}
+      --receive-zipkin         Flag to run the Zipkin receiver, default settings: {Port:9411}
 ```
 
 Sample configuration file:

--- a/cmd/occollector/app/collector/collector.go
+++ b/cmd/occollector/app/collector/collector.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -28,6 +30,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics"
+	"go.opencensus.io/exporter/prometheus"
+	"go.opencensus.io/stats/view"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -38,12 +42,15 @@ import (
 	"github.com/census-instrumentation/opencensus-service/internal/collector/jaeger"
 	"github.com/census-instrumentation/opencensus-service/internal/collector/opencensus"
 	"github.com/census-instrumentation/opencensus-service/internal/collector/processor"
+	"github.com/census-instrumentation/opencensus-service/internal/collector/telemetry"
 	"github.com/census-instrumentation/opencensus-service/internal/collector/zipkin"
 )
 
 const (
 	configCfg         = "config"
 	logLevelCfg       = "log-level"
+	metricsLevelCfg   = "metrics-level"
+	metricsPortCfg    = "metrics-port"
 	jaegerReceiverFlg = "receive-jaeger"
 	ocReceiverFlg     = "receive-oc-trace"
 	zipkinReceiverFlg = "receive-zipkin"
@@ -79,6 +86,13 @@ func init() {
 	rootCmd.PersistentFlags().String(logLevelCfg, "INFO", "Output level of logs (TRACE, DEBUG, INFO, WARN, ERROR, FATAL)")
 	v.BindPFlag(logLevelCfg, rootCmd.PersistentFlags().Lookup(logLevelCfg))
 
+	rootCmd.PersistentFlags().String(metricsLevelCfg, "BASIC", "Output level of telemetry metrics (NONE, BASIC, NORMAL, DETAILED)")
+	v.BindPFlag(metricsLevelCfg, rootCmd.PersistentFlags().Lookup(metricsLevelCfg))
+
+	// At least until we can use a generic, i.e.: OpenCensus, metrics exporter we default to Prometheus at port 8888, if not otherwise specified.
+	rootCmd.PersistentFlags().Uint16(metricsPortCfg, 8888, "Port exposing collector telemetry.")
+	v.BindPFlag(metricsPortCfg, rootCmd.PersistentFlags().Lookup(metricsPortCfg))
+
 	// local flags
 	rootCmd.Flags().StringVar(&config, configCfg, "", "Path to the config file")
 	rootCmd.Flags().Bool(jaegerReceiverFlg, false,
@@ -108,6 +122,7 @@ func newLogger() (*zap.Logger, error) {
 }
 
 func execute() {
+	var asyncErrorChannel = make(chan error)
 	var signalsChannel = make(chan os.Signal)
 	signal.Notify(signalsChannel, os.Interrupt, syscall.SIGTERM)
 
@@ -115,6 +130,11 @@ func execute() {
 	logger, err = newLogger()
 	if err != nil {
 		log.Fatalf("Failed to get logger: %v", err)
+	}
+
+	telemetryLevel, err := telemetry.ParseLevel(v.GetString(metricsLevelCfg))
+	if err != nil {
+		log.Fatalf("Failed to parse metrics level: %v", err)
 	}
 
 	logger.Info("Starting...")
@@ -161,9 +181,23 @@ func execute() {
 	receiversCloseFns := createReceivers(spanProcessor)
 	closeFns = append(closeFns, receiversCloseFns...)
 
-	logger.Info("Collector is up and running.")
+	view.Register(processor.MetricViews(telemetryLevel)...)
+	view.Register(processor.QueuedProcessorMetricViews(telemetryLevel)...)
 
-	<-signalsChannel
+	// All metric views should have been loaded at this point.
+	err = initTelemetry(telemetryLevel, v.GetInt(metricsPortCfg), asyncErrorChannel, logger)
+	if err != nil {
+		logger.Error("Failed to initialize telemetry", zap.Error(err))
+		os.Exit(1)
+	}
+
+	select {
+	case err = <-asyncErrorChannel:
+		logger.Error("Asynchronous error received, terminating process", zap.Error(err))
+	case <-signalsChannel:
+		logger.Info("Received kill signal from OS")
+	}
+
 	logger.Info("Starting shutdown...")
 
 	// TODO: orderly shutdown: first receivers, then flushing pipelines giving
@@ -174,6 +208,35 @@ func execute() {
 	}
 
 	logger.Info("Shutdown complete.")
+}
+
+func initTelemetry(level telemetry.Level, port int, asyncErrorChannel chan<- error, logger *zap.Logger) error {
+	if level == telemetry.None {
+		return nil
+	}
+
+	// Until we can use a generic metrics exporter, default to Prometheus.
+	opts := prometheus.Options{
+		Namespace: "oc_collector",
+	}
+	pe, err := prometheus.NewExporter(opts)
+	if err != nil {
+		return err
+	}
+
+	view.RegisterExporter(pe)
+
+	logger.Info("Serving Prometheus metrics", zap.Int("port", port))
+	go func() {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", pe)
+		serveErr := http.ListenAndServe(":"+strconv.Itoa(port), mux)
+		if serveErr != nil && serveErr != http.ErrServerClosed {
+			asyncErrorChannel <- serveErr
+		}
+	}()
+
+	return nil
 }
 
 func createExporters() (doneFns []func(), traceExporters []exporter.TraceExporter) {

--- a/internal/collector/processor/processor.go
+++ b/internal/collector/processor/processor.go
@@ -15,9 +15,15 @@
 package processor
 
 import (
-	"go.uber.org/zap"
+	"context"
 
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	"go.uber.org/zap"
+
+	"github.com/census-instrumentation/opencensus-service/internal/collector/telemetry"
 )
 
 // SpanProcessor handles batches of spans converted to OpenCensus proto format.
@@ -37,11 +43,109 @@ func (sp *debugSpanProcessor) ProcessSpans(batch *agenttracepb.ExportTraceServic
 		sp.logger.Warn("Received batch with nil Node", zap.String("format", spanFormat))
 	}
 
-	sp.logger.Debug("debugSpanProcessor", zap.String("originalFormat", spanFormat), zap.Int("#spans", len(batch.Spans)))
+	statsTags := statsTagsForBatch("debug", batch, spanFormat)
+	numSpans := len(batch.Spans)
+	stats.RecordWithTags(context.Background(), statsTags, statBatchCount.M(1), statSpanCount.M(int64(numSpans)))
+
+	sp.logger.Debug("debugSpanProcessor", zap.String("originalFormat", spanFormat), zap.Int("#spans", numSpans))
 	return 0, nil
 }
 
 // NewNoopSpanProcessor creates an OC SpanProcessor that just drops the received data.
 func NewNoopSpanProcessor(logger *zap.Logger) SpanProcessor {
 	return &debugSpanProcessor{logger: logger}
+}
+
+// Keys and stats for telemetry.
+var (
+	tagSourceFormatKey, _ = tag.NewKey("format")
+	tagServiceNameKey, _  = tag.NewKey("service")
+	tagExporterNameKey, _ = tag.NewKey("exporter")
+
+	statBatchCount        = stats.Int64("batches_received", "counts the number of batches received", stats.UnitDimensionless)
+	statDroppedBatchCount = stats.Int64("batches_dropped", "counts the number of batches dropped", stats.UnitDimensionless)
+
+	statSpanCount        = stats.Int64("spans_received", "counts the number of spans received", stats.UnitDimensionless)
+	statDroppedSpanCount = stats.Int64("spans_dropped", "counts the number of spans dropped", stats.UnitDimensionless)
+)
+
+// metricTagKeys returns the metric tag keys according to the given telemetry level.
+func metricTagKeys(level telemetry.Level) []tag.Key {
+	var tagKeys []tag.Key
+	switch level {
+	case telemetry.Detailed:
+		tagKeys = append(tagKeys, tagServiceNameKey)
+		fallthrough
+	case telemetry.Normal:
+		tagKeys = append(tagKeys, tagSourceFormatKey)
+		fallthrough
+	case telemetry.Basic:
+		tagKeys = append(tagKeys, tagExporterNameKey)
+		break
+	default:
+		return nil
+	}
+
+	return tagKeys
+}
+
+// MetricViews return the metrics views according to given telemetry level.
+func MetricViews(level telemetry.Level) []*view.View {
+	tagKeys := metricTagKeys(level)
+	if tagKeys == nil {
+		return nil
+	}
+
+	// There are some metrics enabled, return the views.
+	receivedBatchesView := &view.View{
+		Name:        statBatchCount.Name(),
+		Measure:     statBatchCount,
+		Description: "The number of span batches received.",
+		TagKeys:     tagKeys,
+		Aggregation: view.Count(),
+	}
+	droppedBatchesView := &view.View{
+		Name:        statDroppedBatchCount.Name(),
+		Measure:     statDroppedBatchCount,
+		Description: "The number of span batches dropped.",
+		TagKeys:     tagKeys,
+		Aggregation: view.Count(),
+	}
+	receivedSpansView := &view.View{
+		Name:        statSpanCount.Name(),
+		Measure:     statSpanCount,
+		Description: "The number of spans received.",
+		TagKeys:     tagKeys,
+		Aggregation: view.Sum(),
+	}
+	droppedSpansView := &view.View{
+		Name:        statDroppedSpanCount.Name(),
+		Measure:     statDroppedSpanCount,
+		Description: "The number of spans dropped.",
+		TagKeys:     tagKeys,
+		Aggregation: view.Sum(),
+	}
+
+	return []*view.View{receivedBatchesView, droppedBatchesView, receivedSpansView, droppedSpansView}
+}
+
+func statsTagsForBatch(processorName string, batch *agenttracepb.ExportTraceServiceRequest, spanFormat string) []tag.Mutator {
+	var serviceName string
+	if batch.Node == nil {
+		serviceName = "<nil-batch-node>"
+	} else if batch.Node.ServiceInfo == nil {
+		serviceName = "<nil-service-info>"
+	} else if batch.Node.ServiceInfo.Name == "" {
+		serviceName = "<empty-service-info-name>"
+	} else {
+		serviceName = batch.Node.ServiceInfo.Name
+	}
+
+	statsTags := []tag.Mutator{
+		tag.Upsert(tagSourceFormatKey, spanFormat),
+		tag.Upsert(tagServiceNameKey, serviceName),
+		tag.Upsert(tagExporterNameKey, processorName),
+	}
+
+	return statsTags
 }

--- a/internal/collector/processor/queued_processor.go
+++ b/internal/collector/processor/queued_processor.go
@@ -15,16 +15,22 @@
 package processor
 
 import (
+	"context"
 	"sync"
 	"time"
 
 	"github.com/jaegertracing/jaeger/pkg/queue"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 	"go.uber.org/zap"
 
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
+	"github.com/census-instrumentation/opencensus-service/internal/collector/telemetry"
 )
 
 type queuedSpanProcessor struct {
+	name                     string
 	queue                    *queue.BoundedQueue
 	logger                   *zap.Logger
 	sender                   SpanProcessor
@@ -54,6 +60,22 @@ func NewQueuedSpanProcessor(sender SpanProcessor, opts ...Option) SpanProcessor 
 		sp.processItemFromQueue(value)
 	})
 
+	// Start a timer to report the queue length.
+	ctx, _ := tag.New(context.Background(), tag.Upsert(tagExporterNameKey, sp.name))
+	ticker := time.NewTicker(1 * time.Second)
+	go func(ctx context.Context) {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-sp.stopCh:
+				return
+			case <-ticker.C:
+				length := int64(sp.queue.Size())
+				stats.Record(ctx, statQueueLength.M(length))
+			}
+		}
+	}(ctx)
+
 	return sp
 }
 
@@ -61,6 +83,7 @@ func newQueuedSpanProcessor(sender SpanProcessor, opts ...Option) *queuedSpanPro
 	options := Options.apply(opts...)
 	boundedQueue := queue.NewBoundedQueue(options.queueSize, func(item interface{}) {})
 	return &queuedSpanProcessor{
+		name:                     options.name,
 		queue:                    boundedQueue,
 		logger:                   options.logger,
 		numWorkers:               options.numWorkers,
@@ -94,50 +117,143 @@ func (sp *queuedSpanProcessor) enqueueSpanBatch(batch *agenttracepb.ExportTraceS
 		batch:      batch,
 		spanFormat: spanFormat,
 	}
+
+	statsTags := statsTagsForBatch(sp.name, batch, spanFormat)
+	numSpans := len(batch.Spans)
+	stats.RecordWithTags(context.Background(), statsTags, statBatchCount.M(1), statSpanCount.M(int64(numSpans)))
+
 	addedToQueue := sp.queue.Produce(item)
 	if !addedToQueue {
-		sp.onItemDropped(item)
+		sp.onItemDropped(item, statsTags)
 	}
 	return addedToQueue
 }
 
 func (sp *queuedSpanProcessor) processItemFromQueue(item *queueItem) {
+	startTime := time.Now()
 	_, err := sp.sender.ProcessSpans(item.batch, item.spanFormat)
-	if err != nil {
-		batchSize := len(item.batch.Spans)
-		sp.logger.Warn("Sender failed", zap.Error(err), zap.String("spanFormat", item.spanFormat))
-		if !sp.retryOnProcessingFailure {
-			// throw away the batch
-			sp.logger.Error("Failed to process batch, discarding", zap.Int("batch-size", batchSize))
-			sp.onItemDropped(item)
+	if err == nil {
+		// Record latency metrics and return
+		sendLatencyMs := int64(time.Since(startTime) / time.Millisecond)
+		inQueueLatencyMs := int64(time.Since(item.queuedTime) / time.Millisecond)
+		statsTags := statsTagsForBatch(sp.name, item.batch, item.spanFormat)
+		stats.RecordWithTags(context.Background(),
+			statsTags,
+			statSuccessSendOps.M(1),
+			statSendLatencyMs.M(sendLatencyMs),
+			statInQueueLatencyMs.M(inQueueLatencyMs))
+
+		return
+	}
+
+	// There was an error
+	statsTags := statsTagsForBatch(sp.name, item.batch, item.spanFormat)
+	stats.RecordWithTags(context.Background(), statsTags, statFailedSendOps.M(1))
+	batchSize := len(item.batch.Spans)
+	sp.logger.Warn("Sender failed", zap.String("processor", sp.name), zap.Error(err), zap.String("spanFormat", item.spanFormat))
+	if !sp.retryOnProcessingFailure {
+		// throw away the batch
+		sp.logger.Error("Failed to process batch, discarding", zap.String("processor", sp.name), zap.Int("batch-size", batchSize))
+		sp.onItemDropped(item, statsTags)
+	} else {
+		// TODO: (@pjanotti) do not put it back on the end of the queue, retry with it directly.
+		// This will have the benefit of keeping the batch closer to related ones in time.
+		if !sp.queue.Produce(item) {
+			sp.logger.Error("Failed to process batch and failed to re-enqueue", zap.String("processor", sp.name), zap.Int("batch-size", batchSize))
+			sp.onItemDropped(item, statsTags)
 		} else {
-			// TODO: (@pjanotti) do not put it back on the end of the queue, retry with it directly.
-			// This will have the benefit of keeping the batch closer to related ones in time.
-			if !sp.queue.Produce(item) {
-				sp.logger.Error("Failed to process batch and failed to re-enqueue", zap.Int("batch-size", batchSize))
-				sp.onItemDropped(item)
-			} else {
-				sp.logger.Warn("Failed to process batch, re-enqueued", zap.Int("batch-size", batchSize))
-			}
+			sp.logger.Warn("Failed to process batch, re-enqueued", zap.String("processor", sp.name), zap.Int("batch-size", batchSize))
 		}
-		// back-off for configured delay, but get interrupted when shutting down
-		if sp.backoffDelay > 0 {
-			sp.logger.Warn("Backing off before next attempt",
-				zap.Duration("backoff-delay", sp.backoffDelay))
-			select {
-			case <-sp.stopCh:
-				sp.logger.Info("Interrupted due to shutdown")
-				break
-			case <-time.After(sp.backoffDelay):
-				sp.logger.Info("Resume processing")
-				break
-			}
+	}
+
+	// back-off for configured delay, but get interrupted when shutting down
+	if sp.backoffDelay > 0 {
+		sp.logger.Warn("Backing off before next attempt",
+			zap.String("processor", sp.name),
+			zap.Duration("backoff-delay", sp.backoffDelay))
+		select {
+		case <-sp.stopCh:
+			sp.logger.Info("Interrupted due to shutdown", zap.String("processor", sp.name))
+			break
+		case <-time.After(sp.backoffDelay):
+			sp.logger.Info("Resume processing", zap.String("processor", sp.name))
+			break
 		}
 	}
 }
 
-func (sp *queuedSpanProcessor) onItemDropped(item *queueItem) {
+func (sp *queuedSpanProcessor) onItemDropped(item *queueItem, statsTags []tag.Mutator) {
+	numSpans := len(item.batch.Spans)
+	stats.RecordWithTags(context.Background(), statsTags, statDroppedBatchCount.M(1), statDroppedSpanCount.M(int64(numSpans)))
+
 	sp.logger.Warn("Span batch dropped",
+		zap.String("processor", sp.name),
 		zap.Int("#spans", len(item.batch.Spans)),
 		zap.String("spanSource", item.spanFormat))
+}
+
+// Variables related to metrics specific to queued processor.
+var (
+	statInQueueLatencyMs = stats.Int64("queue_latency", "Latency (in milliseconds) that a batch stayed in queue", stats.UnitMilliseconds)
+	statSendLatencyMs    = stats.Int64("send_latency", "Latency (in milliseconds) to send a batch", stats.UnitMilliseconds)
+
+	statSuccessSendOps = stats.Int64("success_send", "Number of successful send operations", stats.UnitDimensionless)
+	statFailedSendOps  = stats.Int64("fail_send", "Number of failed send operations", stats.UnitDimensionless)
+
+	statQueueLength = stats.Int64("queue_length", "Current length of the queue (in batches)", stats.UnitDimensionless)
+)
+
+// QueuedProcessorMetricViews return the metrics views according to given telemetry level.
+func QueuedProcessorMetricViews(level telemetry.Level) []*view.View {
+	if level == telemetry.None {
+		return nil
+	}
+
+	tagKeys := metricTagKeys(level)
+	if tagKeys == nil {
+		return nil
+	}
+
+	exporterTagKeys := []tag.Key{tagExporterNameKey}
+
+	queueLengthView := &view.View{
+		Name:        statQueueLength.Name(),
+		Measure:     statQueueLength,
+		Description: "Current number of batches in the queued exporter",
+		TagKeys:     exporterTagKeys,
+		Aggregation: view.LastValue(),
+	}
+	countSuccessSendView := &view.View{
+		Name:        statSuccessSendOps.Name(),
+		Measure:     statSuccessSendOps,
+		Description: "The number of successful send operations performed by queued exporter",
+		TagKeys:     tagKeys,
+		Aggregation: view.Count(),
+	}
+	countFailuresSendView := &view.View{
+		Name:        statFailedSendOps.Name(),
+		Measure:     statFailedSendOps,
+		Description: "The number of failed send operations performed by queued exporter",
+		TagKeys:     tagKeys,
+		Aggregation: view.Count(),
+	}
+
+	latencyDistributionAggregation := view.Distribution(10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 10000, 20000, 30000, 50000)
+
+	sendLatencyView := &view.View{
+		Name:        statSendLatencyMs.Name(),
+		Measure:     statSendLatencyMs,
+		Description: "The latency of the successful send operations.",
+		TagKeys:     exporterTagKeys,
+		Aggregation: latencyDistributionAggregation,
+	}
+	inQueueLatencyView := &view.View{
+		Name:        statInQueueLatencyMs.Name(),
+		Measure:     statInQueueLatencyMs,
+		Description: "The \"in queue\" latency of the successful send operations.",
+		TagKeys:     exporterTagKeys,
+		Aggregation: latencyDistributionAggregation,
+	}
+
+	return []*view.View{queueLengthView, countSuccessSendView, countFailuresSendView, sendLatencyView, inQueueLatencyView}
 }

--- a/internal/collector/telemetry/telemetry.go
+++ b/internal/collector/telemetry/telemetry.go
@@ -1,0 +1,56 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package telemetry controls the telemetry settings to be used in the collector.
+package telemetry
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// None indicates that no telemetry data should be collected.
+	None Level = iota - 1
+	// Basic is the default and covers the basics of the service telemetry.
+	Basic
+	// Normal adds some other indicators on top of basic.
+	Normal
+	// Detailed adds dimensions and views to the previous levels.
+	Detailed
+)
+
+// Level of telemetry data to be generated.
+type Level int8
+
+// ParseLevel returns the Level represented by the string. The parsing is case-insensitive
+// and it returns error if the string value is unknown.
+func ParseLevel(s string) (Level, error) {
+	var level Level
+	str := strings.ToLower(s)
+	switch str {
+	case "none":
+		level = None
+	case "", "basic":
+		level = Basic
+	case "normal":
+		level = Normal
+	case "detailed":
+		level = Detailed
+	default:
+		return level, fmt.Errorf("unknown metrics level %q", str)
+	}
+
+	return level, nil
+}


### PR DESCRIPTION
This change adds a Prometheus endpoint using OC to provide metrics
to the collector. There are settings to control the level and port
in which the metrics are exposed. The main metrics added for now
are in the queued exporters.