### PR TITLE
exporter: add Honeycomb.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ exporters:
     default_service_name: "verifiability_agent"
     version: "latest"
     buffer_size: 200
+  honeycomb:
+    write_key: "739769d7-e61c-42ec-82b9-3ee88dfeff43"
+    dataset_name: "dc8_9"
 ```
 
 ### <a name="config-diagnostics"></a>Diagnostics

--- a/exporter/exporterparser/honeycomb.go
+++ b/exporter/exporterparser/honeycomb.go
@@ -1,0 +1,67 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterparser
+
+// TODO: (@odeke-em) file an issue at the official Honeycomb repository to
+// ask them to make an exporter that uses OpenCensus-Proto instead of OpenCensus-Go.
+
+import (
+	"context"
+
+	"github.com/honeycombio/opencensus-exporter/honeycomb"
+	"github.com/spf13/viper"
+
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/exporter"
+)
+
+type honeycombConfig struct {
+	WriteKey    string `mapstructure:"write_key"`
+	DatasetName string `mapstructure:"dataset_name"`
+}
+
+// HoneycombTraceExportersFromViper unmarshals the viper and returns an exporter.TraceExporter
+// targeting Honeycomb according to the configuration settings.
+func HoneycombTraceExportersFromViper(v *viper.Viper) (tes []exporter.TraceExporter, mes []exporter.MetricsExporter, doneFns []func() error, err error) {
+	var cfg struct {
+		Honeycomb *honeycombConfig `mapstructure:"honeycomb"`
+	}
+	if err := v.Unmarshal(&cfg); err != nil {
+		return nil, nil, nil, err
+	}
+
+	hc := cfg.Honeycomb
+	if hc == nil {
+		return nil, nil, nil, nil
+	}
+
+	rawExp := honeycomb.NewExporter(hc.WriteKey, hc.DatasetName)
+	hce := &honeycombExporter{exporter: rawExp}
+
+	tes = append(tes, hce)
+	doneFns = append(doneFns, func() error {
+		rawExp.Close()
+		return nil
+	})
+	return
+}
+
+type honeycombExporter struct {
+	exporter *honeycomb.Exporter
+}
+
+func (hce *honeycombExporter) ExportSpans(ctx context.Context, td data.TraceData) error {
+	return exportSpans(ctx, "honeycomb", hce.exporter, td)
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b // indirect
 	github.com/census-instrumentation/opencensus-proto v0.1.0-0.20181214143942-ba49f56771b8
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/facebookgo/limitgroup v0.0.0-20150612190941-6abd8d71ec01 // indirect
+	github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52 // indirect
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/gogo/googleapis v1.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
@@ -32,6 +34,8 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.0 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.0 // indirect
 	github.com/hashicorp/serf v0.8.2 // indirect
+	github.com/honeycombio/libhoney-go v1.8.2 // indirect
+	github.com/honeycombio/opencensus-exporter v0.0.0-20181101214123-9be2bb327b5a
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jaegertracing/jaeger v1.8.2
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
@@ -78,6 +82,7 @@ require (
 	google.golang.org/genproto v0.0.0-20181101192439-c830210a61df // indirect
 	google.golang.org/grpc v1.17.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.4.0 // indirect
+	gopkg.in/alexcesaro/statsd.v2 v2.0.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,7 +92,12 @@ github.com/elastic/gosigar v0.9.0/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyC
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/evanphx/json-patch v4.1.0+incompatible h1:K1MDoo4AZ4wU0GIU/fPmtZg7VpzLjCxu+UwBD1FvwOc=
 github.com/evanphx/json-patch v4.1.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a h1:yDWHCSQ40h88yih2JAcL6Ls/kVkSE8GFACTGVnMPruw=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
+github.com/facebookgo/limitgroup v0.0.0-20150612190941-6abd8d71ec01 h1:IeaD1VDVBPlx3viJT9Md8if8IxxJnO+x0JCGb054heg=
+github.com/facebookgo/limitgroup v0.0.0-20150612190941-6abd8d71ec01/go.mod h1:ypD5nozFk9vcGw1ATYefw6jHe/jZP++Z15/+VTMcWhc=
+github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52 h1:a4DFiKFJiDRGFD1qIcqGLX/WlUMD9dyLSLDt+9QZgt8=
+github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52/go.mod h1:yIquW87NGRw1FU5p5lEkpnt/QxoH5uPAOUlOVkAUuMg=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -199,6 +204,10 @@ github.com/hashicorp/serf v0.0.0-20161007004122-1d4fa605f6ff/go.mod h1:h/Ru6tmZa
 github.com/hashicorp/serf v0.8.2 h1:YZ7UKsJv+hKjqGVUUbtE3HNj79Eln2oQ75tniF6iPt0=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/honeycombio/libhoney-go v1.8.2 h1:stYQJi/21p37Qan2DlSkXDuIrup9zxOul2UyeqMAqX0=
+github.com/honeycombio/libhoney-go v1.8.2/go.mod h1:jdLxh51fcBTy6XIpx1efuJmHePs2xUfVkw25lr+hsmg=
+github.com/honeycombio/opencensus-exporter v0.0.0-20181101214123-9be2bb327b5a h1:XZRt69AYOjIRW3KGpzOh0ulEa4DOep0snLPlIgtaXPE=
+github.com/honeycombio/opencensus-exporter v0.0.0-20181101214123-9be2bb327b5a/go.mod h1:Zx4YGFb3eHJsstwhyB5yaVGLROSXWCd0b4PkFKb1mdc=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
@@ -461,6 +470,8 @@ google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3
 gopkg.in/DataDog/dd-trace-go.v1 v1.4.0 h1:RYj+AsYR1/yW/6vuZ2YFAXKVJEV7sTiupNcQeslicM4=
 gopkg.in/DataDog/dd-trace-go.v1 v1.4.0/go.mod h1:DVp8HmDh8PuTu2Z0fVVlBsyWaC++fzwVCaGWylTe3tg=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
+gopkg.in/alexcesaro/statsd.v2 v2.0.0 h1:FXkZSCZIH17vLCO5sO2UucTHsH9pc+17F6pl3JVCwMc=
+gopkg.in/alexcesaro/statsd.v2 v2.0.0/go.mod h1:i0ubccKGzBVNBpdGV5MocxyA/XlLUJzA7SLonnE4drU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -391,6 +391,7 @@ func eqLocalHost(host string) bool {
 //  + opencensus
 //  + prometheus
 //  + aws-xray
+//  + honeycomb
 func ExportersFromViperConfig(logger *zap.Logger, v *viper.Viper) ([]exporter.TraceExporter, []exporter.MetricsExporter, []func() error, error) {
 	parseFns := []struct {
 		name string
@@ -404,6 +405,7 @@ func ExportersFromViperConfig(logger *zap.Logger, v *viper.Viper) ([]exporter.Tr
 		{name: "opencensus", fn: exporterparser.OpenCensusTraceExportersFromViper},
 		{name: "prometheus", fn: exporterparser.PrometheusExportersFromViper},
 		{name: "aws-xray", fn: exporterparser.AWSXRayTraceExportersFromViper},
+		{name: "honeycomb", fn: exporterparser.HoneycombTraceExportersFromViper},
 	}
 
 	var traceExporters []exporter.TraceExporter


### PR DESCRIPTION
Add Honeycomb.io as a trace exporter.
This exporter is based off OpenCensus-Go trace.Exporter.
However, I shall file an issue or firstly page them to
ask them to implement an OpenCensus-Proto trace Exporter.

This change currently imports the work from:
    https://opencensus.io/exporters/supported-exporters/go/honeycomb/
or succinctly
    https://github.com/honeycombio/opencensus-exporter

A sample YAML file is:
```yaml
receivers:
  opencensus:
    address: "localhost:55678"

exporters:
  honeycomb:
    write_key: "739769d7-e61c-42ec-82b9-3ee88dfeff43"
    dataset_name: "dc8_9"
```

Fixes #398