### PR TITLE
Fix nil pointer panic zipkinv1

### DIFF
--- a/translator/trace/testdata/zipkin_v1_multiple_batches.json
+++ b/translator/trace/testdata/zipkin_v1_multiple_batches.json
@@ -126,5 +126,16 @@
                 }
             ]
         }
+    ],
+    [
+        {
+            "traceId": "0ed2e63cbe71f5a8",
+            "name": "checkStock",
+            "id": "fe351a053fbcac1f",
+            "parentId": "0ed2e63cbe71f5a8",
+            "timestamp": 1544805927453923,
+            "duration": 3740,
+            "annotations": []
+        }
     ]
 ]

--- a/translator/trace/testdata/zipkin_v1_single_batch.json
+++ b/translator/trace/testdata/zipkin_v1_single_batch.json
@@ -118,5 +118,14 @@
                 "value": "true"
             }
         ]
+    },
+    {
+        "traceId": "0ed2e63cbe71f5a8",
+        "name": "checkStock",
+        "id": "fe351a053fbcac1f",
+        "parentId": "0ed2e63cbe71f5a8",
+        "timestamp": 1544805927453923,
+        "duration": 3740,
+        "annotations": []
     }
 ]

--- a/translator/trace/zipkinv1_to_protospan.go
+++ b/translator/trace/zipkinv1_to_protospan.go
@@ -194,10 +194,6 @@ type annotationParseResult struct {
 }
 
 func parseZipkinV1Annotations(annotations []*annotation) *annotationParseResult {
-	if len(annotations) == 0 {
-		return nil
-	}
-
 	// Unknown service name works both as a default value and a flag to indicate that a valid endpoint was found.
 	const unknownServiceName = "unknown-service"
 

--- a/translator/trace/zipkinv1_to_protospan_test.go
+++ b/translator/trace/zipkinv1_to_protospan_test.go
@@ -16,7 +16,6 @@ package tracetranslator
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"reflect"
 	"sort"
@@ -196,9 +195,6 @@ func TestMultipleJSONZipkinV1BatchesToOCProto(t *testing.T) {
 	sortTraceByNodeName(got)
 
 	if !reflect.DeepEqual(got, want) {
-
-		fmt.Printf("%+v\n", got)
-		fmt.Printf("%+v\n", want)
 		t.Fatalf("got different data than want")
 	}
 }

--- a/translator/trace/zipkinv1_to_protospan_test.go
+++ b/translator/trace/zipkinv1_to_protospan_test.go
@@ -16,6 +16,7 @@ package tracetranslator
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"reflect"
 	"sort"
@@ -195,6 +196,9 @@ func TestMultipleJSONZipkinV1BatchesToOCProto(t *testing.T) {
 	sortTraceByNodeName(got)
 
 	if !reflect.DeepEqual(got, want) {
+
+		fmt.Printf("%+v\n", got)
+		fmt.Printf("%+v\n", want)
 		t.Fatalf("got different data than want")
 	}
 }
@@ -406,6 +410,23 @@ var ocBatchesFromZipkinV1 = []*agenttracepb.ExportTraceServiceRequest{
 						},
 					},
 				},
+			},
+		},
+	},
+	{
+		Node: &commonpb.Node{
+			ServiceInfo: &commonpb.ServiceInfo{Name: "unknown-service"},
+		},
+		Spans: []*tracepb.Span{
+			{
+				TraceId:      []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8},
+				SpanId:       []byte{0xfe, 0x35, 0x1a, 0x05, 0x3f, 0xbc, 0xac, 0x1f},
+				ParentSpanId: []byte{0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8},
+				Name:         &tracepb.TruncatableString{Value: "checkStock"},
+				Kind:         tracepb.Span_SPAN_KIND_UNSPECIFIED,
+				StartTime:    &timestamp.Timestamp{Seconds: 1544805927, Nanos: 453923000},
+				EndTime:      &timestamp.Timestamp{Seconds: 1544805927, Nanos: 457663000},
+				Attributes:   nil,
 			},
 		},
 	},


### PR DESCRIPTION
If we received a span with no annotations, there would be a nil panic
due to parsedAnnotations being nil. This fixes that.

Testing Done: unit test added