### PR TITLE
Fix format error in tests.

### DIFF
--- a/internal/collector/processor/nodebatcher/node_batcher_test.go
+++ b/internal/collector/processor/nodebatcher/node_batcher_test.go
@@ -239,7 +239,7 @@ func TestConcurrentBatchAdds(t *testing.T) {
 		t.Errorf("failed to wait for sender %s", err)
 	}
 	if len(sender.spansReceivedByName) != requestCount*spansPerRequest {
-		t.Errorf("Did not receive the correct number of spans. %d != %d", sender.spansReceivedByName, requestCount*spansPerRequest)
+		t.Errorf("Did not receive the correct number of spans. %d != %d", len(sender.spansReceivedByName), requestCount*spansPerRequest)
 	}
 
 	for requestNum := 0; requestNum < requestCount; requestNum++ {


### PR DESCRIPTION
internal/collector/processor/nodebatcher/node_batcher_test.go:242:3: Errorf format %d has arg sender.spansReceivedByName of wrong type map[string]*github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1.Span
