### PR TITLE
receiver/opencensus: fix crash on unstarted receiver.Stop

### DIFF
--- a/receiver/opencensus/opencensus.go
+++ b/receiver/opencensus/opencensus.go
@@ -189,9 +189,13 @@ func (ocr *Receiver) Stop() error {
 
 	var err = errAlreadyStopped
 	ocr.stopOnce.Do(func() {
-		_ = ocr.serverHTTP.Close()
+		if ocr.serverHTTP != nil {
+			_ = ocr.serverHTTP.Close()
+		}
 
-		_ = ocr.ln.Close()
+		if ocr.ln != nil {
+			_ = ocr.ln.Close()
+		}
 
 		// TODO: @(odeke-em) investigate what utility invoking (*grpc.Server).Stop()
 		// gives us yet we invoke (net.Listener).Close().

--- a/receiver/opencensus/opencensus_test.go
+++ b/receiver/opencensus/opencensus_test.go
@@ -312,3 +312,13 @@ func verifyCorsResp(t *testing.T, url string, origin string, wantStatus int, wan
 		t.Errorf("Unexpected Access-Control-Allow-Methods: %v", gotAllowMethods)
 	}
 }
+
+// Issue #379: Invoking Stop on an unstarted OpenCensus receiver should never crash.
+func TestStopWithoutStartNeverCrashes(t *testing.T) {
+	ocr, err := opencensus.New(":55444")
+	if err != nil {
+		t.Fatalf("Failed to create an OpenCensus receiver: %v", err)
+	}
+	// Stop it before ever invoking Start*.
+	ocr.Stop()
+}


### PR DESCRIPTION
If an unstarted OpenCensus receiver was Stop()-ed, it would
undefensively invoke .serverHTTP.Close()
which would cause a nil dereference panic, moreover in situations
where only unrelated receivers were explicitly started.

Fixes #379