### PR TITLE
ZipkinV1 JSON Receiver: handle LOCAL_COMPONENT binary annotation

### DIFF
--- a/translator/trace/testdata/zipkin_v1_local_component.json
+++ b/translator/trace/testdata/zipkin_v1_local_component.json
@@ -1,0 +1,17 @@
+[
+    {
+        "traceId": "0ed2e63cbe71f5a8",
+        "name": "checkStock",
+        "id": "fe351a053fbcac1f",
+        "parentId": "0ed2e63cbe71f5a8",
+        "timestamp": 1544805927453923,
+        "duration": 3740,
+        "annotations": [],
+        "binaryAnnotations": [
+            {
+                "key": "lc",
+                "value": "myLocalComponent"
+            }
+        ]
+    }
+]

--- a/translator/trace/testdata/zipkin_v1_thrift_local_component.json
+++ b/translator/trace/testdata/zipkin_v1_thrift_local_component.json
@@ -1,0 +1,18 @@
+[
+    {
+        "trace_id": 1068169210207794600,
+        "name": "checkStock",
+        "id": -129168404463703009,
+        "parent_id": 1068169210207794600,
+        "timestamp": 1544805927453923,
+        "duration": 3740,
+        "annotations": [],
+        "binary_annotations": [
+            {
+                "key": "lc",
+                "annotation_type": "STRING",
+                "value": "bXlMb2NhbENvbXBvbmVudA=="
+            }
+        ]
+    }
+]

--- a/translator/trace/zipkinv1_thrift_to_protospan_test.go
+++ b/translator/trace/zipkinv1_thrift_to_protospan_test.go
@@ -23,6 +23,29 @@ import (
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
+func TestZipkinThriftFallbackToLocalComponent(t *testing.T) {
+	blob, err := ioutil.ReadFile("./testdata/zipkin_v1_thrift_local_component.json")
+	if err != nil {
+		t.Fatalf("failed to load test data: %v", err)
+	}
+	var ztSpans []*zipkincore.Span
+	err = json.Unmarshal(blob, &ztSpans)
+	if err != nil {
+		t.Fatalf("failed to unmarshal json into zipkin v1 thrift: %v", err)
+	}
+
+	reqs, err := ZipkinV1ThriftBatchToOCProto(ztSpans)
+	if err != nil {
+		t.Fatalf("failed to translate zipkinv1 thrift to OC proto: %v", err)
+	}
+
+	got := reqs[0].Node.ServiceInfo.Name
+	const want = "myLocalComponent"
+	if got != want {
+		t.Fatalf("got %q for service name, want %q", got, want)
+	}
+}
+
 func TestZipkinV1ThriftToOCProto(t *testing.T) {
 	blob, err := ioutil.ReadFile("./testdata/zipkin_v1_thrift_single_batch.json")
 	if err != nil {

--- a/translator/trace/zipkinv1_to_protospan.go
+++ b/translator/trace/zipkinv1_to_protospan.go
@@ -25,6 +25,7 @@ import (
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 	"github.com/pkg/errors"
 )
 
@@ -143,7 +144,10 @@ func zipkinV1ToOCSpan(zSpan *zipkinV1Span) (*tracepb.Span, *annotationParseResul
 	}
 
 	parsedAnnotations := parseZipkinV1Annotations(zSpan.Annotations)
-	attributes := zipkinV1BinAnnotationsToOCAttributes(zSpan.BinaryAnnotations)
+	attributes, localComponent := zipkinV1BinAnnotationsToOCAttributes(zSpan.BinaryAnnotations)
+	if parsedAnnotations.Endpoint.ServiceName == unknownServiceName && localComponent != "" {
+		parsedAnnotations.Endpoint.ServiceName = localComponent
+	}
 	var startTime, endTime *timestamp.Timestamp
 	if zSpan.Timestamp == 0 {
 		startTime = parsedAnnotations.EarlyAnnotationTime
@@ -171,13 +175,17 @@ func zipkinV1ToOCSpan(zSpan *zipkinV1Span) (*tracepb.Span, *annotationParseResul
 	return ocSpan, parsedAnnotations, nil
 }
 
-func zipkinV1BinAnnotationsToOCAttributes(binAnnotations []*binaryAnnotation) *tracepb.Span_Attributes {
+func zipkinV1BinAnnotationsToOCAttributes(binAnnotations []*binaryAnnotation) (attributes *tracepb.Span_Attributes, localComponent string) {
 	if len(binAnnotations) == 0 {
-		return nil
+		return nil, ""
 	}
 
+	var fallbackServiceName string
 	attributeMap := make(map[string]*tracepb.AttributeValue)
 	for _, binAnnotation := range binAnnotations {
+		if binAnnotation.Endpoint != nil && binAnnotation.Endpoint.ServiceName != "" {
+			fallbackServiceName = binAnnotation.Endpoint.ServiceName
+		}
 		pbAttrib := &tracepb.AttributeValue{}
 		if iValue, err := strconv.ParseInt(binAnnotation.Value, 10, 64); err == nil {
 			pbAttrib.Value = &tracepb.AttributeValue_IntValue{IntValue: iValue}
@@ -187,16 +195,29 @@ func zipkinV1BinAnnotationsToOCAttributes(binAnnotations []*binaryAnnotation) *t
 			// For now all else go to string
 			pbAttrib.Value = &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: binAnnotation.Value}}
 		}
-		attributeMap[binAnnotation.Key] = pbAttrib
+
+		key := binAnnotation.Key
+		if key == zipkincore.LOCAL_COMPONENT {
+			// TODO: (@pjanotti) add reference to OpenTracing and change related tags to use them
+			key = "component"
+			localComponent = binAnnotation.Value
+		}
+		attributeMap[key] = pbAttrib
 	}
 
 	if len(attributeMap) == 0 {
-		return nil
+		return nil, ""
 	}
 
-	return &tracepb.Span_Attributes{
+	if localComponent == "" && fallbackServiceName != "" {
+		localComponent = fallbackServiceName
+	}
+
+	attributes = &tracepb.Span_Attributes{
 		AttributeMap: attributeMap,
 	}
+
+	return attributes, localComponent
 }
 
 // annotationParseResult stores the results of examining the original annotations,

--- a/translator/trace/zipkinv1_to_protospan_test.go
+++ b/translator/trace/zipkinv1_to_protospan_test.go
@@ -131,6 +131,23 @@ func Test_hexTraceIDToOCTraceID(t *testing.T) {
 	}
 }
 
+func TestZipkinJSONFallbackToLocalComponent(t *testing.T) {
+	blob, err := ioutil.ReadFile("./testdata/zipkin_v1_local_component.json")
+	if err != nil {
+		t.Fatalf("failed to load test data: %v", err)
+	}
+	reqs, err := ZipkinV1JSONBatchToOCProto(blob)
+	if err != nil {
+		t.Fatalf("failed to translate zipkinv1 to OC proto: %v", err)
+	}
+
+	got := reqs[0].Node.ServiceInfo.Name
+	const want = "myLocalComponent"
+	if got != want {
+		t.Fatalf("got %q for service name, want %q", got, want)
+	}
+}
+
 func TestSingleJSONZipkinV1BatchToOCProto(t *testing.T) {
 	blob, err := ioutil.ReadFile("./testdata/zipkin_v1_single_batch.json")
 	if err != nil {


### PR DESCRIPTION
The LOCAL_COMPONENT key is used to express the "component or namespace of a local span" in Zipkin V1. This should be used as a fallback for service name if other information is not available for the span.

The LOCAL_COMPONENT, if available, is one of the binary annotations on the span. This change tries to capture it when processing the binary annotations, but, only uses it if none of the other sources for service name is available.

Opportunistically adding equivalent test to Zipkin V1 Thrift that already handles LOCAL_COMPONENT correctly.

Fix #352 