### PR TITLE
Tiny, tiny, improvement on Zipkin path

### DIFF
--- a/receiver/zipkin/trace_receiver.go
+++ b/receiver/zipkin/trace_receiver.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -392,7 +393,7 @@ func nodeFromZipkinEndpoints(zs *zipkinmodel.SpanModel) *commonpb.Node {
 		node.ServiceInfo = &commonpb.ServiceInfo{
 			Name: lep.ServiceName,
 		}
-		node.Attributes = zipkinEndpointIntoAttributes(lep, node.Attributes, func(s string) string { return s })
+		node.Attributes = zipkinEndpointIntoAttributes(lep, node.Attributes, isLocalEndpoint)
 	}
 
 	// Retrieve and make use of the remote endpoint
@@ -404,30 +405,42 @@ func nodeFromZipkinEndpoints(zs *zipkinmodel.SpanModel) *commonpb.Node {
 		//      "zipkin.remoteEndpoint.port": "9000"
 		//      "zipkin.remoteEndpoint.serviceName": "backend",
 		// }
-		node.Attributes = zipkinEndpointIntoAttributes(rep, node.Attributes, func(s string) string {
-			return "zipkin.remoteEndpoint." + s
-		})
+		node.Attributes = zipkinEndpointIntoAttributes(rep, node.Attributes, isRemoteEndpoint)
 	}
 	return node
 }
 
+type zipkinDirection bool
+
+const (
+	isLocalEndpoint  zipkinDirection = true
+	isRemoteEndpoint zipkinDirection = false
+)
+
 var blankIP net.IP
 
-func zipkinEndpointIntoAttributes(ep *zipkinmodel.Endpoint, into map[string]string, prefixFunc func(string) string) map[string]string {
+func zipkinEndpointIntoAttributes(ep *zipkinmodel.Endpoint, into map[string]string, endpointType zipkinDirection) map[string]string {
 	if into == nil {
 		into = make(map[string]string)
 	}
+
+	var ipv4Key, ipv6Key, portKey, serviceNameKey string
+	if endpointType == isLocalEndpoint {
+		ipv4Key, ipv6Key, portKey, serviceNameKey = "ipv4", "ipv6", "port", "serviceName"
+	} else {
+		ipv4Key, ipv6Key, portKey, serviceNameKey = "zipkin.remoteEndpoint.ipv4", "zipkin.remoteEndpoint.ipv6", "zipkin.remoteEndpoint.port", "zipkin.remoteEndpoint.serviceName"
+	}
 	if ep.IPv4 != nil && !ep.IPv4.Equal(blankIP) {
-		into[prefixFunc("ipv4")] = ep.IPv4.String()
+		into[ipv4Key] = ep.IPv4.String()
 	}
 	if ep.IPv6 != nil && !ep.IPv6.Equal(blankIP) {
-		into[prefixFunc("ipv6")] = ep.IPv6.String()
+		into[ipv6Key] = ep.IPv6.String()
 	}
 	if ep.Port > 0 {
-		into[prefixFunc("port")] = fmt.Sprintf("%d", ep.Port)
+		into[portKey] = strconv.Itoa(int(ep.Port))
 	}
 	if serviceName := ep.ServiceName; serviceName != "" {
-		into[prefixFunc("serviceName")] = serviceName
+		into[serviceNameKey] = serviceName
 	}
 	return into
 }


### PR DESCRIPTION
This shouldn't be noticable and it is not detected as problem, but,
since we have a better pattern on the exporter I'm bringing the same
to the receiver.

Benchmarking the change:
```
goos: darwin
goarch: amd64
pkg: github.com/census-instrumentation/opencensus-service/receiver/zipkin
Benchmark_zipkinEndpointIntoAttributes_local-8        	10000000	       189 ns/op	      16 B/op	       3 allocs/op
Benchmark_new_zipkinEndpointIntoAttributes_local-8    	10000000	       113 ns/op	      16 B/op	       2 allocs/op
Benchmark_zipkinEndpointIntoAttributes_remote-8       	 5000000	       367 ns/op	     128 B/op	       6 allocs/op
Benchmark_new_zipkinEndpointIntoAttributes_remote-8   	20000000	       117 ns/op	      16 B/op	       2 allocs/op
PASS
ok  	github.com/census-instrumentation/opencensus-service/receiver/zipkin	8.072s
Success: Benchmarks passed.
```

Benchmark code:
```go
func Benchmark_zipkinEndpointIntoAttributes_local(b *testing.B) {
	ep := &zipkinmodel.Endpoint {
		ServiceName: "benchmark",
		IPv4: net.IPv4(1, 2, 3, 4),
		Port: 9411,
	}
	m := make(map[string]string)
	for i := 0; i < b.N; i++ {
		zipkinEndpointIntoAttributes(ep, m, func(s string) string { return s })
	}
}

func Benchmark_new_zipkinEndpointIntoAttributes_local(b *testing.B) {
	ep := &zipkinmodel.Endpoint {
		ServiceName: "benchmark",
		IPv4: net.IPv4(1, 2, 3, 4),
		Port: 9411,
	}
	m := make(map[string]string)
	for i := 0; i < b.N; i++ {
		newzipkinEndpointIntoAttributes(ep, m, false)
	}
}

func Benchmark_zipkinEndpointIntoAttributes_remote(b *testing.B) {
	ep := &zipkinmodel.Endpoint {
		ServiceName: "benchmark",
		IPv4: net.IPv4(1, 2, 3, 4),
		Port: 9411,
	}
	m := make(map[string]string)
	for i := 0; i < b.N; i++ {
		zipkinEndpointIntoAttributes(ep, m, func(s string) string {
			return "zipkin.remoteEndpoint." + s
		})
	}
}

func Benchmark_new_zipkinEndpointIntoAttributes_remote(b *testing.B) {
	ep := &zipkinmodel.Endpoint {
		ServiceName: "benchmark",
		IPv4: net.IPv4(1, 2, 3, 4),
		Port: 9411,
	}
	m := make(map[string]string)
	for i := 0; i < b.N; i++ {
		newzipkinEndpointIntoAttributes(ep, m, true)
	}
}
```