### PR TITLE
Fix flaky test for Zipkin LOCAL_COMPONENT handling

### DIFF
--- a/translator/trace/zipkinv1_thrift_to_protospan_test.go
+++ b/translator/trace/zipkinv1_thrift_to_protospan_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
@@ -42,6 +43,11 @@ func TestZipkinThriftFallbackToLocalComponent(t *testing.T) {
 	if len(reqs) != 2 {
 		t.Fatalf("got %d trace service request(s), want 2", len(reqs))
 	}
+
+	// Ensure the order of nodes
+	sort.Slice(reqs, func(i, j int) bool {
+		return reqs[i].Node.ServiceInfo.Name < reqs[j].Node.ServiceInfo.Name
+	})
 
 	// First span didn't have a host/endpoint to give service name, use the local component.
 	got := reqs[0].Node.ServiceInfo.Name

--- a/translator/trace/zipkinv1_to_protospan_test.go
+++ b/translator/trace/zipkinv1_to_protospan_test.go
@@ -145,6 +145,11 @@ func TestZipkinJSONFallbackToLocalComponent(t *testing.T) {
 		t.Fatalf("got %d trace service request(s), want 2", len(reqs))
 	}
 
+	// Ensure the order of nodes
+	sort.Slice(reqs, func(i, j int) bool {
+		return reqs[i].Node.ServiceInfo.Name < reqs[j].Node.ServiceInfo.Name
+	})
+
 	// First span didn't have a host/endpoint to give service name, use the local component.
 	got := reqs[0].Node.ServiceInfo.Name
 	want := "myLocalComponent"


### PR DESCRIPTION
Internally the function being tested uses a map to generate the slice with the translation results, however, the order is not deterministic and some runs fail. There are just two elements on the translated results but to make clear the expectation of the test this change uses sort.Slice function to achieve the desired order.