### PR TITLE
AppVeyor build: install bazaar using choco

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ install:
   - go version
   - go env
   - choco install make
+  - choco install bzr
 
 build: false
 deploy: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ deploy: false
 
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%
+  - echo %cd%
   - make install-tools
   - go build -v .\...
   - go test -v .\... # No -race because cgo is disabled

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,3 +25,6 @@ test_script:
   - make install-tools
   - go build -v .\...
   - go test -v .\... # No -race because cgo is disabled
+
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ install:
   - go env
   - choco install make
   - choco install bzr
+  - refreshenv
 
 build: false
 deploy: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,13 +11,12 @@ environment:
   CGO_ENABLED: '0' # See: https://github.com/appveyor/ci/issues/2613
 
 install:
-  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
-  - go version
-  - go env
   - choco install make
   - choco install bzr
-  - refreshenv
-
+  - set PATH=%GOPATH%\bin;c:\go\bin;C:\Program Files (x86)\Bazaar\;%PATH%
+  - go version
+  - go env
+  
 build: false
 deploy: false
 


### PR DESCRIPTION
AppVeyor builds are broken since the repo now has dependencies that require bazaar. This change adds bazaar ([installed using chocolatey](https://chocolatey.org/packages?q=bazaar)) to the set of tools for AppVeyor builds.

There may be more issues with AppVeyor build, but, first we need to install the needed tools.