### PR TITLE
Avoid go build in AppVeyor so bzr is not used

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ environment:
   GOVERSION: '1.11'
   GO111MODULE: 'on'
   CGO_ENABLED: '0' # See: https://github.com/appveyor/ci/issues/2613
+  GOTEST_OPT: '-v -timeout 30s' # No -race because cgo is disabled
 
 install:
   - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
@@ -22,5 +23,4 @@ deploy: false
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%
   - make install-tools
-  - go build -v .\...
-  - go test -v .\... # No -race because cgo is disabled
+  - make


### PR DESCRIPTION
This tries to work around the issue with AppVeyor by not having a explicit go build.

Opening a PR to test this idea.