### PR TITLE
Add a "zipkin-scribe" receiver

### DIFF
--- a/cmd/occollector/app/builder/builder_test.go
+++ b/cmd/occollector/app/builder/builder_test.go
@@ -28,9 +28,10 @@ func TestReceiversEnabledByPresenceWithDefaultSettings(t *testing.T) {
 		t.Fatalf("Failed to load viper from test file: %v", err)
 	}
 
-	jaegerEnabled, opencensusEnabled, zipkinEnabled := JaegerReceiverEnabled(v), OpenCensusReceiverEnabled(v), ZipkinReceiverEnabled(v)
-	if !jaegerEnabled || !opencensusEnabled || !zipkinEnabled {
-		t.Fatalf("Some of the expected receivers were not enabled j:%v oc:%v z:%v", jaegerEnabled, opencensusEnabled, zipkinEnabled)
+	jaegerEnabled, opencensusEnabled, zipkinEnabled, scribeEnabled :=
+		JaegerReceiverEnabled(v), OpenCensusReceiverEnabled(v), ZipkinReceiverEnabled(v), ZipkinScribeReceiverEnabled(v)
+	if !jaegerEnabled || !opencensusEnabled || !zipkinEnabled || !scribeEnabled {
+		t.Fatalf("Some of the expected receivers were not enabled j:%v oc:%v z:%v scribe:%v", jaegerEnabled, opencensusEnabled, zipkinEnabled, scribeEnabled)
 	}
 
 	wj := NewDefaultJaegerReceiverCfg()
@@ -56,6 +57,14 @@ func TestReceiversEnabledByPresenceWithDefaultSettings(t *testing.T) {
 	} else if !reflect.DeepEqual(wz, gz) {
 		t.Errorf("Incorrect config for Zipkin receiver, want %v got %v", wz, gz)
 	}
+
+	wscrb := NewDefaultZipkinScribeReceiverCfg()
+	gscrb, err := wscrb.InitFromViper(v)
+	if err != nil {
+		t.Errorf("Failed to InitFromViper for Zipkin Scribe receiver: %v", err)
+	} else if !reflect.DeepEqual(wscrb, gscrb) {
+		t.Errorf("Incorrect config for Zipkin Scribe receiver, want %v got %v", wscrb, gscrb)
+	}
 }
 
 func TestReceiversDisabledByPresenceWithDefaultSettings(t *testing.T) {
@@ -64,9 +73,10 @@ func TestReceiversDisabledByPresenceWithDefaultSettings(t *testing.T) {
 		t.Fatalf("Failed to load viper from test file: %v", err)
 	}
 
-	jaegerEnabled, opencensusEnabled, zipkinEnabled := JaegerReceiverEnabled(v), OpenCensusReceiverEnabled(v), ZipkinReceiverEnabled(v)
+	jaegerEnabled, opencensusEnabled, zipkinEnabled, scribeEnabled :=
+		JaegerReceiverEnabled(v), OpenCensusReceiverEnabled(v), ZipkinReceiverEnabled(v), ZipkinScribeReceiverEnabled(v)
 	if jaegerEnabled || opencensusEnabled || zipkinEnabled {
-		t.Fatalf("Not all receivers were disabled j:%v oc:%v z:%v", jaegerEnabled, opencensusEnabled, zipkinEnabled)
+		t.Fatalf("Not all receivers were disabled j:%v oc:%v z:%v scribe:%v", jaegerEnabled, opencensusEnabled, zipkinEnabled, scribeEnabled)
 	}
 }
 

--- a/cmd/occollector/app/builder/testdata/receivers_disabled.yaml
+++ b/cmd/occollector/app/builder/testdata/receivers_disabled.yaml
@@ -3,3 +3,4 @@ receivers:
   # jaeger: {} 
   # opencensus: {}
   # zipkin: {}
+  # zipkin-scribe: {}

--- a/cmd/occollector/app/builder/testdata/receivers_enabled.yaml
+++ b/cmd/occollector/app/builder/testdata/receivers_enabled.yaml
@@ -3,3 +3,4 @@ receivers:
   jaeger: {} 
   opencensus: {}
   zipkin: {}
+  zipkin-scribe: {}

--- a/cmd/occollector/app/collector/receivers.go
+++ b/cmd/occollector/app/collector/receivers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/census-instrumentation/opencensus-service/internal/collector/opencensus"
 	"github.com/census-instrumentation/opencensus-service/internal/collector/processor"
 	"github.com/census-instrumentation/opencensus-service/internal/collector/zipkin"
+	"github.com/census-instrumentation/opencensus-service/internal/collector/zipkin/scribe"
 	"github.com/census-instrumentation/opencensus-service/receiver"
 )
 
@@ -39,6 +40,7 @@ func createReceivers(v *viper.Viper, logger *zap.Logger, spanProcessor processor
 		{"Jaeger", jaegerreceiver.Start, builder.JaegerReceiverEnabled(v)},
 		{"OpenCensus", ocreceiver.Start, builder.OpenCensusReceiverEnabled(v)},
 		{"Zipkin", zipkinreceiver.Start, builder.ZipkinReceiverEnabled(v)},
+		{"Zipkin-Scribe", zipkinscribereceiver.Start, builder.ZipkinScribeReceiverEnabled(v)},
 	}
 
 	var startedTraceReceivers []receiver.TraceReceiver

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	cloud.google.com/go v0.32.0 // indirect
 	contrib.go.opencensus.io/exporter/ocagent v0.4.3
 	contrib.go.opencensus.io/exporter/stackdriver v0.9.1
-	git.apache.org/thrift.git v0.0.0-20181101003639-92be4f312b88 // indirect
+	git.apache.org/thrift.git v0.0.0-20181101003639-92be4f312b88
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/DataDog/datadog-go v0.0.0-20180822151419-281ae9f2d895 // indirect
 	github.com/DataDog/opencensus-go-exporter-datadog v0.0.0-20181026070331-e7c4bd17b329
@@ -26,6 +26,7 @@ require (
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/omnition/scribe-go v0.0.0-20190131012523-9e3c68f31124
 	github.com/opentracing/opentracing-go v1.0.2 // indirect
 	github.com/openzipkin/zipkin-go v0.1.3
 	github.com/orijtech/prometheus-go-metrics-exporter v0.0.2
@@ -34,6 +35,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prashantv/protectmem v0.0.0-20171002184600-e20412882b3a // indirect
 	github.com/prometheus/client_golang v0.8.0
+	github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273
 	github.com/rs/cors v1.6.0
 	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/cast v1.2.0
@@ -57,6 +59,7 @@ require (
 	golang.org/x/net v0.0.0-20181102091132-c10e9556a7bc
 	golang.org/x/oauth2 v0.0.0-20181102170140-232e45548389 // indirect
 	golang.org/x/sys v0.0.0-20181031143558-9b800f95dbbc // indirect
+	golang.org/x/text v0.3.0
 	google.golang.org/api v0.0.0-20181102150758-04bb50b6b83d
 	google.golang.org/appengine v1.3.0 // indirect
 	google.golang.org/genproto v0.0.0-20181101192439-c830210a61df // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ cloud.google.com/go v0.32.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 contrib.go.opencensus.io/exporter/ocagent v0.3.0 h1:fyqPXp7d+BBV3tXa7EE1CYrObJr7R9jTAOO/AsdcQBg=
 contrib.go.opencensus.io/exporter/ocagent v0.3.0/go.mod h1:0fnkYHF+ORKj7HWzOExKkUHeFX79gXSKUQbpnAM+wzo=
 contrib.go.opencensus.io/exporter/ocagent v0.4.2/go.mod h1:YuG83h+XWwqWjvCqn7vK4KSyLKhThY3+gNGQ37iS2V0=
+contrib.go.opencensus.io/exporter/ocagent v0.4.3 h1:QjNm697iO7CZ09IxxSiCUzOhALENIsLsixdPwjV1yGs=
 contrib.go.opencensus.io/exporter/ocagent v0.4.3/go.mod h1:YuG83h+XWwqWjvCqn7vK4KSyLKhThY3+gNGQ37iS2V0=
 contrib.go.opencensus.io/exporter/stackdriver v0.7.0 h1:pmo1ol3uPcrLmvOET8bEbu5sialRZDDSHqJso0vo28o=
 contrib.go.opencensus.io/exporter/stackdriver v0.7.0/go.mod h1:hNe5qQofPbg6bLQY5wHCvQ7o+2E5P8PkegEuQ+MyRw0=
@@ -14,6 +15,7 @@ contrib.go.opencensus.io/exporter/stackdriver v0.9.1 h1:W6APgQ9we4BH8U8bnq/FvwLK
 contrib.go.opencensus.io/exporter/stackdriver v0.9.1/go.mod h1:hNe5qQofPbg6bLQY5wHCvQ7o+2E5P8PkegEuQ+MyRw0=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999 h1:sihTnRgTOUSCQz0iS0pjZuFQy/z7GXCJgSBg3+rZKHw=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+git.apache.org/thrift.git v0.0.0-20181101003639-92be4f312b88 h1:c+lV5k88kQl9zle5Wstbsf1rW2Y9bMfuVyhJeIk5hgM=
 git.apache.org/thrift.git v0.0.0-20181101003639-92be4f312b88/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -27,6 +29,7 @@ github.com/Shopify/toxiproxy v2.1.3+incompatible h1:awiJqUYH4q4OmoBiRccJykjd7B+w
 github.com/Shopify/toxiproxy v2.1.3+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 h1:Fv9bK1Q+ly/ROk4aJsVMeuIwPel4bEnD8EPiI91nZMg=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/aws/aws-sdk-go v1.15.31/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
@@ -107,6 +110,8 @@ github.com/mitchellh/mapstructure v1.0.0 h1:vVpGvMXJPqSDh2VYHF7gsfQj8Ncx+Xw5Y1KH
 github.com/mitchellh/mapstructure v1.0.0/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/omnition/scribe-go v0.0.0-20190131012523-9e3c68f31124 h1:mJ3GKMlsntao+kIP06AjcDxTQ5M4uG+cFKp8rRLTJG8=
+github.com/omnition/scribe-go v0.0.0-20190131012523-9e3c68f31124/go.mod h1:GnPmaNTr3pdt/V0JmVNVgDq+JEMb/oXxNlsG+pN6gg4=
 github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=

--- a/internal/collector/zipkin/scribe/receiver.go
+++ b/internal/collector/zipkin/scribe/receiver.go
@@ -1,0 +1,52 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package zipkinscribereceiver wraps the functionality to start the end-point that
+// receives Zipkin Scribe spans.
+package zipkinscribereceiver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/census-instrumentation/opencensus-service/cmd/occollector/app/builder"
+	"github.com/census-instrumentation/opencensus-service/internal/collector/processor"
+	"github.com/census-instrumentation/opencensus-service/receiver"
+	"github.com/census-instrumentation/opencensus-service/receiver/zipkin/scribe"
+)
+
+// Start starts the Zipkin Scribe receiver endpoint.
+func Start(logger *zap.Logger, v *viper.Viper, spanProc processor.SpanProcessor) (receiver.TraceReceiver, error) {
+	rOpts, err := builder.NewDefaultZipkinScribeReceiverCfg().InitFromViper(v)
+	if err != nil {
+		return nil, err
+	}
+
+	sr, err := scribe.NewReceiver(rOpts.Address, rOpts.Port, rOpts.Category)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create the Zipkin Scribe receiver: %v", err)
+	}
+	ss := processor.WrapWithSpanSink("zipkin-scribe", spanProc)
+
+	if err := sr.StartTraceReception(context.Background(), ss); err != nil {
+		return nil, fmt.Errorf("Cannot start Zipkin Scribe receiver %+v: %v", rOpts, err)
+	}
+
+	logger.Info("Zipkin Scribe receiver is running.", zap.Uint16("port", rOpts.Port), zap.String("category", rOpts.Category))
+
+	return sr, nil
+}

--- a/receiver/zipkin/scribe/scribe_receiver.go
+++ b/receiver/zipkin/scribe/scribe_receiver.go
@@ -1,0 +1,170 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scribe
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"strconv"
+	"sync"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
+	"github.com/omnition/scribe-go/if/scribe/gen-go/scribe"
+
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/internal"
+	"github.com/census-instrumentation/opencensus-service/receiver"
+	"github.com/census-instrumentation/opencensus-service/translator/trace"
+)
+
+var (
+	errAlreadyStarted = errors.New("already started")
+	errAlreadyStopped = errors.New("already stopped")
+)
+
+var _ receiver.TraceReceiver = (*scribeReceiver)(nil)
+
+// scribeReceiver implements the receiver.TraceReceiver for Zipkin Scribe protocol.
+type scribeReceiver struct {
+	sync.Mutex
+	addr      string
+	port      uint16
+	collector *scribeCollector
+	server    *thrift.TSimpleServer
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+// NewReceiver creates the Zipkin Scribe receiver with the given parameters.
+func NewReceiver(addr string, port uint16, category string) (receiver.TraceReceiver, error) {
+	r := &scribeReceiver{
+		addr: addr,
+		port: port,
+		collector: &scribeCollector{
+			category:            category,
+			msgDecoder:          base64.StdEncoding.WithPadding('='),
+			tBinProtocolFactory: thrift.NewTBinaryProtocolFactory(true, false),
+		},
+	}
+	return r, nil
+}
+
+func (r *scribeReceiver) StartTraceReception(ctx context.Context, destination receiver.TraceReceiverSink) error {
+	r.Lock()
+	defer r.Unlock()
+
+	if destination == nil {
+		return errors.New("trace reception requires a non-nil destination")
+	}
+
+	err := errAlreadyStarted
+	r.startOnce.Do(func() {
+		err = nil
+		r.collector.traceSink = destination
+		serverSocket, sockErr := thrift.NewTServerSocket(r.addr + ":" + strconv.Itoa(int(r.port)))
+		if sockErr != nil {
+			err = sockErr
+			return
+		}
+
+		sockErr = serverSocket.Open()
+		if sockErr != nil {
+			err = sockErr
+			return
+		}
+
+		r.server = thrift.NewTSimpleServer4(
+			scribe.NewScribeProcessor(r.collector),
+			serverSocket,
+			thrift.NewTFramedTransportFactory(thrift.NewTTransportFactory()),
+			thrift.NewTBinaryProtocolFactory(true, false),
+		)
+
+		// The interface doesn't support reporting anything from the async function.
+		go r.server.Serve()
+	})
+
+	return err
+}
+
+func (r *scribeReceiver) StopTraceReception(ctx context.Context) error {
+	r.Lock()
+	defer r.Unlock()
+
+	var err = errAlreadyStopped
+	r.stopOnce.Do(func() {
+		err = r.server.Stop()
+	})
+	return err
+}
+
+// scribeCollector implements the Thrift interface of a scribe server as supported by zipkin.
+// See https://github.com/openzipkin/zipkin/tree/master/zipkin-collector/scribe
+type scribeCollector struct {
+	category            string
+	msgDecoder          *base64.Encoding
+	tBinProtocolFactory *thrift.TBinaryProtocolFactory
+	traceSink           receiver.TraceReceiverSink
+}
+
+var _ scribe.Scribe = (*scribeCollector)(nil)
+
+// Log is the function that receives the messages sent to the scribe server. It is required
+func (sc *scribeCollector) Log(messages []*scribe.LogEntry) (r scribe.ResultCode, err error) {
+	zSpans := make([]*zipkincore.Span, 0, len(messages))
+	for _, logEntry := range messages {
+		if sc.category != logEntry.Category {
+			// Not the specified category, do nothing
+			continue
+		}
+
+		b, err := sc.msgDecoder.DecodeString(logEntry.Message)
+		if err != nil {
+			return scribe.ResultCode_OK, err
+		}
+
+		r := bytes.NewReader(b)
+		st := thrift.NewStreamTransportR(r)
+		zs := &zipkincore.Span{}
+		if err := zs.Read(sc.tBinProtocolFactory.GetProtocol(st)); err != nil {
+			return scribe.ResultCode_OK, err
+		}
+
+		zSpans = append(zSpans, zs)
+	}
+
+	if len(zSpans) == 0 {
+		return scribe.ResultCode_OK, nil
+	}
+
+	ocBatches, err := tracetranslator.ZipkinV1ThriftBatchToOCProto(zSpans)
+	if err != nil {
+		return scribe.ResultCode_OK, err
+	}
+
+	ctx := context.Background()
+	spansMetricsFn := internal.NewReceivedSpansRecorderStreaming(ctx, "zipkin-scribe")
+
+	for _, ocBatch := range ocBatches {
+		sc.traceSink.ReceiveTraceData(ctx, data.TraceData{Node: ocBatch.Node, Spans: ocBatch.Spans})
+		spansMetricsFn(ocBatch.Node, ocBatch.Spans)
+	}
+
+	return scribe.ResultCode_OK, nil
+}

--- a/receiver/zipkin/scribe/scribe_receiver_test.go
+++ b/receiver/zipkin/scribe/scribe_receiver_test.go
@@ -1,0 +1,265 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scribe
+
+import (
+	"context"
+	"log"
+	"net"
+	"reflect"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/omnition/scribe-go/if/scribe/gen-go/scribe"
+
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/receiver"
+)
+
+func TestNonEqualCategoryIsIgnored(t *testing.T) {
+	sink := &mockTraceSink{}
+	traceReceiver, err := NewReceiver("", 0, "not-zipkin")
+	if err != nil {
+		t.Fatalf("Failed to create receiver: %v", err)
+	}
+
+	messages := []*scribe.LogEntry{
+		{
+			Category: "zipkin",
+			Message:  "Shouldn't be parsed, should be just ignored",
+		},
+	}
+
+	scribeReceiver := traceReceiver.(*scribeReceiver)
+	tstatus, err := scribeReceiver.collector.Log(messages)
+	if tstatus != scribe.ResultCode_OK {
+		t.Errorf("got %v, want scribe.ResultCode_OK", tstatus)
+	}
+	if err != nil {
+		t.Errorf("got error %v, want nil", err)
+	}
+	if len(sink.receivedData) != 0 {
+		t.Fatalf("no items should have been captured")
+	}
+}
+
+func TestScribeReceiverPortAlreadyInUse(t *testing.T) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("failed to open a port: %v", err)
+	}
+	defer l.Close()
+	_, portStr, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split listener address: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("failed to convert %s to an int: %v", portStr, err)
+	}
+	traceReceiver, err := NewReceiver("", uint16(port), "zipkin")
+	if err != nil {
+		t.Fatalf("Failed to create receiver: %v", err)
+	}
+	err = traceReceiver.StartTraceReception(context.Background(), &mockTraceSink{})
+	if err == nil {
+		traceReceiver.StopTraceReception(context.Background())
+		t.Fatal("conflict on port was expected")
+	}
+	log.Printf("%v", err)
+}
+
+func TestScribeReceiverServer(t *testing.T) {
+	const host = ""
+	const port = 9410
+
+	traceReceiver, err := NewReceiver(host, port, "zipkin")
+	if err != nil {
+		t.Fatalf("Failed to create receiver: %v", err)
+	}
+
+	messages := []*scribe.LogEntry{
+		{
+			Category: "zipkin",
+			// Encoded span obtained at https://github.com/openzipkin/zipkin/blob/a40ebcb47986ed1efb85a0543a17611d78404eb2/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ScribeSpanConsumerTest.java#L197
+			Message: "CgABq/sBMnzE048LAAMAAAAOZ2V0VHJhY2VzQnlJZHMKAATN0p+4EGfTdAoABav7ATJ8xNOPDwAGDAAAAAQKAAEABR/wq+2DeAsAAgAAAAJzcgwAAwgAAX8AAAEGAAIkwwsAAwAAAAx6aXBraW4tcXVlcnkAAAoAAQAFH/Cr7zj4CwACAAAIAGFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh\nYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhDAADCAABfwAAAQYAAiTDCwADAAAADHppcGtpbi1xdWVyeQAACgABAAUf8KwLPyILAAIAAABOR2MoOSwwLlBTU2NhdmVuZ2UsMjAxNS0wOS0xNyAxMjozNzowMiArMDAwMCwzMDQubWlsbGlzZWNvbmRzKzc2Mi5taWNyb3NlY29uZHMpDAADCAABfwAAAQYAAiTDCwADAAAADHppcGtpbi1xdWVyeQAIAAQABKZ6AAoAAQAFH/CsDLfACwACAAAAAnNzDAADCAABfwAAAQYAAiTDCwADAAAADHppcGtpbi1xdWVyeQAADwAIDAAAAAULAAEAAAATc3J2L2ZpbmFnbGUudmVyc2lvbgsAAgAAAAY2LjI4LjAIAAMAAAAGDAAECAABfwAAAQYAAgAACwADAAAADHppcGtpbi1xdWVyeQAACwABAAAAD3Nydi9tdXgvZW5hYmxlZAsAAgAAAAEBCAADAAAAAAwABAgAAX8AAAEGAAIAAAsAAwAAAAx6aXBraW4tcXVlcnkAAAsAAQAAAAJzYQsAAgAAAAEBCAADAAAAAAwABAgAAX8AAAEGAAIkwwsAAwAAAAx6aXBraW4tcXVlcnkAAAsAAQAAAAJjYQsAAgAAAAEBCAADAAAAAAwABAgAAX8AAAEGAAL5YAsAAwAAAAx6aXBraW4tcXVlcnkAAAsAAQAAAAZudW1JZHMLAAIAAAAEAAAAAQgAAwAAAAMMAAQIAAF/AAABBgACJMMLAAMAAAAMemlwa2luLXF1ZXJ5AAACAAkAAA==\n",
+		},
+	}
+	sink := newMockTraceSink(len(messages))
+	traceReceiver.StartTraceReception(context.Background(), sink)
+	if err != nil {
+		t.Fatalf("Failed to start trace reception: %v", err)
+	}
+	defer func() {
+		err := traceReceiver.StopTraceReception(context.Background())
+		if err != nil {
+			t.Fatalf("Error stopping trace reception: %v", err)
+		}
+	}()
+
+	var trans thrift.TTransport
+	trans, err = thrift.NewTSocket(net.JoinHostPort("localhost", strconv.Itoa(port)))
+	if err != nil {
+		t.Fatalf("error creating thrift socket: %v", err)
+	}
+	trans = thrift.NewTFramedTransport(trans)
+	defer trans.Close()
+
+	client := scribe.NewScribeClientFactory(trans, thrift.NewTBinaryProtocolFactoryDefault())
+	if err = trans.Open(); err != nil {
+		t.Fatalf("error opening thrift socket: %v", err)
+	}
+
+	client.Log(messages)
+	sink.Wait()
+
+	if len(sink.receivedData) != 1 {
+		t.Fatalf("got %d items, want 1 item", len(sink.receivedData))
+	}
+
+	if !reflect.DeepEqual(sink.receivedData[0], wantTraceData) {
+		t.Errorf("got:\n%+v\nwant:\n%+v\n", sink.receivedData[0], wantTraceData)
+	}
+}
+
+type mockTraceSink struct {
+	wg           *sync.WaitGroup
+	receivedData []data.TraceData
+}
+
+func newMockTraceSink(numReceiveTraceDataCount int) *mockTraceSink {
+	wg := &sync.WaitGroup{}
+	wg.Add(numReceiveTraceDataCount)
+	return &mockTraceSink{
+		wg: wg,
+	}
+}
+
+var _ receiver.TraceReceiverSink = (*mockTraceSink)(nil)
+
+func (m *mockTraceSink) ReceiveTraceData(ctx context.Context, tracedata data.TraceData) (*receiver.TraceReceiverAcknowledgement, error) {
+	m.receivedData = append(m.receivedData, tracedata)
+	m.wg.Done()
+	return &receiver.TraceReceiverAcknowledgement{}, nil
+}
+
+func (m *mockTraceSink) Wait() {
+	m.wg.Wait()
+}
+
+var wantTraceData = data.TraceData{
+	Node: &commonpb.Node{
+		ServiceInfo: &commonpb.ServiceInfo{Name: "zipkin-query"},
+		Attributes: map[string]string{
+			"ipv4": "127.0.0.1",
+			"port": "9411",
+		},
+	},
+	Spans: []*tracepb.Span{
+		{
+			TraceId:      []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xAB, 0xFB, 0x01, 0x32, 0x7C, 0xC4, 0xD3, 0x8F},
+			SpanId:       []byte{0xCD, 0xD2, 0x9F, 0xB8, 0x10, 0x67, 0xD3, 0x74},
+			ParentSpanId: []byte{0xAB, 0xFB, 0x01, 0x32, 0x7C, 0xC4, 0xD3, 0x8F},
+			Name:         &tracepb.TruncatableString{Value: "getTracesByIds"},
+			Kind:         tracepb.Span_SERVER,
+			StartTime:    &timestamp.Timestamp{Seconds: 1442493420, Nanos: 635000000},
+			EndTime:      &timestamp.Timestamp{Seconds: 1442493422, Nanos: 680000000},
+			Attributes: &tracepb.Span_Attributes{
+				AttributeMap: map[string]*tracepb.AttributeValue{
+					"ca": {
+						Value: &tracepb.AttributeValue_BoolValue{BoolValue: true},
+					},
+					"numIds": {
+						Value: &tracepb.AttributeValue_IntValue{IntValue: 1},
+					},
+					"sa": {
+						Value: &tracepb.AttributeValue_BoolValue{BoolValue: true},
+					},
+					"srv/finagle.version": {
+						Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "6.28.0"}},
+					},
+					"srv/mux/enabled": {
+						Value: &tracepb.AttributeValue_BoolValue{BoolValue: true},
+					},
+				},
+			},
+			TimeEvents: &tracepb.Span_TimeEvents{
+				TimeEvent: []*tracepb.Span_TimeEvent{
+					{
+						Time: &timestamp.Timestamp{Seconds: 1442493420, Nanos: 635000000},
+						Value: &tracepb.Span_TimeEvent_Annotation_{
+							Annotation: &tracepb.Span_TimeEvent_Annotation{
+								Attributes: &tracepb.Span_Attributes{
+									AttributeMap: map[string]*tracepb.AttributeValue{
+										"sr": {
+											Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "zipkin-query"}},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Time: &timestamp.Timestamp{Seconds: 1442493420, Nanos: 747000000},
+						Value: &tracepb.Span_TimeEvent_Annotation_{
+							Annotation: &tracepb.Span_TimeEvent_Annotation{
+								Attributes: &tracepb.Span_Attributes{
+									AttributeMap: map[string]*tracepb.AttributeValue{
+										"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+											Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "zipkin-query"}},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Time: &timestamp.Timestamp{Seconds: 1442493422, Nanos: 583586000},
+						Value: &tracepb.Span_TimeEvent_Annotation_{
+							Annotation: &tracepb.Span_TimeEvent_Annotation{
+								Attributes: &tracepb.Span_Attributes{
+									AttributeMap: map[string]*tracepb.AttributeValue{
+										"Gc(9,0.PSScavenge,2015-09-17 12:37:02 +0000,304.milliseconds+762.microseconds)": {
+											Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "zipkin-query"}},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Time: &timestamp.Timestamp{Seconds: 1442493422, Nanos: 680000000},
+						Value: &tracepb.Span_TimeEvent_Annotation_{
+							Annotation: &tracepb.Span_TimeEvent_Annotation{
+								Attributes: &tracepb.Span_Attributes{
+									AttributeMap: map[string]*tracepb.AttributeValue{
+										"ss": {
+											Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "zipkin-query"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}

--- a/translator/trace/zipkinv1_thrift_to_protospan.go
+++ b/translator/trace/zipkinv1_thrift_to_protospan.go
@@ -142,10 +142,14 @@ func zipkinV1ThriftBinAnnotationsToOCAttributes(ztBinAnnotations []*zipkincore.B
 		return nil, ""
 	}
 
+	var fallbackServiceName string
 	attributeMap := make(map[string]*tracepb.AttributeValue)
 	for _, binaryAnnotation := range ztBinAnnotations {
 		pbAttrib := &tracepb.AttributeValue{}
 		binAnnotationType := binaryAnnotation.AnnotationType
+		if binaryAnnotation.Host != nil {
+			fallbackServiceName = binaryAnnotation.Host.ServiceName
+		}
 		switch binaryAnnotation.AnnotationType {
 		case zipkincore.AnnotationType_BOOL:
 			isTrue := bytes.Equal(binaryAnnotation.Value, trueByteSlice)
@@ -194,6 +198,10 @@ func zipkinV1ThriftBinAnnotationsToOCAttributes(ztBinAnnotations []*zipkincore.B
 		}
 
 		attributeMap[key] = pbAttrib
+	}
+
+	if localComponent == "" && fallbackServiceName != "" {
+		localComponent = fallbackServiceName
 	}
 
 	attributes = &tracepb.Span_Attributes{

--- a/translator/trace/zipkinv1_thrift_to_protospan_test.go
+++ b/translator/trace/zipkinv1_thrift_to_protospan_test.go
@@ -49,6 +49,23 @@ func TestZipkinV1ThriftToOCProto(t *testing.T) {
 	}
 }
 
+func BenchmarkZipkinV1ThriftToOCProto(b *testing.B) {
+	blob, err := ioutil.ReadFile("./testdata/zipkin_v1_thrift_single_batch.json")
+	if err != nil {
+		b.Fatalf("failed to load test data: %v", err)
+	}
+
+	var ztSpans []*zipkincore.Span
+	err = json.Unmarshal(blob, &ztSpans)
+	if err != nil {
+		b.Fatalf("failed to unmarshal json into zipkin v1 thrift: %v", err)
+	}
+
+	for n := 0; n < b.N; n++ {
+		ZipkinV1ThriftBatchToOCProto(ztSpans)
+	}
+}
+
 func Test_bytesInt16ToInt64(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Fix #338 

Adds support to zipkin-scribe. While this is zipkin it uses a different protocol (other are all over http), so this becomes a different receiver "zipkin-scribe" that can be enabled separately from normal zipkin. It adds a reference to a repo with the thrift generated files for Scribe protocol (the project in question uses the same version of thrift currently used in oc-service, an old one to match usage in some Jaeger references), the repo is https://github.com/Omnition/scribe-go we can move it later if we want (we can't simply add the files to this repo because them we need to subject the generated files to the same gofmt rules, etc).