### PR TITLE
exporter/exporterparser/all: update SpanData translator

### DIFF
--- a/exporter/exporterparser/aws_xray.go
+++ b/exporter/exporterparser/aws_xray.go
@@ -172,7 +172,7 @@ func (axe *awsXRayExporter) ExportSpans(ctx context.Context, td data.TraceData) 
 	if err != nil {
 		return err
 	}
-	return exportSpans(ctx, "aws-xray", exp, td)
+	return ocProtoSpansToOCSpanDataInstrumented(ctx, "aws-xray", exp, td)
 }
 
 func (axe *awsXRayExporter) getOrMakeExporterByServiceName(serviceName string) (*xray.Exporter, error) {

--- a/exporter/exporterparser/datadog.go
+++ b/exporter/exporterparser/datadog.go
@@ -90,5 +90,5 @@ func (dde *datadogExporter) ExportSpans(ctx context.Context, td data.TraceData) 
 	// TODO: Examine the Datadog exporter to see
 	// if trace.ExportSpan was constraining and if perhaps the
 	// upload can use the context and information from the Node.
-	return exportSpans(ctx, "datadog", dde.exporter, td)
+	return ocProtoSpansToOCSpanDataInstrumented(ctx, "datadog", dde.exporter, td)
 }

--- a/exporter/exporterparser/honeycomb.go
+++ b/exporter/exporterparser/honeycomb.go
@@ -63,5 +63,5 @@ type honeycombExporter struct {
 }
 
 func (hce *honeycombExporter) ExportSpans(ctx context.Context, td data.TraceData) error {
-	return exportSpans(ctx, "honeycomb", hce.exporter, td)
+	return ocProtoSpansToOCSpanDataInstrumented(ctx, "honeycomb", hce.exporter, td)
 }

--- a/exporter/exporterparser/jaeger.go
+++ b/exporter/exporterparser/jaeger.go
@@ -75,5 +75,5 @@ func (je *jaegerExporter) ExportSpans(ctx context.Context, td data.TraceData) er
 	// TODO: Examine "contrib.go.opencensus.io/exporter/jaeger" to see
 	// if trace.ExportSpan was constraining and if perhaps the Jaeger
 	// upload can use the context and information from the Node.
-	return exportSpans(ctx, "jaeger", je.exporter, td)
+	return ocProtoSpansToOCSpanDataInstrumented(ctx, "jaeger", je.exporter, td)
 }

--- a/exporter/exporterparser/kafka.go
+++ b/exporter/exporterparser/kafka.go
@@ -69,5 +69,5 @@ func KafkaExportersFromViper(v *viper.Viper) (tes []exporter.TraceExporter, mes 
 }
 
 func (kde *kafkaExporter) ExportSpans(ctx context.Context, td data.TraceData) error {
-	return exportSpans(ctx, "kafka", kde.exporter, td)
+	return ocProtoSpansToOCSpanDataInstrumented(ctx, "kafka", kde.exporter, td)
 }

--- a/exporter/exporterparser/stackdriver.go
+++ b/exporter/exporterparser/stackdriver.go
@@ -105,7 +105,7 @@ func (sde *stackdriverExporter) ExportSpans(ctx context.Context, td data.TraceDa
 	// TODO: Examine "contrib.go.opencensus.io/exporter/stackdriver" to see
 	// if trace.ExportSpan was constraining and if perhaps the Stackdriver
 	// upload can use the context and information from the Node.
-	return exportSpans(ctx, "stackdriver", sde.exporter, td)
+	return ocProtoSpansToOCSpanDataInstrumented(ctx, "stackdriver", sde.exporter, td)
 }
 
 var _ exporter.MetricsExporter = (*stackdriverExporter)(nil)


### PR DESCRIPTION
Update the OpenCensus Proto TraceData
to OpenCensus-Go SpanData translator by:
* Name from:
    "exportSpans"
to
    "ocProtoSpansToOCSpanDataInstrumented"
to make it more intuitive but also declare
its intentions and add a reminder that we
should get vendors to start using OpenCensus Proto

* Added tracing for each export with a span that'll
record the errors and number of spans