### PR TITLE
Move every exporter in it's own directory.

### DIFF
--- a/exporter/awsexporter/aws_xray.go
+++ b/exporter/awsexporter/aws_xray.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporterparser
+package awsexporter
 
 import (
 	"context"
@@ -28,6 +28,7 @@ import (
 
 	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/exporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/exporterparser"
 )
 
 const defaultVersionForAWSXRayApplications = "latest"
@@ -172,7 +173,7 @@ func (axe *awsXRayExporter) ExportSpans(ctx context.Context, td data.TraceData) 
 	if err != nil {
 		return err
 	}
-	return ocProtoSpansToOCSpanDataInstrumented(ctx, "aws-xray", exp, td)
+	return exporterparser.OcProtoSpansToOCSpanDataInstrumented(ctx, "aws-xray", exp, td)
 }
 
 func (axe *awsXRayExporter) getOrMakeExporterByServiceName(serviceName string) (*xray.Exporter, error) {

--- a/exporter/awsexporter/aws_xray_test.go
+++ b/exporter/awsexporter/aws_xray_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporterparser
+package awsexporter
 
 import (
 	"fmt"

--- a/exporter/datadogexporter/datadog.go
+++ b/exporter/datadogexporter/datadog.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporterparser
+package datadogexporter
 
 import (
 	"context"
@@ -22,6 +22,7 @@ import (
 
 	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/exporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/exporterparser"
 )
 
 type datadogConfig struct {
@@ -90,5 +91,5 @@ func (dde *datadogExporter) ExportSpans(ctx context.Context, td data.TraceData) 
 	// TODO: Examine the Datadog exporter to see
 	// if trace.ExportSpan was constraining and if perhaps the
 	// upload can use the context and information from the Node.
-	return ocProtoSpansToOCSpanDataInstrumented(ctx, "datadog", dde.exporter, td)
+	return exporterparser.OcProtoSpansToOCSpanDataInstrumented(ctx, "datadog", dde.exporter, td)
 }

--- a/exporter/exporterparser/exparser.go
+++ b/exporter/exporterparser/exparser.go
@@ -32,7 +32,7 @@ import (
 	tracetranslator "github.com/census-instrumentation/opencensus-service/translator/trace"
 )
 
-// ocProtoSpansToOCSpanDataInstrumented converts
+// OcProtoSpansToOCSpanDataInstrumented converts
 // OpenCensus Proto TraceData to OpenCensus-Go SpanData.
 // The "Instrumented" suffix serves to document that this
 // function is traced but also has stats for self-observability.
@@ -42,7 +42,7 @@ import (
 // by various vendors and contributors. Eventually the goal is to
 // get those exporters converted to directly receive
 // OpenCensus Proto TraceData.
-func ocProtoSpansToOCSpanDataInstrumented(ctx context.Context, exporterName string, te trace.Exporter, td data.TraceData) (aerr error) {
+func OcProtoSpansToOCSpanDataInstrumented(ctx context.Context, exporterName string, te trace.Exporter, td data.TraceData) (aerr error) {
 	ctx, span := trace.StartSpan(ctx,
 		"opencensus.service.exporter."+exporterName+".ExportTrace",
 		trace.WithSampler(trace.NeverSample()))

--- a/exporter/honeycombexporter/honeycomb.go
+++ b/exporter/honeycombexporter/honeycomb.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporterparser
+package honeycombexporter
 
 // TODO: (@odeke-em) file an issue at the official Honeycomb repository to
 // ask them to make an exporter that uses OpenCensus-Proto instead of OpenCensus-Go.
@@ -25,6 +25,7 @@ import (
 
 	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/exporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/exporterparser"
 )
 
 type honeycombConfig struct {
@@ -63,5 +64,5 @@ type honeycombExporter struct {
 }
 
 func (hce *honeycombExporter) ExportSpans(ctx context.Context, td data.TraceData) error {
-	return ocProtoSpansToOCSpanDataInstrumented(ctx, "honeycomb", hce.exporter, td)
+	return exporterparser.OcProtoSpansToOCSpanDataInstrumented(ctx, "honeycomb", hce.exporter, td)
 }

--- a/exporter/jaegerexporter/jaeger.go
+++ b/exporter/jaegerexporter/jaeger.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporterparser
+package jaegerexporter
 
 import (
 	"context"
@@ -22,6 +22,7 @@ import (
 
 	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/exporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/exporterparser"
 )
 
 // Slight modified version of go/src/go.opencensus.io/exporter/jaeger/jaeger.go
@@ -75,5 +76,5 @@ func (je *jaegerExporter) ExportSpans(ctx context.Context, td data.TraceData) er
 	// TODO: Examine "contrib.go.opencensus.io/exporter/jaeger" to see
 	// if trace.ExportSpan was constraining and if perhaps the Jaeger
 	// upload can use the context and information from the Node.
-	return ocProtoSpansToOCSpanDataInstrumented(ctx, "jaeger", je.exporter, td)
+	return exporterparser.OcProtoSpansToOCSpanDataInstrumented(ctx, "jaeger", je.exporter, td)
 }

--- a/exporter/kafkaexporter/kafka.go
+++ b/exporter/kafkaexporter/kafka.go
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporterparser
+package kafkaexporter
 
 import (
 	"context"
 	"fmt"
 
 	"github.com/spf13/viper"
-	"github.com/yancl/opencensus-go-exporter-kafka"
+	kafka "github.com/yancl/opencensus-go-exporter-kafka"
 
 	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/exporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/exporterparser"
 )
 
 type kafkaConfig struct {
@@ -69,5 +70,5 @@ func KafkaExportersFromViper(v *viper.Viper) (tes []exporter.TraceExporter, mes 
 }
 
 func (kde *kafkaExporter) ExportSpans(ctx context.Context, td data.TraceData) error {
-	return ocProtoSpansToOCSpanDataInstrumented(ctx, "kafka", kde.exporter, td)
+	return exporterparser.OcProtoSpansToOCSpanDataInstrumented(ctx, "kafka", kde.exporter, td)
 }

--- a/exporter/opencensusexporter/opencensus.go
+++ b/exporter/opencensusexporter/opencensus.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporterparser
+package opencensusexporter
 
 import (
 	"context"

--- a/exporter/prometheusexporter/prometheus.go
+++ b/exporter/prometheusexporter/prometheus.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporterparser
+package prometheusexporter
 
 import (
 	"context"

--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporterparser
+package prometheusexporter
 
 import (
 	"context"

--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporterparser
+package stackdriverexporter
 
 import (
 	"context"
@@ -26,6 +26,7 @@ import (
 
 	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/exporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/exporterparser"
 )
 
 type stackdriverConfig struct {
@@ -105,7 +106,7 @@ func (sde *stackdriverExporter) ExportSpans(ctx context.Context, td data.TraceDa
 	// TODO: Examine "contrib.go.opencensus.io/exporter/stackdriver" to see
 	// if trace.ExportSpan was constraining and if perhaps the Stackdriver
 	// upload can use the context and information from the Node.
-	return ocProtoSpansToOCSpanDataInstrumented(ctx, "stackdriver", sde.exporter, td)
+	return exporterparser.OcProtoSpansToOCSpanDataInstrumented(ctx, "stackdriver", sde.exporter, td)
 }
 
 var _ exporter.MetricsExporter = (*stackdriverExporter)(nil)

--- a/exporter/zipkinexporter/zipkin.go
+++ b/exporter/zipkinexporter/zipkin.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporterparser
+package zipkinexporter
 
 import (
 	"context"

--- a/exporter/zipkinexporter/zipkin_test.go
+++ b/exporter/zipkinexporter/zipkin_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporterparser
+package zipkinexporter
 
 import (
 	"bytes"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,15 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/census-instrumentation/opencensus-service/exporter"
-	"github.com/census-instrumentation/opencensus-service/exporter/exporterparser"
+	"github.com/census-instrumentation/opencensus-service/exporter/awsexporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/datadogexporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/honeycombexporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/jaegerexporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/kafkaexporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/opencensusexporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/prometheusexporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/stackdriverexporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/zipkinexporter"
 	"github.com/census-instrumentation/opencensus-service/receiver/prometheusreceiver"
 )
 
@@ -143,7 +151,7 @@ type ScribeReceiverConfig struct {
 // Exporters denotes the configurations for the various backends
 // that this service exports observability signals to.
 type Exporters struct {
-	Zipkin *exporterparser.ZipkinConfig `yaml:"zipkin"`
+	Zipkin *zipkinexporter.ZipkinConfig `yaml:"zipkin"`
 }
 
 // ZPagesConfig denotes the configuration that zPages will be run with.
@@ -269,11 +277,11 @@ func (c *Config) PrometheusConfiguration() *prometheusreceiver.Configuration {
 // will return the default of "localhost:9411"
 func (c *Config) ZipkinReceiverAddress() string {
 	if c == nil || c.Receivers == nil {
-		return exporterparser.DefaultZipkinEndpointHostPort
+		return zipkinexporter.DefaultZipkinEndpointHostPort
 	}
 	inCfg := c.Receivers
 	if inCfg.Zipkin == nil || inCfg.Zipkin.Address == "" {
-		return exporterparser.DefaultZipkinEndpointHostPort
+		return zipkinexporter.DefaultZipkinEndpointHostPort
 	}
 	return inCfg.Zipkin.Address
 }
@@ -397,15 +405,15 @@ func ExportersFromViperConfig(logger *zap.Logger, v *viper.Viper) ([]exporter.Tr
 		name string
 		fn   func(*viper.Viper) ([]exporter.TraceExporter, []exporter.MetricsExporter, []func() error, error)
 	}{
-		{name: "datadog", fn: exporterparser.DatadogTraceExportersFromViper},
-		{name: "stackdriver", fn: exporterparser.StackdriverTraceExportersFromViper},
-		{name: "zipkin", fn: exporterparser.ZipkinExportersFromViper},
-		{name: "jaeger", fn: exporterparser.JaegerExportersFromViper},
-		{name: "kafka", fn: exporterparser.KafkaExportersFromViper},
-		{name: "opencensus", fn: exporterparser.OpenCensusTraceExportersFromViper},
-		{name: "prometheus", fn: exporterparser.PrometheusExportersFromViper},
-		{name: "aws-xray", fn: exporterparser.AWSXRayTraceExportersFromViper},
-		{name: "honeycomb", fn: exporterparser.HoneycombTraceExportersFromViper},
+		{name: "datadog", fn: datadogexporter.DatadogTraceExportersFromViper},
+		{name: "stackdriver", fn: stackdriverexporter.StackdriverTraceExportersFromViper},
+		{name: "zipkin", fn: zipkinexporter.ZipkinExportersFromViper},
+		{name: "jaeger", fn: jaegerexporter.JaegerExportersFromViper},
+		{name: "kafka", fn: kafkaexporter.KafkaExportersFromViper},
+		{name: "opencensus", fn: opencensusexporter.OpenCensusTraceExportersFromViper},
+		{name: "prometheus", fn: prometheusexporter.PrometheusExportersFromViper},
+		{name: "aws-xray", fn: awsexporter.AWSXRayTraceExportersFromViper},
+		{name: "honeycomb", fn: honeycombexporter.HoneycombTraceExportersFromViper},
 	}
 
 	var traceExporters []exporter.TraceExporter

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,7 +19,7 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/census-instrumentation/opencensus-service/exporter/exporterparser"
+	"github.com/census-instrumentation/opencensus-service/exporter/zipkinexporter"
 	"github.com/census-instrumentation/opencensus-service/internal/config"
 )
 
@@ -53,7 +53,7 @@ exporters:
 
 	var ecfg struct {
 		Exporters *struct {
-			Zipkin *exporterparser.ZipkinConfig `yaml:"zipkin"`
+			Zipkin *zipkinexporter.ZipkinConfig `yaml:"zipkin"`
 		} `yaml:"exporters"`
 	}
 	_ = yaml.Unmarshal(regressionYAML, &ecfg)


### PR DESCRIPTION
With this change we split a large package exporterparser (in terms of dependencies) and make sure that we don't download the entire internet if depend on one of the exporters. 

Updates https://github.com/census-instrumentation/opencensus-service/issues/369