### PR TITLE
all: accept MetricsExporters by implementation

### DIFF
--- a/cmd/ocagent/main.go
+++ b/cmd/ocagent/main.go
@@ -76,14 +76,13 @@ func runOCAgent() {
 		log.Fatalf("Configuration logical error: %v", err)
 	}
 
-	traceExporters, closeFns, err := config.ExportersFromYAMLConfig(yamlBlob)
+	traceExporters, metricsExporters, closeFns, err := config.ExportersFromYAMLConfig(yamlBlob)
 	if err != nil {
 		log.Fatalf("Config: failed to create exporters from YAML: %v", err)
 	}
 
 	commonSpanSink := exporter.MultiTraceExporters(traceExporters...)
-	// TODO: (@odeke-em, @songy23) remove this noopMetricsSink once we have metrics exporters.
-	commonMetricsSink := new(noopMetricsSink)
+	commonMetricsSink := exporter.MultiMetricsExporters(metricsExporters...)
 
 	// Add other receivers here as they are implemented
 	ocReceiverDoneFn, err := runOCReceiver(agentConfig, commonSpanSink, commonMetricsSink)

--- a/exporter/exporterparser/jaeger.go
+++ b/exporter/exporterparser/jaeger.go
@@ -34,23 +34,23 @@ type jaegerExporter struct {
 	exporter *jaeger.Exporter
 }
 
-// JaegerExportersFromYAML parses the yaml bytes and returns an exporter.TraceExporter targeting
+// JaegerExportersFromYAML parses the yaml bytes and returns exporter.TraceExporters targeting
 // Jaeger according to the configuration settings.
-func JaegerExportersFromYAML(config []byte) (tes []exporter.TraceExporter, doneFns []func() error, err error) {
+func JaegerExportersFromYAML(config []byte) (tes []exporter.TraceExporter, mes []exporter.MetricsExporter, doneFns []func() error, err error) {
 	var cfg struct {
 		Exporters *struct {
 			Jaeger *jaegerConfig `yaml:"jaeger"`
 		} `yaml:"exporters"`
 	}
 	if err := yamlUnmarshal(config, &cfg); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if cfg.Exporters == nil {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 	jc := cfg.Exporters.Jaeger
 	if jc == nil {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	// jaeger.NewExporter performs configurqtion validation
@@ -63,7 +63,7 @@ func JaegerExportersFromYAML(config []byte) (tes []exporter.TraceExporter, doneF
 		},
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	doneFns = append(doneFns, func() error {

--- a/exporter/exporterparser/zipkin.go
+++ b/exporter/exporterparser/zipkin.go
@@ -77,22 +77,22 @@ func (zc *ZipkinConfig) EndpointURL() string {
 
 // ZipkinExportersFromYAML parses the yaml bytes and returns an exporter.TraceExporter targeting
 // Zipkin according to the configuration settings.
-func ZipkinExportersFromYAML(config []byte) (tes []exporter.TraceExporter, doneFns []func() error, err error) {
+func ZipkinExportersFromYAML(config []byte) (tes []exporter.TraceExporter, mes []exporter.MetricsExporter, doneFns []func() error, err error) {
 	var cfg struct {
 		Exporters *struct {
 			Zipkin *ZipkinConfig `yaml:"zipkin"`
 		} `yaml:"exporters"`
 	}
 	if err := yamlUnmarshal(config, &cfg); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if cfg.Exporters == nil {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	zc := cfg.Exporters.Zipkin
 	if zc == nil {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	serviceName := ""
@@ -110,7 +110,7 @@ func ZipkinExportersFromYAML(config []byte) (tes []exporter.TraceExporter, doneF
 	}
 	zle, err := newZipkinExporter(endpoint, serviceName, localEndpointURI, uploadPeriod)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Cannot configure Zipkin exporter: %v", err)
+		return nil, nil, nil, fmt.Errorf("Cannot configure Zipkin exporter: %v", err)
 	}
 	tes = append(tes, zle)
 	doneFns = append(doneFns, zle.stop)

--- a/exporter/exporterparser/zipkin_test.go
+++ b/exporter/exporterparser/zipkin_test.go
@@ -146,7 +146,7 @@ exporters:
     zipkin:
       upload_period: 1ms
       endpoint: ` + cst.URL
-	tes, doneFns, err := ZipkinExportersFromYAML([]byte(config))
+	tes, _, doneFns, err := ZipkinExportersFromYAML([]byte(config))
 	if err != nil {
 		t.Fatalf("Failed to parse out exporters: %v", err)
 	}


### PR DESCRIPTION
ExportersFromYAMLConfig now returns metricsExporters
if the underlying code implements exporter.MetricsExporter.