### PR TITLE
Fix some of the stats exported.

### DIFF
--- a/internal/collector/processor/nodebatcher/metrics.go
+++ b/internal/collector/processor/nodebatcher/metrics.go
@@ -61,7 +61,7 @@ func MetricViews(level telemetry.Level) []*view.View {
 		Measure:     statNodesAddedToBatches,
 		Description: statNodesAddedToBatches.Description(),
 		TagKeys:     exporterTagKeys,
-		Aggregation: view.Count(),
+		Aggregation: view.Sum(),
 	}
 
 	nodesRemovedFromBatchesView := &view.View{
@@ -69,7 +69,7 @@ func MetricViews(level telemetry.Level) []*view.View {
 		Measure:     statNodesRemovedFromBatches,
 		Description: statNodesRemovedFromBatches.Description(),
 		TagKeys:     exporterTagKeys,
-		Aggregation: view.Count(),
+		Aggregation: view.Sum(),
 	}
 
 	countBatchSizeTriggerSendView := &view.View{
@@ -77,7 +77,7 @@ func MetricViews(level telemetry.Level) []*view.View {
 		Measure:     statBatchSizeTriggerSend,
 		Description: statBatchSizeTriggerSend.Description(),
 		TagKeys:     tagKeys,
-		Aggregation: view.Count(),
+		Aggregation: view.Sum(),
 	}
 
 	countTimeoutTriggerSendView := &view.View{
@@ -85,7 +85,7 @@ func MetricViews(level telemetry.Level) []*view.View {
 		Measure:     statTimeoutTriggerSend,
 		Description: statTimeoutTriggerSend.Description(),
 		TagKeys:     tagKeys,
-		Aggregation: view.Count(),
+		Aggregation: view.Sum(),
 	}
 
 	countBatchOnDeadNode := &view.View{
@@ -93,7 +93,7 @@ func MetricViews(level telemetry.Level) []*view.View {
 		Measure:     statBatchOnDeadNode,
 		Description: statBatchOnDeadNode.Description(),
 		TagKeys:     tagKeys,
-		Aggregation: view.Count(),
+		Aggregation: view.Sum(),
 	}
 
 	return []*view.View{

--- a/internal/collector/processor/queued/queued_processor.go
+++ b/internal/collector/processor/queued/queued_processor.go
@@ -112,10 +112,6 @@ func (sp *queuedSpanProcessor) Stop() {
 
 // ProcessSpans implements the SpanProcessor interface
 func (sp *queuedSpanProcessor) ProcessSpans(td data.TraceData, spanFormat string) error {
-	return sp.enqueueSpanBatch(td, spanFormat)
-}
-
-func (sp *queuedSpanProcessor) enqueueSpanBatch(td data.TraceData, spanFormat string) error {
 	item := &queueItem{
 		queuedTime: time.Now(),
 		td:         td,
@@ -232,14 +228,14 @@ func MetricViews(level telemetry.Level) []*view.View {
 		Measure:     statSuccessSendOps,
 		Description: "The number of successful send operations performed by queued exporter",
 		TagKeys:     tagKeys,
-		Aggregation: view.Count(),
+		Aggregation: view.Sum(),
 	}
 	countFailuresSendView := &view.View{
 		Name:        statFailedSendOps.Name(),
 		Measure:     statFailedSendOps,
 		Description: "The number of failed send operations performed by queued exporter",
 		TagKeys:     tagKeys,
-		Aggregation: view.Count(),
+		Aggregation: view.Sum(),
 	}
 
 	latencyDistributionAggregation := view.Distribution(10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 10000, 20000, 30000, 50000)

--- a/internal/collector/telemetry/process_telemetry.go
+++ b/internal/collector/telemetry/process_telemetry.go
@@ -31,7 +31,7 @@ var viewTotalAllocMem = &view.View{
 	Name:        mRuntimeTotalAllocMem.Name(),
 	Description: mRuntimeTotalAllocMem.Description(),
 	Measure:     mRuntimeTotalAllocMem,
-	Aggregation: view.Count(),
+	Aggregation: view.LastValue(),
 	TagKeys:     nil,
 }
 
@@ -49,7 +49,7 @@ var viewCPUSeconds = &view.View{
 	Name:        mCPUSeconds.Name(),
 	Description: mCPUSeconds.Description(),
 	Measure:     mCPUSeconds,
-	Aggregation: view.Count(),
+	Aggregation: view.LastValue(),
 	TagKeys:     nil,
 }
 


### PR DESCRIPTION
Count -> Sum changes are because count is the aggregation that counts the number of recorded measurements not the sum of the recorded values. In the current case this should be the same.

For process telemetry the TotalAlloc and CPUSeconds are exported as cumulative data so they need to use LastValue, unfortunately they will be exported as gauges even though they are cumulative values (this is unfortunately, but when metrics package will be done in Go we should use that).