### PR TITLE
Add CORS option for OC Receiver grpc-gateway

### DIFF
--- a/cmd/ocagent/main.go
+++ b/cmd/ocagent/main.go
@@ -156,7 +156,8 @@ func runZPages(port int) func() error {
 
 func runOCReceiver(acfg *config.Config, sr receiver.TraceReceiverSink, mr receiver.MetricsReceiverSink) (doneFn func() error, err error) {
 	addr := acfg.OpenCensusReceiverAddress()
-	ocr, err := opencensus.New(addr)
+	corsOrigins := acfg.OpenCensusReceiverCorsAllowedOrigins()
+	ocr, err := opencensus.New(addr, opencensus.WithCorsOrigins(corsOrigins))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create the OpenCensus receiver on address %q: error %v", addr, err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prashantv/protectmem v0.0.0-20171002184600-e20412882b3a // indirect
 	github.com/prometheus/client_golang v0.8.0
+	github.com/rs/cors v1.6.0
 	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ contrib.go.opencensus.io/exporter/stackdriver v0.7.0 h1:pmo1ol3uPcrLmvOET8bEbu5s
 contrib.go.opencensus.io/exporter/stackdriver v0.7.0/go.mod h1:hNe5qQofPbg6bLQY5wHCvQ7o+2E5P8PkegEuQ+MyRw0=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999 h1:sihTnRgTOUSCQz0iS0pjZuFQy/z7GXCJgSBg3+rZKHw=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+git.apache.org/thrift.git v0.0.0-20181101003639-92be4f312b88 h1:km2LQYVCbsEbT7HCJ/nrMopI5CvJUkniCcSf9ZP5+iQ=
 git.apache.org/thrift.git v0.0.0-20181101003639-92be4f312b88/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -23,6 +24,7 @@ github.com/Shopify/toxiproxy v2.1.3+incompatible h1:awiJqUYH4q4OmoBiRccJykjd7B+w
 github.com/Shopify/toxiproxy v2.1.3+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 h1:CZI8h5fmYwCCvd2RMSsjLqHN6OqABlWJweFKxz4vdEs=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/aws/aws-sdk-go v1.15.31/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
@@ -133,6 +135,8 @@ github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273 h1:agujYaXJSxSo1
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/rs/cors v1.6.0 h1:G9tHG9lebljV9mfp9SNPDL36nCDxmo3zTlAf1YgvzmI=
+github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,6 @@ contrib.go.opencensus.io/exporter/stackdriver v0.7.0 h1:pmo1ol3uPcrLmvOET8bEbu5s
 contrib.go.opencensus.io/exporter/stackdriver v0.7.0/go.mod h1:hNe5qQofPbg6bLQY5wHCvQ7o+2E5P8PkegEuQ+MyRw0=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999 h1:sihTnRgTOUSCQz0iS0pjZuFQy/z7GXCJgSBg3+rZKHw=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-git.apache.org/thrift.git v0.0.0-20181101003639-92be4f312b88 h1:km2LQYVCbsEbT7HCJ/nrMopI5CvJUkniCcSf9ZP5+iQ=
 git.apache.org/thrift.git v0.0.0-20181101003639-92be4f312b88/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -24,7 +23,6 @@ github.com/Shopify/toxiproxy v2.1.3+incompatible h1:awiJqUYH4q4OmoBiRccJykjd7B+w
 github.com/Shopify/toxiproxy v2.1.3+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
-github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 h1:CZI8h5fmYwCCvd2RMSsjLqHN6OqABlWJweFKxz4vdEs=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/aws/aws-sdk-go v1.15.31/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,9 +45,12 @@ import (
 //  zpages:
 //      port: 55679
 
+
+var defaultOCReceiverCorsAllowedOrigins = []string{}
+
 const (
-	defaultOCReceiverAddress = ":55678"
-	defaultZPagesPort        = 55679
+	defaultOCReceiverAddress            = ":55678"
+	defaultZPagesPort                   = 55679
 )
 
 // Config denotes the configuration for the various elements of an agent, that is:
@@ -76,9 +79,14 @@ type Receivers struct {
 // * Various ports
 type ReceiverConfig struct {
 	// The address to which the OpenCensus receiver will be bound and run on.
-	Address             string `yaml:"address"`
-	CollectorHTTPPort   int    `yaml:"collector_http_port"`
-	CollectorThriftPort int    `yaml:"collector_thrift_port"`
+	Address string `yaml:"address"`
+
+	// The allowed CORS origins for HTTP/JSON requests the grpc-gateway adapter
+	// for the OpenCensus receiver. See github.com/rs/cors
+	CorsAllowedOrigins []string `yaml:"cors_allowed_origins"`
+
+	CollectorHTTPPort   int `yaml:"collector_http_port"`
+	CollectorThriftPort int `yaml:"collector_thrift_port"`
 
 	// DisableTracing disables trace receiving and is only applicable to trace receivers.
 	DisableTracing bool `yaml:"disable_tracing"`
@@ -111,6 +119,19 @@ func (c *Config) OpenCensusReceiverAddress() string {
 		return defaultOCReceiverAddress
 	}
 	return inCfg.OpenCensus.Address
+}
+
+// OpenCensusReceiverCorsAllowedOrigins is a helper to safely retrieve the list
+// of allowed CORS origins for HTTP/JSON requests to the grpc-gateway adapter.
+func (c *Config) OpenCensusReceiverCorsAllowedOrigins() []string {
+	if c == nil || c.Receivers == nil {
+		return defaultOCReceiverCorsAllowedOrigins
+	}
+	inCfg := c.Receivers
+	if inCfg.OpenCensus == nil {
+		return defaultOCReceiverCorsAllowedOrigins
+	}
+	return inCfg.OpenCensus.CorsAllowedOrigins
 }
 
 // CanRunOpenCensusTraceReceiver returns true if the configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,13 +45,12 @@ import (
 //  zpages:
 //      port: 55679
 
+const (
+	defaultOCReceiverAddress = ":55678"
+	defaultZPagesPort        = 55679
+)
 
 var defaultOCReceiverCorsAllowedOrigins = []string{}
-
-const (
-	defaultOCReceiverAddress            = ":55678"
-	defaultZPagesPort                   = 55679
-)
 
 // Config denotes the configuration for the various elements of an agent, that is:
 // * Receivers
@@ -79,14 +78,15 @@ type Receivers struct {
 // * Various ports
 type ReceiverConfig struct {
 	// The address to which the OpenCensus receiver will be bound and run on.
-	Address string `yaml:"address"`
+	Address             string `yaml:"address"`
+	CollectorHTTPPort   int    `yaml:"collector_http_port"`
+	CollectorThriftPort int    `yaml:"collector_thrift_port"`
 
 	// The allowed CORS origins for HTTP/JSON requests the grpc-gateway adapter
 	// for the OpenCensus receiver. See github.com/rs/cors
+	// An empty list means that CORS is not enabled at all. A wildcard (*) can be
+	// used to match any origin or one or more characters of an origin.
 	CorsAllowedOrigins []string `yaml:"cors_allowed_origins"`
-
-	CollectorHTTPPort   int `yaml:"collector_http_port"`
-	CollectorThriftPort int `yaml:"collector_thrift_port"`
 
 	// DisableTracing disables trace receiving and is only applicable to trace receivers.
 	DisableTracing bool `yaml:"disable_tracing"`

--- a/receiver/opencensus/opencensus.go
+++ b/receiver/opencensus/opencensus.go
@@ -30,6 +30,7 @@ import (
 	"github.com/census-instrumentation/opencensus-service/receiver/opencensus/ocmetrics"
 	"github.com/census-instrumentation/opencensus-service/receiver/opencensus/octrace"
 	gatewayruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/rs/cors"
 	"github.com/soheilhy/cmux"
 
 	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
@@ -42,6 +43,9 @@ type Receiver struct {
 	ln         net.Listener
 	serverGRPC *grpc.Server
 	serverHTTP *http.Server
+	gatewayMux *gatewayruntime.ServeMux
+
+	corsOrigins []string
 
 	traceReceiverOpts   []octrace.Option
 	metricsReceiverOpts []ocmetrics.Option
@@ -51,7 +55,6 @@ type Receiver struct {
 
 	stopOnce                 sync.Once
 	startServerOnce          sync.Once
-	startHTTPServerOnce      sync.Once
 	startTraceReceiverOnce   sync.Once
 	startMetricsReceiverOnce sync.Once
 }
@@ -68,10 +71,17 @@ func New(addr string, opts ...Option) (*Receiver, error) {
 	// TODO: (@odeke-em) use options to enable address binding changes.
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to bind to gRPC address %q: %v", addr, err)
+		return nil, fmt.Errorf("Failed to bind to address %q: %v", addr, err)
 	}
 
-	ocr := &Receiver{ln: ln}
+	// Do not allow any CORS origins by default.
+	defaultCorsOrigins := []string{}
+
+	ocr := &Receiver{
+		ln:          ln,
+		corsOrigins: defaultCorsOrigins,
+		gatewayMux:  gatewayruntime.NewServeMux(),
+	}
 
 	for _, opt := range opts {
 		opt.withReceiver(ocr)
@@ -196,7 +206,12 @@ func (ocr *Receiver) httpServer() *http.Server {
 	defer ocr.mu.Unlock()
 
 	if ocr.serverHTTP == nil {
-		ocr.serverHTTP = &http.Server{Handler: gatewayruntime.NewServeMux()}
+		var mux http.Handler = ocr.gatewayMux
+		if len(ocr.corsOrigins) > 0 {
+			co := cors.Options{AllowedOrigins: ocr.corsOrigins}
+			mux = cors.New(co).Handler(mux)
+		}
+		ocr.serverHTTP = &http.Server{Handler: mux}
 	}
 
 	return ocr.serverHTTP
@@ -211,8 +226,8 @@ func (ocr *Receiver) startServer() error {
 			c := context.Background()
 			opts := []grpc.DialOption{grpc.WithInsecure()}
 			endpoint := ocr.ln.Addr().String()
-			mux := ocr.httpServer().Handler.(*gatewayruntime.ServeMux)
-			err := agenttracepb.RegisterTraceServiceHandlerFromEndpoint(c, mux, endpoint, opts)
+
+			err := agenttracepb.RegisterTraceServiceHandlerFromEndpoint(c, ocr.gatewayMux, endpoint, opts)
 			if err != nil {
 				errChan <- err
 				return

--- a/receiver/opencensus/opencensus.go
+++ b/receiver/opencensus/opencensus.go
@@ -39,12 +39,11 @@ import (
 
 // Receiver is the type that exposes Trace and Metrics reception.
 type Receiver struct {
-	mu         sync.Mutex
-	ln         net.Listener
-	serverGRPC *grpc.Server
-	serverHTTP *http.Server
-	gatewayMux *gatewayruntime.ServeMux
-
+	mu          sync.Mutex
+	ln          net.Listener
+	serverGRPC  *grpc.Server
+	serverHTTP  *http.Server
+	gatewayMux  *gatewayruntime.ServeMux
 	corsOrigins []string
 
 	traceReceiverOpts   []octrace.Option
@@ -74,12 +73,9 @@ func New(addr string, opts ...Option) (*Receiver, error) {
 		return nil, fmt.Errorf("Failed to bind to address %q: %v", addr, err)
 	}
 
-	// Do not allow any CORS origins by default.
-	defaultCorsOrigins := []string{}
-
 	ocr := &Receiver{
 		ln:          ln,
-		corsOrigins: defaultCorsOrigins,
+		corsOrigins: []string{}, // Disable CORS by default.
 		gatewayMux:  gatewayruntime.NewServeMux(),
 	}
 

--- a/receiver/opencensus/options.go
+++ b/receiver/opencensus/options.go
@@ -57,3 +57,19 @@ func (mro *metricsReceiverOptions) withReceiver(ocr *Receiver) {
 func WithMetricsReceiverOptions(opts ...ocmetrics.Option) Option {
 	return &metricsReceiverOptions{opts: opts}
 }
+
+type corsOrigins struct {
+	origins []string
+}
+
+var _ Option = (*corsOrigins)(nil)
+
+func (co *corsOrigins) withReceiver(ocr *Receiver) {
+	ocr.corsOrigins = co.origins
+}
+
+// WithCorsOrigins is an option to specify the allowed origins to enable writing
+// HTTP/JSON requests to the grpc-gateway adapter using CORS.
+func WithCorsOrigins(origins []string) Option {
+	return &corsOrigins{origins: origins}
+}


### PR DESCRIPTION
This adds a new `cors_allowed_origins` YAML config parameter to the `opencensus` receiver config block, which, if specified will allow HTTP clients to write to the trace grpc-gateway using CORS with the specified list of origins (wildcards can be used to match all origins or arbitrary origin substrings).

This will help with development of [opencensus-web](https://github.com/census-instrumentation/opencensus-web).