### PR TITLE
Enable receiver/exporter metrics for collector

### DIFF
--- a/cmd/occollector/app/collector/collector.go
+++ b/cmd/occollector/app/collector/collector.go
@@ -40,6 +40,7 @@ import (
 	"github.com/census-instrumentation/opencensus-service/cmd/occollector/app/sender"
 	"github.com/census-instrumentation/opencensus-service/exporter"
 	"github.com/census-instrumentation/opencensus-service/exporter/exporterparser"
+	"github.com/census-instrumentation/opencensus-service/internal"
 	"github.com/census-instrumentation/opencensus-service/internal/collector/jaeger"
 	"github.com/census-instrumentation/opencensus-service/internal/collector/opencensus"
 	"github.com/census-instrumentation/opencensus-service/internal/collector/processor"
@@ -231,6 +232,7 @@ func initTelemetry(level telemetry.Level, port int, asyncErrorChannel chan<- err
 
 	views := processor.MetricViews(level)
 	views = append(views, processor.QueuedProcessorMetricViews(level)...)
+	views = append(views, internal.AllViews...)
 	if err := view.Register(views...); err != nil {
 		return err
 	}

--- a/receiver/zipkin/trace_receiver.go
+++ b/receiver/zipkin/trace_receiver.go
@@ -251,10 +251,13 @@ func (zr *ZipkinReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var ereqs []*agenttracepb.ExportTraceServiceRequest
 
+	var receiverNameTag string
 	if asZipkinv1 {
 		ereqs, err = zr.v1ToTraceSpans(slurp)
+		receiverNameTag = "zipkinV1"
 	} else {
 		ereqs, err = zr.v2ToTraceSpans(slurp, r.Header)
+		receiverNameTag = "zipkinV2"
 	}
 
 	if err != nil {
@@ -266,7 +269,7 @@ func (zr *ZipkinReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	spansMetricsFn := internal.NewReceivedSpansRecorderStreaming(ctx, "zipkin")
+	spansMetricsFn := internal.NewReceivedSpansRecorderStreaming(ctx, receiverNameTag)
 	// Now translate them into TraceData
 	for _, ereq := range ereqs {
 		zr.spanSink.ReceiveTraceData(ctx, data.TraceData{Node: ereq.Node, Spans: ereq.Spans})


### PR DESCRIPTION
Enabling some metrics that exist for receivers/exporters but were
missing on the collector. We should do a separate change to get
consistency on the name of metrics and tags but let's do it in a
separate change.