### PR TITLE
internal/config: fix nil OpenCensus receiver dereference

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -182,13 +182,15 @@ func (c *Config) OpenCensusReceiverCorsAllowedOrigins() []string {
 // CanRunOpenCensusTraceReceiver returns true if the configuration
 // permits running the OpenCensus Trace receiver.
 func (c *Config) CanRunOpenCensusTraceReceiver() bool {
-	return c != nil && c.Receivers != nil && !c.Receivers.OpenCensus.DisableTracing
+	return c != nil && c.Receivers != nil &&
+		c.Receivers.OpenCensus != nil && !c.Receivers.OpenCensus.DisableTracing
 }
 
 // CanRunOpenCensusMetricsReceiver returns true if the configuration
 // permits running the OpenCensus Metrics receiver.
 func (c *Config) CanRunOpenCensusMetricsReceiver() bool {
-	return c != nil && c.Receivers != nil && !c.Receivers.OpenCensus.DisableMetrics
+	return c != nil && c.Receivers != nil &&
+		c.Receivers.OpenCensus != nil && !c.Receivers.OpenCensus.DisableMetrics
 }
 
 // ZPagesDisabled returns true if zPages have not been enabled.


### PR DESCRIPTION
An embarrasing non-defensive nil dereference if
  Config.Receivers.OpenCensus was nil

then either of:
* CanRunOpenCensusTraceReceiver
* CanRunOpenCensusMetricsReceiver

were invoked.

Fixes #377