### PR TITLE
Makefile: add a timeout to tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ALL_SRC := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
-GOTEST_OPT?=-v -race
+GOTEST_OPT?=-v -race -timeout 30s
 GOTEST=go test
 GOFMT=gofmt
 GOLINT=golint


### PR DESCRIPTION
Adding a timeout to tests to help cache any test that maybe deadlocking with certain frequency.

This is related to #375 