### PR TITLE
exporters: enable AWS X-Ray Trace exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ exporters:
 
   zipkin:
     endpoint: "http://127.0.0.1:9411/api/v2/spans"
+
+  aws-xray:
+    region: "us-west-2"
+    default_service_name: "verifiability_agent"
+    version: "latest"
+    buffer_size: 200
 ```
 
 ### <a name="config-diagnostics"></a>Diagnostics

--- a/example/main.go
+++ b/example/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"os"
 	"time"
 
 	"contrib.go.opencensus.io/exporter/ocagent"
@@ -32,7 +33,7 @@ import (
 func main() {
 	oce, err := ocagent.NewExporter(
 		ocagent.WithInsecure(),
-		ocagent.WithServiceName("example-go"))
+		ocagent.WithServiceName(fmt.Sprintf("example-go-%d", os.Getpid())))
 	if err != nil {
 		log.Fatalf("Failed to create ocagent-exporter: %v", err)
 	}

--- a/exporter/exporterparser/aws_xray.go
+++ b/exporter/exporterparser/aws_xray.go
@@ -1,0 +1,199 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterparser
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sync"
+	"time"
+
+	xray "contrib.go.opencensus.io/exporter/aws"
+	"go.opencensus.io/trace"
+
+	"github.com/spf13/viper"
+
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/exporter"
+)
+
+const defaultVersionForAWSXRayApplications = "latest"
+
+type awsXRayConfig struct {
+	Version            string        `mapstructure:"version"`
+	BlacklistRegexes   []string      `mapstructure:"blacklist_regexes"`
+	BufferSize         int           `mapstructure:"buffer_size"`
+	BufferPeriod       time.Duration `mapstructure:"buffer_period"`
+	DefaultServiceName string        `mapstructure:"default_service_name"`
+
+	// DestinationRegion is an optional field that if set defines
+	// the region to which the X-Ray payloads will be sent.
+	DestinationRegion string `mapstructure:"destination_region"`
+}
+
+type awsXRayExporter struct {
+	mu sync.RWMutex
+
+	// exportersByServiceName shards AWS X-Ray OpenCensus-Go
+	// Trace exporters by serviceName that's derived
+	// from each Node of spans that this exporter receives.
+	exportersByServiceName map[string]*xray.Exporter
+
+	defaultServiceName string
+	defaultOptions     []xray.Option
+}
+
+var _ exporter.TraceExporter = (*awsXRayExporter)(nil)
+
+// AWSXRayTraceExportersFromViper unmarshals the viper and returns an exporter.TraceExporter targeting
+// AWS X-Ray according to the configuration settings.
+func AWSXRayTraceExportersFromViper(v *viper.Viper) (tes []exporter.TraceExporter, mes []exporter.MetricsExporter, doneFns []func() error, err error) {
+	var cfg struct {
+		AWSXRay *awsXRayConfig `mapstructure:"aws-xray"`
+	}
+	if err := v.Unmarshal(&cfg); err != nil {
+		return nil, nil, nil, err
+	}
+	xc := cfg.AWSXRay
+	if xc == nil {
+		return nil, nil, nil, nil
+	}
+
+	defaultOptions, err := transformConfigToXRayOptions(xc)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("AWS-Xray: converting configuration to options: %v", err)
+	}
+
+	axe := &awsXRayExporter{
+		exportersByServiceName: make(map[string]*xray.Exporter),
+		defaultOptions:         defaultOptions,
+		defaultServiceName:     xc.DefaultServiceName,
+	}
+
+	tes = append(tes, axe)
+	doneFns = append(doneFns, func() error {
+		axe.Flush()
+		return nil
+	})
+	return tes, mes, doneFns, nil
+}
+
+// Flush invokes .Flush() for every one of its underlying exporters.
+func (axe *awsXRayExporter) Flush() {
+	axe.mu.RLock()
+	defer axe.mu.RUnlock()
+
+	for _, exp := range axe.exportersByServiceName {
+		if exp != nil {
+			exp.Flush()
+		}
+	}
+}
+
+func transformConfigToXRayOptions(axrCfg *awsXRayConfig) (xopts []xray.Option, err error) {
+	if axrCfg == nil {
+		return nil, nil
+	}
+
+	// Compile any blacklist regexes.
+	var blacklistRegexes []*regexp.Regexp
+	for _, blacklistRegexStr := range axrCfg.BlacklistRegexes {
+		blacklistRegex, err := regexp.Compile(blacklistRegexStr)
+		if err != nil {
+			return nil, fmt.Errorf("compiling %q error: %v", blacklistRegexStr, err)
+		}
+		blacklistRegexes = append(blacklistRegexes, blacklistRegex)
+	}
+	if len(blacklistRegexes) > 0 {
+		xopts = append(xopts, xray.WithBlacklist(blacklistRegexes))
+	}
+
+	// Handle the buffer-size option.
+	if axrCfg.BufferSize > 0 {
+		xopts = append(xopts, xray.WithBufferSize(axrCfg.BufferSize))
+	}
+
+	if axrCfg.BufferPeriod > 0 {
+		xopts = append(xopts, xray.WithInterval(axrCfg.BufferPeriod))
+	}
+
+	if axrCfg.DestinationRegion != "" {
+		xopts = append(xopts, xray.WithRegion(axrCfg.DestinationRegion))
+	}
+
+	version := axrCfg.Version
+	if version == "" {
+		version = defaultVersionForAWSXRayApplications
+	}
+	xopts = append(xopts, xray.WithVersion(version))
+
+	return xopts, nil
+}
+
+// ExportSpans is the method that translates OpenCensus-Proto Traces into AWS X-Ray spans.
+// It uniquely maintains
+func (axe *awsXRayExporter) ExportSpans(ctx context.Context, td data.TraceData) (xerr error) {
+	ctx, span := trace.StartSpan(ctx,
+		"opencensus.service.exporter.aws_xray.ExportSpans",
+		trace.WithSampler(trace.NeverSample()))
+
+	defer func() {
+		if xerr != nil {
+			span.SetStatus(trace.Status{
+				Code:    int32(trace.StatusCodeUnknown),
+				Message: xerr.Error(),
+			})
+		}
+		span.End()
+	}()
+
+	serviceName := td.Node.GetServiceInfo().GetName()
+	if serviceName == "" {
+		serviceName = axe.defaultServiceName
+	}
+	span.Annotate([]trace.Attribute{
+		trace.StringAttribute("service_name", serviceName),
+	}, "")
+
+	exp, err := axe.getOrMakeExporterByServiceName(serviceName)
+	if err != nil {
+		return err
+	}
+	return exportSpans(ctx, "aws-xray", exp, td)
+}
+
+func (axe *awsXRayExporter) getOrMakeExporterByServiceName(serviceName string) (*xray.Exporter, error) {
+	axe.mu.Lock()
+	defer axe.mu.Unlock()
+
+	exp, ok := axe.exportersByServiceName[serviceName]
+	if ok && exp != nil {
+		return exp, nil
+	}
+
+	// Otherwise, this is the our first time creating this exporter,
+	// so create it with the default options but finally the prescribed serviceName.
+	opts := append(axe.defaultOptions, xray.WithServiceName(serviceName))
+	exp, err := xray.NewExporter(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Now memoize the newly created AWS X-Ray exporter, for later lookups.
+	axe.exportersByServiceName[serviceName] = exp
+
+	return exp, nil
+}

--- a/exporter/exporterparser/aws_xray_test.go
+++ b/exporter/exporterparser/aws_xray_test.go
@@ -1,0 +1,96 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterparser
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	xray "contrib.go.opencensus.io/exporter/aws"
+)
+
+func TestTransformConfigToXRayOptions(t *testing.T) {
+	testCases := []struct {
+		config  *awsXRayConfig
+		want    []xray.Option
+		wantErr string
+	}{
+		{
+			config: nil,
+			want:   nil,
+		},
+		{
+			config: &awsXRayConfig{
+				Version:           "0.12.9",
+				BlacklistRegexes:  []string{"foo.+", "[a-z]+"},
+				BufferSize:        10,
+				BufferPeriod:      379 * time.Millisecond,
+				DestinationRegion: "us-west-2",
+			},
+			want: []xray.Option{
+				xray.WithBlacklist([]*regexp.Regexp{
+					regexp.MustCompile("foo.+"), regexp.MustCompile("[a-z]+"),
+				}),
+				xray.WithBufferSize(10),
+				xray.WithInterval(379 * time.Millisecond),
+				xray.WithRegion("us-west-2"),
+				xray.WithVersion("0.12.9"),
+			},
+		},
+		{
+			config: &awsXRayConfig{
+				Version:          "0.12.9",
+				BlacklistRegexes: []string{"+"},
+			},
+			wantErr: "error parsing regexp: missing argument to repetition operator: `+`",
+		},
+	}
+
+	for i, tt := range testCases {
+		got, err := transformConfigToXRayOptions(tt.config)
+		if tt.wantErr != "" {
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("#%d:\nGot: %q\nWant substring: %q\n", i, err, tt.wantErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("#%d: Unexpected error: %v", i, err)
+			continue
+		}
+
+		ng, nw := len(got), len(tt.want)
+		if ng != nw {
+			t.Errorf("#%d: got len(options)=%d want len(options)=%d", i, ng, nw)
+			continue
+		}
+
+		// Comparing the slice of options. This is a horrendous
+		// comparison but the closest that we can do for now.
+		addrStr := func(v interface{}) string { return fmt.Sprintf("%p", v) }
+
+		for j := 0; j < ng; j++ {
+			sg, sw := addrStr(got[j]), addrStr(tt.want[j])
+			// Since these are unexported options that could be anything,
+			// the best that we could do is compare pointer addresses.
+			if sg != sw {
+				t.Errorf("#%d:\nGot:\n%v\nWant:\n%v\n", i, sg, sw)
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/census-instrumentation/opencensus-service
 
 require (
 	cloud.google.com/go v0.32.0 // indirect
+	contrib.go.opencensus.io/exporter/aws v0.0.0-20181029163544-2befc13012d0
 	contrib.go.opencensus.io/exporter/ocagent v0.4.4
 	contrib.go.opencensus.io/exporter/stackdriver v0.9.1
 	git.apache.org/thrift.git v0.0.0-20181101003639-92be4f312b88 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.31.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.32.0 h1:DSt59WoyNcfAInilEpfvm2ugq8zvNyaHAm9MkzOwRQ4=
 cloud.google.com/go v0.32.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+contrib.go.opencensus.io/exporter/aws v0.0.0-20181029163544-2befc13012d0 h1:YsbWYxDZkC7x2OxlsDEYvvEXZ3cBI3qBgUK5BqkZvRw=
+contrib.go.opencensus.io/exporter/aws v0.0.0-20181029163544-2befc13012d0/go.mod h1:uu1P0UCM/6RbsMrgPa98ll8ZcHM858i/AD06a9aLRCA=
 contrib.go.opencensus.io/exporter/ocagent v0.4.3 h1:QjNm697iO7CZ09IxxSiCUzOhALENIsLsixdPwjV1yGs=
 contrib.go.opencensus.io/exporter/ocagent v0.4.3/go.mod h1:YuG83h+XWwqWjvCqn7vK4KSyLKhThY3+gNGQ37iS2V0=
 contrib.go.opencensus.io/exporter/ocagent v0.4.4 h1:6v7OlUmiBDhvbYcHPWp8LHO8wh9jJY8f4mO34J4GJiA=
@@ -47,6 +49,7 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da h1:8GUt8eRujhVEGZ
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v0.0.0-20180507225419-00862f899353/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
+github.com/aws/aws-sdk-go v1.15.27/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.15.31/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.15.68 h1:2+CJhKkxU/ldztVaJ7V5adR1/ZnYl+oc7ufq2Bl18BQ=
 github.com/aws/aws-sdk-go v1.15.68/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -390,6 +390,7 @@ func eqLocalHost(host string) bool {
 //  + kafka
 //  + opencensus
 //  + prometheus
+//  + aws-xray
 func ExportersFromViperConfig(logger *zap.Logger, v *viper.Viper) ([]exporter.TraceExporter, []exporter.MetricsExporter, []func() error, error) {
 	parseFns := []struct {
 		name string
@@ -402,6 +403,7 @@ func ExportersFromViperConfig(logger *zap.Logger, v *viper.Viper) ([]exporter.Tr
 		{name: "kafka", fn: exporterparser.KafkaExportersFromViper},
 		{name: "opencensus", fn: exporterparser.OpenCensusTraceExportersFromViper},
 		{name: "prometheus", fn: exporterparser.PrometheusExportersFromViper},
+		{name: "aws-xray", fn: exporterparser.AWSXRayTraceExportersFromViper},
 	}
 
 	var traceExporters []exporter.TraceExporter


### PR DESCRIPTION
Added AWS X-Ray as a Trace exporter.
It shards exporters by service-name that's
retrieved by each Trace batch's Node.

With this sample configuration YAML file:
```yaml
receivers:
  opencensus:
    address: "localhost:55678"

exporters:
  aws-xray:
    default_service_name: "ocagent"
    version: "latest"
    buffer_size: 200
```

and obviously AWS credentials in your environment,
it will export to AWS X-Ray.

Fixes #241