### PR TITLE
exporter/prometheus: fix nil deference when no Prometheus exporter

### DIFF
--- a/exporter/exporterparser/prometheus.go
+++ b/exporter/exporterparser/prometheus.go
@@ -56,7 +56,7 @@ func PrometheusExportersFromYAML(config []byte) (tes []exporter.TraceExporter, m
 	if err := yamlUnmarshal(config, &cfg); err != nil {
 		return nil, nil, nil, err
 	}
-	if cfg.Exporters == nil {
+	if cfg.Exporters == nil || cfg.Exporters.Prometheus == nil {
 		return nil, nil, nil, nil
 	}
 

--- a/exporter/exporterparser/prometheus_test.go
+++ b/exporter/exporterparser/prometheus_test.go
@@ -72,6 +72,26 @@ exporters:
 	}
 }
 
+func TestPrometheusExporter_nilDoesntCauseCrash(t *testing.T) {
+	config := []byte(`
+exporters:
+    prometheus:`)
+
+	tes, mes, doneFns, err := PrometheusExportersFromYAML(config)
+	if err != nil {
+		t.Errorf("Unexpected parse error: %v", err)
+	}
+	if len(tes) != 0 {
+		t.Errorf("Unexpectedly got back %d > 0 trace exporters", len(tes))
+	}
+	if len(mes) != 0 {
+		t.Errorf("Unexpectedly got back %d > 0 metrics exporters", len(mes))
+	}
+	for _, doneFn := range doneFns {
+		doneFn()
+	}
+}
+
 func TestPrometheusExporter_endToEnd(t *testing.T) {
 	config := []byte(`
 exporters:


### PR DESCRIPTION
An embarassing crash would occur if in YAML, exporters were specified
and perhaps the Prometheus clause was started but had no content e.g.
```yaml
exporters:
   prometheus:
```

This change fixes that by explicitly returning nil early, but also
added a test to ensure we never regress.