### PR TITLE
Jaeger requires non-nil Process

### DIFF
--- a/translator/trace/protospan_to_jaegerthrift.go
+++ b/translator/trace/protospan_to_jaegerthrift.go
@@ -37,6 +37,10 @@ var (
 	errWrongLenID      = errors.New("ID does not have 8 bytes")
 )
 
+var (
+	unknownProcess = &jaeger.Process{ServiceName: "unknown-service-name"}
+)
+
 // OCProtoToJaegerThrift translates OpenCensus trace data into the Jaeger Thrift format.
 func OCProtoToJaegerThrift(ocBatch *agenttracepb.ExportTraceServiceRequest) (*jaeger.Batch, error) {
 	if ocBatch == nil {
@@ -58,7 +62,8 @@ func OCProtoToJaegerThrift(ocBatch *agenttracepb.ExportTraceServiceRequest) (*ja
 
 func ocNodeToJaegerProcess(node *commonpb.Node) *jaeger.Process {
 	if node == nil {
-		return nil
+		// Jaeger requires a non-nil Process
+		return unknownProcess
 	}
 
 	var jTags []*jaeger.Tag

--- a/translator/trace/protospan_to_jaegerthrift_test.go
+++ b/translator/trace/protospan_to_jaegerthrift_test.go
@@ -112,6 +112,27 @@ func TestInvalidOCProtoIDs(t *testing.T) {
 	}
 }
 
+func TestNilOCProtoNode(t *testing.T) {
+	nilNodeBatch := &agenttracepb.ExportTraceServiceRequest{
+		Spans: []*tracepb.Span{
+			{
+				TraceId: []byte("0123456789abcdef"),
+				SpanId:  []byte("01234567"),
+			},
+		},
+	}
+	got, err := OCProtoToJaegerThrift(nilNodeBatch)
+	if err != nil {
+		t.Fatalf("Failed to translate OC batch to Jaeger Thrift: %v", err)
+	}
+	if got.Process == nil {
+		t.Fatalf("Jaeger requires a non-nil Process field")
+	}
+	if got.Process != unknownProcess {
+		t.Fatalf("got unexpected Jaeger Process field")
+	}
+}
+
 func TestOCProtoToJaegerThrift(t *testing.T) {
 	const numOfFiles = 2
 	for i := 0; i < numOfFiles; i++ {


### PR DESCRIPTION
Enforcing that conversion from OC proto to Jaeger always ends with a
non-nil Process.

Fix #332 