### PR TITLE
receiver/prometheus: migrate code in here

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52 // indirect
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 // indirect
+	github.com/go-kit/kit v0.8.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/gogo/googleapis v1.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
@@ -51,7 +52,6 @@ require (
 	github.com/opentracing/opentracing-go v1.0.2 // indirect
 	github.com/openzipkin/zipkin-go v0.1.3
 	github.com/orijtech/prometheus-go-metrics-exporter v0.0.2
-	github.com/orijtech/promreceiver v0.0.3
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pkg/errors v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ cloud.google.com/go v0.32.0 h1:DSt59WoyNcfAInilEpfvm2ugq8zvNyaHAm9MkzOwRQ4=
 cloud.google.com/go v0.32.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 contrib.go.opencensus.io/exporter/aws v0.0.0-20181029163544-2befc13012d0 h1:YsbWYxDZkC7x2OxlsDEYvvEXZ3cBI3qBgUK5BqkZvRw=
 contrib.go.opencensus.io/exporter/aws v0.0.0-20181029163544-2befc13012d0/go.mod h1:uu1P0UCM/6RbsMrgPa98ll8ZcHM858i/AD06a9aLRCA=
-contrib.go.opencensus.io/exporter/ocagent v0.4.4 h1:6v7OlUmiBDhvbYcHPWp8LHO8wh9jJY8f4mO34J4GJiA=
-contrib.go.opencensus.io/exporter/ocagent v0.4.4/go.mod h1:YuG83h+XWwqWjvCqn7vK4KSyLKhThY3+gNGQ37iS2V0=
 contrib.go.opencensus.io/exporter/ocagent v0.4.6 h1:xVeoJwnzMbseoL9YWhohR6SN/GncvP1p/fznasLkT/E=
 contrib.go.opencensus.io/exporter/ocagent v0.4.6/go.mod h1:YuG83h+XWwqWjvCqn7vK4KSyLKhThY3+gNGQ37iS2V0=
 contrib.go.opencensus.io/exporter/stackdriver v0.9.1 h1:W6APgQ9we4BH8U8bnq/FvwLKo2WSMHuiMkkS/Slkg30=
@@ -298,8 +296,6 @@ github.com/openzipkin/zipkin-go v0.1.3 h1:36hTtUTQR/vPX7YVJo2PYexSbHdAJiAkDrjuXw
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/orijtech/prometheus-go-metrics-exporter v0.0.2 h1:XZGTMsJ8xM4VyrFGwHkdpZNnexxmAzFaq1//gUWqyKE=
 github.com/orijtech/prometheus-go-metrics-exporter v0.0.2/go.mod h1:+Mu9w51Uc2RNKSUTA95d6Pvy8cxFiRX3ANRPlCcnGLA=
-github.com/orijtech/promreceiver v0.0.3 h1:qK3QOv1JdLtD+8Mc0bx3RdDPTVE1uUBI25YtttuWATc=
-github.com/orijtech/promreceiver v0.0.3/go.mod h1:2MEABETYIwm/Don8X1s/mv8R5FwJbtwo4GwxW2qAFYQ=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c h1:Lgl0gzECD8GnQ5QCWA8o6BtfL6mDH5rQgM4/fX3avOs=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=

--- a/receiver/prometheusreceiver/buffering.go
+++ b/receiver/prometheusreceiver/buffering.go
@@ -1,0 +1,151 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusreceiver
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/timestamp"
+)
+
+type bundling struct {
+	md          *metricspb.MetricDescriptor
+	node        *commonpb.Node
+	resource    *resourcepb.Resource
+	point       *metricspb.Point
+	ts          *timestamp.Timestamp
+	labelValues []*metricspb.LabelValue
+}
+
+type signatureNodeResourceTriple struct {
+	node      *commonpb.Node
+	resource  *resourcepb.Resource
+	signature string
+}
+
+func compactAndCombineMetrics(ms metricsSink, bundlings []*bundling) {
+	// Sort all of them by timestamp first.
+	sort.Slice(bundlings, func(i, j int) bool {
+		bdli, bdlj := bundlings[i], bundlings[j]
+		ti := bdli.point.GetTimestamp()
+		tj := bdlj.point.GetTimestamp()
+		return ti.GetSeconds() < tj.GetSeconds() &&
+			ti.GetNanos() < tj.GetNanos()
+	})
+
+	// Our goal is to bundle metrics indexed by metricDescriptor
+	byMdNodeResourceSignature := make(map[string][]*bundling)
+	uniqueOrderedMNRSignatures := make([]string, 0, len(bundlings))
+	for _, bdl := range bundlings {
+		mdSignature, _ := proto.Marshal(bdl.md)
+		nodeResourceSignature := nodeResourceSignature(bdl.node, bdl.resource)
+		signature := fmt.Sprintf("%s%s", mdSignature, nodeResourceSignature)
+		if _, ok := byMdNodeResourceSignature[signature]; !ok {
+			uniqueOrderedMNRSignatures = append(uniqueOrderedMNRSignatures, signature)
+		}
+		byMdNodeResourceSignature[signature] = append(byMdNodeResourceSignature[signature], bdl)
+	}
+
+	byNodeResourceSignature := make(map[string][]*metricspb.Metric)
+	uniqueOrderedNRSignatures := make([]*signatureNodeResourceTriple, 0, len(bundlings))
+	for _, bdls := range byMdNodeResourceSignature {
+		node, resource, metric := createMetricsWithSameMetricDescriptorNodeResource(bdls)
+		signature := nodeResourceSignature(node, resource)
+		if _, ok := byNodeResourceSignature[signature]; !ok {
+			uniqueOrderedNRSignatures = append(uniqueOrderedNRSignatures, &signatureNodeResourceTriple{
+				node:      node,
+				resource:  resource,
+				signature: signature,
+			})
+		}
+		byNodeResourceSignature[signature] = append(byNodeResourceSignature[signature], metric)
+	}
+
+	// And finally since we now have the Node+Metric pairs ordered
+	for _, snrt := range uniqueOrderedNRSignatures {
+		metrics := byNodeResourceSignature[snrt.signature]
+		ereq := &agentmetricspb.ExportMetricsServiceRequest{
+			Node:     snrt.node,
+			Resource: snrt.resource,
+			Metrics:  metrics,
+		}
+		_ = ms.ReceiveMetrics(context.Background(), ereq)
+	}
+}
+
+func nodeResourceSignature(node *commonpb.Node, resource *resourcepb.Resource) string {
+	nodeSignature, _ := proto.Marshal(node)
+	resourceSignature, _ := proto.Marshal(resource)
+	return fmt.Sprintf("%s%s", nodeSignature, resourceSignature)
+}
+
+func labelValuesSignature(labelValues []*metricspb.LabelValue) string {
+	buf := new(strings.Builder)
+	for _, labelValue := range labelValues {
+		buf.WriteString(labelValue.Value)
+		fmt.Fprintf(buf, "%t", labelValue.HasValue)
+	}
+	return buf.String()
+}
+
+func createMetricsWithSameMetricDescriptorNodeResource(bundlings []*bundling) (*commonpb.Node, *resourcepb.Resource, *metricspb.Metric) {
+	// We've got to index by labelValues now too
+	// so that TimeSeries are easily compacted.
+	byLabelValuesIndex := make(map[string][]*bundling)
+	uniqueOrderedLabelValues := make([]string, 0, len(bundlings))
+	for _, bdl := range bundlings {
+		signature := labelValuesSignature(bdl.labelValues)
+		bdvl, ok := byLabelValuesIndex[signature]
+		if !ok {
+			uniqueOrderedLabelValues = append(uniqueOrderedLabelValues, signature)
+		}
+		bdvl = append(bdvl, bdl)
+		byLabelValuesIndex[signature] = bdvl
+	}
+
+	var timeseries []*metricspb.TimeSeries
+	for _, signature := range uniqueOrderedLabelValues {
+		bdls := byLabelValuesIndex[signature]
+		points := make([]*metricspb.Point, len(bdls))
+		for i, bdl := range bdls {
+			points[i] = bdl.point
+		}
+
+		bhead := bdls[0]
+		timeseries = append(timeseries, &metricspb.TimeSeries{
+			LabelValues:    bhead.labelValues,
+			StartTimestamp: bhead.ts,
+			Points:         points,
+		})
+	}
+
+	head := bundlings[0]
+	metric := &metricspb.Metric{
+		Descriptor_: &metricspb.Metric_MetricDescriptor{
+			MetricDescriptor: head.md,
+		},
+		Timeseries: timeseries,
+	}
+
+	return head.node, head.resource, metric
+}

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -28,7 +28,6 @@ import (
 	"github.com/census-instrumentation/opencensus-service/consumer"
 	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/receiver"
-	"github.com/orijtech/promreceiver"
 	"github.com/prometheus/prometheus/config"
 )
 
@@ -42,7 +41,7 @@ type Configuration struct {
 // Preceiver is the type that provides Prometheus scraper/receiver functionality.
 type Preceiver struct {
 	startOnce sync.Once
-	recv      *promreceiver.Receiver
+	recv      *preceiver
 	cfg       *Configuration
 }
 
@@ -107,12 +106,12 @@ func (pr *Preceiver) StartMetricsReception(ctx context.Context, nextConsumer con
 
 		tms := &promMetricsReceiverToOpenCensusMetricsReceiver{nextConsumer: nextConsumer}
 		cfg := pr.cfg
-		pr.recv, err = promreceiver.ReceiverFromConfig(
+		pr.recv, err = receiverFromConfig(
 			context.Background(),
 			tms,
 			cfg.ScrapeConfig,
-			promreceiver.WithBufferPeriod(cfg.BufferPeriod),
-			promreceiver.WithBufferCount(cfg.BufferCount))
+			WithBufferPeriod(cfg.BufferPeriod),
+			WithBufferCount(cfg.BufferCount))
 	})
 	return err
 }
@@ -133,7 +132,7 @@ type promMetricsReceiverToOpenCensusMetricsReceiver struct {
 	nextConsumer consumer.MetricsConsumer
 }
 
-var _ promreceiver.MetricsSink = (*promMetricsReceiverToOpenCensusMetricsReceiver)(nil)
+var _ metricsSink = (*promMetricsReceiverToOpenCensusMetricsReceiver)(nil)
 
 var errNilRequest = errors.New("expecting a non-nil request")
 

--- a/receiver/prometheusreceiver/options.go
+++ b/receiver/prometheusreceiver/options.go
@@ -1,0 +1,71 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusreceiver
+
+import (
+	"time"
+
+	gokitLog "github.com/go-kit/kit/log"
+)
+
+// Option is an interface to configure the receiver.
+type Option interface {
+	withCustomAppender(*customAppender)
+}
+
+type withBufferPeriod time.Duration
+
+func (wbp *withBufferPeriod) withCustomAppender(ca *customAppender) {
+	ca.metricsBufferPeriod = time.Duration(*wbp)
+}
+
+var _ Option = (*withBufferPeriod)(nil)
+
+// WithBufferPeriod configures the period for which the receiver will perform scrapes.
+func WithBufferPeriod(period time.Duration) Option {
+	wbp := withBufferPeriod(period)
+	return &wbp
+}
+
+type withBufferCount int
+
+func (wbc *withBufferCount) withCustomAppender(ca *customAppender) {
+	ca.metricsBufferCount = int(*wbc)
+}
+
+var _ Option = (*withBufferCount)(nil)
+
+// WithBufferCount configures the number of metrics that the receiver
+// buffers before it writes them to the underlying metrics sink.
+func WithBufferCount(count int) Option {
+	wbc := withBufferCount(count)
+	return &wbc
+}
+
+type withLogger struct {
+	logger gokitLog.Logger
+}
+
+func (wl *withLogger) withCustomAppender(ca *customAppender) {
+	ca.logger = wl.logger
+}
+
+var _ Option = (*withLogger)(nil)
+
+// WithLogger configures the underlying logger that the receiver will use.
+func WithLogger(lgr gokitLog.Logger) Option {
+	wl := withLogger{logger: lgr}
+	return &wl
+}

--- a/receiver/prometheusreceiver/receiver.go
+++ b/receiver/prometheusreceiver/receiver.go
@@ -1,0 +1,990 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusreceiver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	gokitLog "github.com/go-kit/kit/log"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+	sd_config "github.com/prometheus/prometheus/discovery/config"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/scrape"
+	"github.com/prometheus/prometheus/storage"
+
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"google.golang.org/api/support/bundler"
+)
+
+type metricsSink interface {
+	ReceiveMetrics(context.Context, *agentmetricspb.ExportMetricsServiceRequest) error
+}
+
+func newCustomAppender(ms metricsSink, opts ...Option) *customAppender {
+	ca := &customAppender{
+		metricsSink: ms,
+		metricsProcessor: &metricsProcessor{
+			definitionsByMetricName: make(map[string][]*bucketDefinition),
+			lastSeenData:            make(map[string]*lastSeenData),
+		},
+	}
+
+	for _, opt := range opts {
+		opt.withCustomAppender(ca)
+	}
+
+	allMetricsBundler := bundler.NewBundler((*bundling)(nil), func(data interface{}) {
+		bundlings := data.([]*bundling)
+		compactAndCombineMetrics(ms, bundlings)
+	})
+	allMetricsBundler.DelayThreshold = ca.metricsBufferPeriod
+	if allMetricsBundler.DelayThreshold <= 0 {
+		allMetricsBundler.DelayThreshold = 5 * time.Second // TODO: Make this configurable.
+	}
+	if allMetricsBundler.BundleCountThreshold <= 0 {
+		allMetricsBundler.BundleCountThreshold = 100 // TODO: Make this configurable.
+	}
+	ca.allMetricsBundler = allMetricsBundler
+
+	if ca.logger == nil {
+		ca.logger = gokitLog.NewNopLogger()
+	}
+
+	return ca
+}
+
+// Receiver
+type preceiver struct {
+	cancelOnce sync.Once
+	cancelFn   func()
+	flushFn    func()
+	errsChan   <-chan error
+}
+
+func (r *preceiver) Flush() {
+	r.flushFn()
+}
+
+func (r *preceiver) ErrsChan() <-chan error {
+	return r.errsChan
+}
+
+var errAlreadyCancelled = errors.New("already cancelled")
+
+func (r *preceiver) Cancel() error {
+	var err = errAlreadyCancelled
+	r.cancelOnce.Do(func() {
+		err = nil
+	})
+	return err
+}
+
+func receiverFromConfig(ctx context.Context, ms metricsSink, cfg *config.Config, opts ...Option) (*preceiver, error) {
+	capp := newCustomAppender(ms, opts...)
+	scrapeManager := scrape.NewManager(capp.logger, capp)
+	capp.scrapeManager = scrapeManager
+
+	ctxScrape, cancelScrape := context.WithCancel(ctx)
+
+	discoveryManagerScrape := discovery.NewManager(ctxScrape, capp.logger)
+	go discoveryManagerScrape.Run()
+	scrapeManager.ApplyConfig(cfg)
+
+	// Run the scrape manager.
+	syncConfig := make(chan bool)
+	errsChan := make(chan error, 1)
+	go func() {
+		defer close(errsChan)
+
+		<-time.After(100 * time.Millisecond)
+		close(syncConfig)
+		if err := scrapeManager.Run(discoveryManagerScrape.SyncCh()); err != nil {
+			errsChan <- err
+		}
+	}()
+	<-syncConfig
+	// By this point we've given time to the scrape manager
+	// to start applying its original configuration.
+
+	discoveryCfg := make(map[string]sd_config.ServiceDiscoveryConfig)
+	for _, scrapeConfig := range cfg.ScrapeConfigs {
+		discoveryCfg[scrapeConfig.JobName] = scrapeConfig.ServiceDiscoveryConfig
+	}
+
+	// Now trigger the discovery notification to the scrape manager.
+	discoveryManagerScrape.ApplyConfig(discoveryCfg)
+
+	rcv := &preceiver{
+		cancelFn: cancelScrape,
+		errsChan: errsChan,
+		flushFn:  capp.flush,
+	}
+
+	return rcv, nil
+}
+
+type customAppender struct {
+	allMetricsBundler   *bundler.Bundler
+	logger              gokitLog.Logger
+	metricsBufferPeriod time.Duration
+	metricsBufferCount  int
+	scrapeManager       *scrape.Manager
+	metricsProcessor    *metricsProcessor
+	metricsSink         metricsSink
+}
+
+var _ scrape.Appendable = (*customAppender)(nil)
+
+func (ca *customAppender) Appender() (storage.Appender, error) {
+	return ca, nil
+}
+
+func (ca *customAppender) flush() {
+	ca.allMetricsBundler.Flush()
+}
+
+func (ca *customAppender) Commit() error   { return nil }
+func (ca *customAppender) Rollback() error { return nil }
+
+func (ca *customAppender) Add(l labels.Labels, t int64, v float64) (uint64, error) {
+	return uint64(t + 1), ca.processMetrics(l, 0, t, v)
+}
+
+func (ca *customAppender) AddFast(l labels.Labels, ref uint64, t int64, v float64) error {
+	return ca.processMetrics(l, ref, t, v)
+}
+
+func (ca *customAppender) processMetrics(l labels.Labels, ref uint64, t int64, v float64) error {
+	metricName, metadata, scheme, err := ca.parseMetadata(l)
+	if err != nil {
+		return err
+	}
+
+	switch metadataType := string(metadata.Type); strings.ToLower(metadataType) {
+	case "gaugehistogram", "histogram":
+		return ca.processHistogramLikeMetrics(metricName, metadata, scheme, l, ref, t, v)
+
+	default:
+		return ca.processNonHistogramLikeMetrics(metricName, metadata, scheme, l, ref, t, v)
+	}
+}
+
+func (ca *customAppender) parseMetadata(labelsList labels.Labels) (string, *scrape.MetricMetadata, string, error) {
+	var jobName, metricName string
+
+	for _, label := range labelsList {
+		switch label.Name {
+		case labels.MetricName:
+			metricName = label.Value
+			// Don't waste time processing Prometheus scrape metrics.
+			if metricName == "up" || strings.HasPrefix(metricName, "scrape_") {
+				return "", nil, "", fmt.Errorf("%q is not an interesting metric", metricName)
+			}
+
+			switch {
+			case strings.HasSuffix(metricName, "_count"):
+				metricName = strings.TrimSuffix(metricName, "_count")
+
+			case strings.HasSuffix(metricName, "_sum"):
+				metricName = strings.TrimSuffix(metricName, "_sum")
+
+			case strings.HasSuffix(metricName, "_bucket"):
+				// Keep this metricName as is because, it'll be processed
+				// later on and have its suffix trimmed if necessary.
+			}
+		case "job":
+			jobName = label.Value
+
+		case labels.BucketLabel:
+			if len(metricName) > 0 {
+				lastUnderscoreIndex := strings.LastIndex(metricName, "_")
+				if lastUnderscoreIndex > 0 {
+					metricName = metricName[:lastUnderscoreIndex]
+				}
+			}
+		}
+	}
+
+	targets := ca.scrapeManager.TargetsAll()
+	var metadata *scrape.MetricMetadata
+	var scheme string
+
+	jobTargets := targets[jobName]
+	for _, target := range jobTargets {
+		if metadata == nil {
+			m, ok := target.Metadata(metricName)
+			if ok {
+				metadata = new(scrape.MetricMetadata)
+				*metadata = m
+
+				discoveredLabels := target.DiscoveredLabels()
+				for _, discoveredLabel := range discoveredLabels {
+					switch discoveredLabel.Name {
+					case "__scheme__":
+						scheme = discoveredLabel.Value
+					}
+				}
+			}
+		}
+	}
+
+	var err error
+	if metadata == nil {
+		err = errNoMetadata
+	} else if metadata.Unit == "" { // Try to infer the metricName and unit heuristically.
+		metricName, metadata.Unit = heuristicalMetricAndKnownUnits(metricName)
+	}
+
+	return metricName, metadata, scheme, err
+}
+
+var (
+	errNoMetadata = errors.New("no metadata was parsed")
+	errStaleData  = errors.New("encountered stale data since last scrape")
+	errNilMetric  = errors.New("expected a non-nil Metric")
+)
+
+type metricsProcessor struct {
+	mu sync.RWMutex
+
+	definitionsByMetricName map[string][]*bucketDefinition
+	lastSeenData            map[string]*lastSeenData
+}
+
+type lastSeenData struct {
+	lastSeenSum          float64
+	lastSeenValue        float64
+	lastSeenCount        float64
+	lastSeenBucketCounts []float64
+
+	// These times below are useful
+	// to aid in garbage collection.
+	lastTouchTime time.Time
+}
+
+func (mp *metricsProcessor) lastSeenSum(key string) (sum float64) {
+	mp.mu.RLock()
+	defer mp.mu.RUnlock()
+
+	lsbd := mp.lastSeenData[key]
+	if lsbd != nil {
+		sum = lsbd.lastSeenSum
+	}
+	return
+}
+
+func (mp *metricsProcessor) lastSeenBucketCounts(key string) (bucketCounts []float64) {
+	mp.mu.RLock()
+	defer mp.mu.RUnlock()
+
+	lsbd := mp.lastSeenData[key]
+	if lsbd != nil {
+		bucketCounts = lsbd.lastSeenBucketCounts
+	}
+	return
+}
+
+func (mp *metricsProcessor) lastSeenCount(key string) (count float64) {
+	mp.mu.RLock()
+	defer mp.mu.RUnlock()
+
+	lsbd := mp.lastSeenData[key]
+	if lsbd != nil {
+		count = lsbd.lastSeenCount
+	}
+	return
+}
+
+func (mp *metricsProcessor) lastSeenValue(key string) (value float64) {
+	mp.mu.RLock()
+	defer mp.mu.RUnlock()
+
+	lsbd := mp.lastSeenData[key]
+	if lsbd != nil {
+		value = lsbd.lastSeenValue
+	}
+	return
+}
+
+func (mp *metricsProcessor) withNonNilAndToBeSavedBucketData(key string, useIt func(*lastSeenData)) {
+	mp.mu.Lock()
+	defer mp.mu.Unlock()
+
+	lsbd, ok := mp.lastSeenData[key]
+	if !ok || lsbd == nil {
+		lsbd = new(lastSeenData)
+	}
+	useIt(lsbd)
+
+	// Update the last touch time in order to aid
+	// with eviction of least recently used items.
+	lsbd.lastTouchTime = time.Now().UTC()
+
+	mp.lastSeenData[key] = lsbd
+}
+
+func (mp *metricsProcessor) clearLastSeenBucketCounts(key string) {
+	mp.mu.Lock()
+	defer mp.mu.Unlock()
+
+	lsbd, ok := mp.lastSeenData[key]
+	if ok && lsbd != nil {
+		lsbd.lastSeenBucketCounts = lsbd.lastSeenBucketCounts[:0]
+	}
+}
+
+func (mp *metricsProcessor) setLastSeenSum(key string, newSum float64) {
+	mp.withNonNilAndToBeSavedBucketData(key, func(lsbd *lastSeenData) {
+		lsbd.lastSeenSum = newSum
+	})
+}
+
+func (mp *metricsProcessor) setLastSeenBucketCounts(key string, newBucketCounts []float64) {
+	mp.withNonNilAndToBeSavedBucketData(key, func(lsbd *lastSeenData) {
+		lsbd.lastSeenBucketCounts = newBucketCounts
+	})
+}
+
+func (mp *metricsProcessor) setLastSeenCount(key string, newCount float64) {
+	mp.withNonNilAndToBeSavedBucketData(key, func(lsbd *lastSeenData) {
+		lsbd.lastSeenCount = newCount
+	})
+}
+
+func (mp *metricsProcessor) setLastSeenValue(key string, newValue float64) {
+	mp.withNonNilAndToBeSavedBucketData(key, func(lsbd *lastSeenData) {
+		lsbd.lastSeenValue = newValue
+	})
+}
+
+func isInfBucket(def *bucketDefinition) bool {
+	if def == nil {
+		return false
+	}
+	return math.IsInf(def.bucketBoundary, -1) || math.IsInf(def.bucketBoundary, +1)
+}
+
+func (ca *customAppender) processHistogramLikeMetrics(metricName string, metadata *scrape.MetricMetadata, scheme string, labelsList labels.Labels, ref uint64, timeAtMs int64, value float64) error {
+	bdef, err := ca.parseDistributions(metadata, scheme, labelsList, ref, timeAtMs, value)
+	if err != nil {
+		return err
+	}
+
+	key := hash(bdef.metricName, bdef.orderedTags)
+
+	// Get the stored stack first.
+	mp := ca.metricsProcessor
+	stack := mp.definitionsByMetricName[key]
+
+	// Before processing a metric, we have to have all 3 markers:
+	// * bucket
+	// * sum
+	// * count
+	var typeBitSet distributionMarker
+	var hasTerminalBucketInf bool
+	for _, def := range stack {
+		typeBitSet |= def.marker
+		if isInfBucket(def) {
+			hasTerminalBucketInf = true
+		}
+	}
+
+	hasAllMarkers := (typeBitSet & allMarkersSet) == allMarkersSet
+	readyForProcessing := hasAllMarkers && hasTerminalBucketInf
+	if !readyForProcessing {
+		stack = append(stack, bdef)
+		mp.definitionsByMetricName[key] = stack
+		return nil
+	}
+
+	// Otherwise we are at terminal state for this bucket
+	// and we can now compile the metric.
+	// Firstly, unmemoize the stack of bucket definitions.
+	delete(mp.definitionsByMetricName, key)
+
+	// Filter out the bucket with Inf
+	var infBucket *bucketDefinition
+
+	var maxSum float64
+	var buckets []*bucketDefinition // All the buckets with the InfBucket excluded.
+	for _, definition := range stack {
+		switch definition.marker {
+		case markerBucket:
+			if isInfBucket(definition) {
+				infBucket = definition
+			} else {
+				buckets = append(buckets, definition)
+			}
+
+		case markerSum:
+			if definition.sum > maxSum {
+				maxSum = definition.sum
+			}
+		}
+	}
+
+	// Sort them by bucket boundaries firstly.
+	sort.Slice(buckets, func(i, j int) bool {
+		bdi, bdj := buckets[i], buckets[j]
+		return bdi.bucketBoundary < bdj.bucketBoundary
+	})
+
+	// Now given that the bucket boundaries are sorted, the last
+	// bucket is the terminal bucket i.e. Inf. Its values are the
+	// remnants on the outer side of the last bucket.
+	if n := len(buckets); n > 0 {
+		lastNonInfiniteBucket := buckets[n-1]
+		if diff := infBucket.bucketCount - lastNonInfiniteBucket.bucketCount; diff > 0 {
+			lastNonInfiniteBucket.sum += infBucket.sum
+			lastNonInfiniteBucket.totalCount += infBucket.totalCount
+			lastNonInfiniteBucket.bucketCount += infBucket.bucketCount
+			buckets[n-1] = lastNonInfiniteBucket
+		}
+	}
+
+	monotonicCounts := make([]float64, len(buckets))
+	rawBucketBounds := make([]float64, len(buckets))
+	for i, bd := range buckets {
+		monotonicCounts[i] = bd.bucketCount
+		rawBucketBounds[i] = bd.bucketBoundary
+	}
+
+	// Because Prometheus cumulatively inserts counts.
+	// We need to further subtract counts from the counts
+	// that were performed during the last scrape.
+	// This is more of a heuristic because if sources are taken
+	// down then resurrected, in the midst of a scrape, that will
+	// yield inaccurate results.
+	lastSeenBucketCounts := mp.lastSeenBucketCounts(key)
+	lastSeenSum := mp.lastSeenSum(key)
+
+	if len(lastSeenBucketCounts) != len(monotonicCounts) { // Perhaps the first time.
+		mp.setLastSeenBucketCounts(key, monotonicCounts[:])
+		mp.setLastSeenSum(key, maxSum)
+	} else { // This is a probable match for values we've probably already seen.
+		dedupedBucketCounts := make([]float64, len(monotonicCounts))
+		// If a scrape target was restarted, its "cumulative" bucket counts
+		// will all start afresh. However, since Prometheus buckets are cumulative,
+		// doing: now[i] - prev[i] should always result in >=0
+		// thus any deduped value that's <0 indicates that we should discard
+		// any deduplication processes and that this is the first of its kind
+		// data being scraped.
+		canDedupe := true
+		for i, nowi := range monotonicCounts {
+			previ := lastSeenBucketCounts[i]
+			deduped := nowi - previ
+			if deduped < 0 { // No need to proceed with deduplication.
+				canDedupe = false
+				break
+			}
+
+			// Otherwise good to go on with deduplication.
+			dedupedBucketCounts[i] = deduped
+			// In place replace the old counts with the new ones.
+			lastSeenBucketCounts[i] = nowi
+		}
+
+		if !canDedupe {
+			// This data is the first of its kind and could most
+			// probably indicate that a scrape target was taken down
+			// or all its data cleared hence it started afresh.
+			mp.clearLastSeenBucketCounts(key)
+			return nil
+		}
+
+		// Otherwise now memoize the deduped bucket counts
+		// for memoization in the next cycle of scraping.
+		mp.setLastSeenBucketCounts(key, lastSeenBucketCounts[:])
+		// Also memoize the last seen sum.
+		mp.setLastSeenSum(key, maxSum)
+		monotonicCounts = dedupedBucketCounts
+	}
+
+	// Since Prometheus values are monotonically accumulated, let's isolate discrete counts.
+	discreteCounts := make([]float64, len(monotonicCounts))
+	var lastSeenCount float64
+	var totalCount float64
+	var maxPlausibleSum float64
+	for i, monotonicCount := range monotonicCounts {
+		// Buckets are monotonic i.e. either all increasing or all decreasing.
+		// Hence, we need to subtract the current count from the last seen count.
+		discreteCount := monotonicCount - lastSeenCount
+		discreteCounts[i] = discreteCount
+		totalCount += discreteCount
+		maxPlausibleSum += (discreteCount * rawBucketBounds[i])
+		lastSeenCount = monotonicCount
+	}
+
+	instantenousSum := maxSum - lastSeenSum
+	// fmt.Printf("DiscreteCounts:       %+v\n\nLastSeenSum: %.3f\nMaxSum:      %.3f\nDiff:        %.3f\033[00m\n\n",
+	// 	discreteCounts, lastSeenSum, maxSum, instantenousSum)
+	// Sanity checks, if the count is unrelatable
+	// to the bucket counts we'll reject this data.
+	if instantenousSum > maxPlausibleSum {
+		// This data is invalid. It is impossible for the instantenous
+		// sum to be greater than the maximum plausible sum.
+		// fmt.Printf("\033[31mInvalidating %+v because\n*instantaneousSum(%.3f) > maxPlausibleSum(%.3f)\033[00m\n\n",
+		// 	discreteCounts, instantenousSum, maxPlausibleSum)
+		return nil
+	} else if instantenousSum <= 0.0 && maxPlausibleSum > 0 {
+		// Clearly there is a miscalculation with the last scraped sum
+		// because instantenousSum can't be <= 0.0 yet here we have
+		// at least 1 element.
+	}
+
+	var mean float64
+	if totalCount > 0 {
+		mean = instantenousSum / totalCount
+	} else {
+		instantenousSum = 0.0
+	}
+
+	var sumOfSquaredDeviation float64
+	protoBuckets := make([]*metricspb.DistributionValue_Bucket, len(discreteCounts))
+	for i := 0; i < len(discreteCounts); i++ {
+		discreteCount := discreteCounts[i]
+		sumOfSquaredDeviation += math.Pow(discreteCount-mean, 2)
+		protoBuckets[i] = &metricspb.DistributionValue_Bucket{
+			Count: int64(discreteCount),
+		}
+	}
+
+	// TODO(@odeke-em): For consistency, ensure that all the discrete
+	// parts of a distribution share the exact same timestamp.
+	startTimestamp := timestampFromMs(infBucket.timeAtMs)
+
+	dv := &metricspb.DistributionValue{
+		Buckets:               protoBuckets,
+		Count:                 int64(totalCount),
+		Sum:                   instantenousSum,
+		SumOfSquaredDeviation: sumOfSquaredDeviation,
+		BucketOptions: &metricspb.DistributionValue_BucketOptions{
+			Type: &metricspb.DistributionValue_BucketOptions_Explicit_{
+				Explicit: &metricspb.DistributionValue_BucketOptions_Explicit{
+					Bounds: rawBucketBounds,
+				},
+			},
+		},
+	}
+
+	labelKeys, labelValues := orderedTagsToLabelKeysLabelValues(infBucket.orderedTags)
+	point := &metricspb.Point{
+		Timestamp: startTimestamp,
+		Value: &metricspb.Point_DistributionValue{
+			DistributionValue: dv,
+		},
+	}
+
+	md := &metricspb.MetricDescriptor{
+		Name:        infBucket.metricName,
+		Description: infBucket.description,
+		Unit:        infBucket.unit,
+		Type:        infBucket.typ,
+		LabelKeys:   labelKeys,
+	}
+
+	node := nodeFromJobNameAddress(infBucket.nodeName, infBucket.address, infBucket.scheme)
+
+	bdl := &bundling{
+		md:          md,
+		node:        node,
+		resource:    nil,
+		point:       point,
+		ts:          startTimestamp,
+		labelValues: labelValues,
+	}
+
+	ca.allMetricsBundler.Add(bdl, 1)
+
+	return nil
+}
+
+type distributionMarker int
+
+const (
+	markerCount distributionMarker = 1 + (iota << 1)
+	markerSum
+	markerBucket
+)
+
+const allMarkersSet = markerCount | markerSum | markerBucket
+
+type bucketDefinition struct {
+	sum        float64
+	typ        metricspb.MetricDescriptor_Type
+	unit       string
+	metricName string
+	nodeName   string
+	scheme     string
+	address    string
+
+	timeAtMs       int64
+	totalCount     float64
+	bucketBoundary float64
+	bucketCount    float64
+	description    string
+	marker         distributionMarker
+	orderedTags    labels.Labels
+}
+
+var errNotHistogramLike = errors.New("not histogram-like")
+
+func (ca *customAppender) parseDistributions(metadata *scrape.MetricMetadata, scheme string, labelsList labels.Labels, ref uint64, timeAtMs int64, value float64) (*bucketDefinition, error) {
+	var address, metricName, jobName, distributionQualifier string
+	var bucketBoundary float64
+	var sum, totalCount float64
+	var orderedTags labels.Labels
+
+	for _, label := range labelsList {
+		switch label.Name {
+		case labels.MetricName:
+			metricName = label.Value
+			// Don't waste time processing Prometheus scrape metrics.
+			if metricName == "up" || strings.HasPrefix(metricName, "scrape_") {
+				return nil, fmt.Errorf("%q is not an interesting metric", metricName)
+			}
+
+			switch {
+			case strings.HasSuffix(metricName, "_count"):
+				totalCount = value
+				metricName = strings.TrimSuffix(metricName, "_count")
+				distributionQualifier = "count"
+
+			case strings.HasSuffix(metricName, "_sum"):
+				distributionQualifier = "sum"
+				metricName = strings.TrimSuffix(metricName, "_sum")
+				sum = value
+
+			case strings.HasSuffix(metricName, "_bucket"):
+				distributionQualifier = "bucket"
+
+			default:
+				orderedTags = append(orderedTags, label)
+			}
+
+		case labels.BucketLabel:
+			bucketBoundary, _ = strconv.ParseFloat(label.Value, 64)
+			if len(metricName) > 0 {
+				lastUnderscoreIndex := strings.LastIndex(metricName, "_")
+				if lastUnderscoreIndex > 0 {
+					distributionQualifier = metricName[lastUnderscoreIndex+1:]
+					metricName = metricName[:lastUnderscoreIndex]
+				}
+			}
+
+		case "job":
+			// Do nothing
+			jobName = label.Value
+
+		case labels.InstanceName:
+			address = label.Value
+
+		default:
+			orderedTags = append(orderedTags, label)
+		}
+	}
+
+	if metadata == nil {
+		// By this point, we don't have the metadata necessary to
+		// construct an OpenCensus Metric from this scraped data.
+		// Perhaps this could be a result from this scraper monitoring itself.
+		return nil, errNoMetadata
+	}
+
+	if metadata.Unit == "" { // Try to infer the metricName and unit heuristically.
+		metricName, metadata.Unit = heuristicalMetricAndKnownUnits(metricName)
+	}
+
+	definition := &bucketDefinition{
+		address:     address,
+		description: metadata.Help,
+		scheme:      scheme,
+		nodeName:    jobName,
+		orderedTags: orderedTags,
+		timeAtMs:    timeAtMs,
+		unit:        metadata.Unit,
+	}
+
+	switch metadataType := string(metadata.Type); strings.ToLower(metadataType) {
+	case "gaugehistogram", "histogram":
+		typ := metricspb.MetricDescriptor_GAUGE_DISTRIBUTION
+		if metadataType == "histogram" {
+			typ = metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION
+		}
+		definition.typ = typ
+
+		switch distributionQualifier {
+		case "sum":
+			definition.sum = sum
+			definition.marker = markerSum
+
+		case "count":
+			definition.totalCount = totalCount
+			definition.marker = markerCount
+
+		case "bucket":
+			definition.bucketBoundary = bucketBoundary
+			definition.bucketCount = value
+			definition.marker = markerBucket
+		}
+
+		definition.metricName = strings.TrimSuffix(metricName, "_"+distributionQualifier)
+
+	default:
+		return nil, errNotHistogramLike
+	}
+
+	return definition, nil
+}
+
+func (ca *customAppender) processNonHistogramLikeMetrics(metricName string, metadata *scrape.MetricMetadata, scheme string, labelsList labels.Labels, ref uint64, timeAtMs int64, value float64) error {
+	var address, jobName string
+	var orderedTags labels.Labels
+
+	for _, label := range labelsList {
+		switch label.Name {
+		case "job":
+			jobName = label.Value
+
+		case labels.BucketLabel:
+			// Should not happen since buckets are processed in a
+			// different route but nonetheless, do nothing here.
+
+		case labels.InstanceName:
+			address = label.Value
+
+		case labels.AlertName:
+			// Do nothing.
+
+		case labels.MetricName:
+			// Do nothing.
+
+		default:
+			orderedTags = append(orderedTags, label)
+		}
+	}
+
+	if metadata == nil {
+		// By this point, we don't have the metadata necessary to
+		// construct an OpenCensus Metric from this scraped data.
+		// Perhaps this could be a result from this scraper monitoring itself.
+		return errNoMetadata
+	}
+
+	if metadata.Unit == "" { // Try to infer the metricName and unit heuristically.
+		metricName, metadata.Unit = heuristicalMetricAndKnownUnits(metricName)
+	}
+
+	// And now it is conversion time.
+
+	atTimestamp := timestampFromMs(timeAtMs)
+	point := &metricspb.Point{
+		Timestamp: atTimestamp,
+	}
+
+	labelKeys, labelValues := orderedTagsToLabelKeysLabelValues(orderedTags)
+	var metricDescriptor *metricspb.MetricDescriptor
+
+	switch metadataType := string(metadata.Type); strings.ToLower(metadataType) {
+	case "counter":
+		mp := ca.metricsProcessor
+		key := hash(metricName, orderedTags)
+		lastSeenCount := mp.lastSeenCount(key)
+		// Memoize the current value as the last seen count.
+		mp.setLastSeenCount(key, value)
+
+		// Now compute the discrete count since
+		// Prometheus data is cumulatively stored.
+		discreteCount := value - lastSeenCount
+		if discreteCount < 0 {
+			// This is stale data that we are dealing with.
+			// We need to discard it.
+			return errStaleData
+		}
+
+		metricDescriptor = &metricspb.MetricDescriptor{
+			Name:        metricName,
+			Unit:        metadata.Unit,
+			Description: metadata.Help,
+			Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+			LabelKeys:   labelKeys,
+		}
+		point.Value = &metricspb.Point_Int64Value{
+			Int64Value: int64(math.Round(discreteCount)),
+		}
+
+	case "gauge":
+		mp := ca.metricsProcessor
+		key := hash(metricName, orderedTags)
+		lastSeenValue := mp.lastSeenValue(key)
+		// Memoize the current value as the last seen count.
+		mp.setLastSeenValue(key, value)
+
+		// Now compute the discrete value since
+		// Prometheus data is cumulatively stored.
+		discreteValue := value - lastSeenValue
+		if discreteValue < 0 {
+			// This is stale data that we are dealing with.
+			// We need to discard it.
+			return errStaleData
+		}
+
+		metricDescriptor = &metricspb.MetricDescriptor{
+			Name:        metricName,
+			Unit:        metadata.Unit,
+			Description: metadata.Help,
+			Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
+			LabelKeys:   labelKeys,
+		}
+		point.Value = &metricspb.Point_DoubleValue{
+			DoubleValue: discreteValue,
+		}
+
+	default:
+		return fmt.Errorf("unknown recognized metric type: %s", metadataType)
+	}
+
+	node := nodeFromJobNameAddress(jobName, address, scheme)
+	bdl := &bundling{
+		md:          metricDescriptor,
+		node:        node,
+		resource:    nil,
+		point:       point,
+		ts:          atTimestamp,
+		labelValues: labelValues,
+	}
+
+	ca.allMetricsBundler.Add(bdl, 1)
+	return nil
+}
+
+func nodeFromJobNameAddress(jobName, address, scheme string) *commonpb.Node {
+	if jobName == "" && address == "" {
+		return nil
+	}
+	var serviceInfo *commonpb.ServiceInfo
+	if jobName != "" {
+		serviceInfo = &commonpb.ServiceInfo{Name: jobName}
+	}
+	var processIdentifier *commonpb.ProcessIdentifier
+	var host, port string
+	if address != "" {
+		host, port = hostPort(address)
+		processIdentifier = &commonpb.ProcessIdentifier{
+			HostName: host,
+		}
+	}
+	node := &commonpb.Node{
+		ServiceInfo: serviceInfo,
+		Identifier:  processIdentifier,
+		Attributes: map[string]string{
+			"scheme": scheme,
+			"port":   port,
+		},
+	}
+	return node
+}
+
+func heuristicalMetricAndKnownUnits(metricName string) (finalMetricName, unit string) {
+	lastUnderscoreIndex := strings.LastIndex(metricName, "_")
+	if lastUnderscoreIndex <= 0 || lastUnderscoreIndex >= len(metricName)-1 {
+		return metricName, ""
+	}
+
+	supposedUnit := metricName[lastUnderscoreIndex+1:]
+	switch strings.ToLower(supposedUnit) {
+	case "millisecond", "milliseconds", "ms":
+		unit = "ms"
+	case "second", "seconds", "s":
+		unit = "s"
+	case "microsecond", "microseconds", "us":
+		unit = "us"
+	case "nanosecond", "nanoseconds", "ns":
+		unit = "ns"
+	case "byte", "bytes", "by":
+		unit = "By"
+	case "bit", "bits":
+		unit = "By"
+	case "kilogram", "kilograms", "kg":
+		unit = "kg"
+	case "gram", "grams", "g":
+		unit = "g"
+	case "meter", "meters", "metre", "metres", "m":
+		unit = "m"
+	case "kilometer", "kilometers", "kilometre", "kilometres", "km":
+		unit = "km"
+	case "milimeter", "milimeters", "milimetre", "milimetres", "mm":
+		unit = "mm"
+	case "nanogram", "ng", "nanograms":
+		unit = "ng"
+	}
+
+	if unit != "" { // A heuristic matched a probable unit, so perform the split.
+		finalMetricName = metricName[:lastUnderscoreIndex]
+	} else {
+		finalMetricName = metricName
+	}
+
+	return finalMetricName, unit
+}
+
+func hostPort(addr string) (host, port string) {
+	if index := strings.LastIndex(addr, ":"); index < 0 {
+		host = addr
+	} else {
+		host, port = addr[:index], addr[index+1:]
+	}
+	return
+}
+
+func hash(metricName string, orderedTags labels.Labels) string {
+	return fmt.Sprintf("%s-%d", metricName, orderedTags.Hash())
+}
+
+func orderedTagsToLabelKeysLabelValues(orderedTags labels.Labels) (labelKeys []*metricspb.LabelKey, labelValues []*metricspb.LabelValue) {
+	if len(orderedTags) == 0 {
+		return
+	}
+
+	labelKeys = make([]*metricspb.LabelKey, len(orderedTags))
+	labelValues = make([]*metricspb.LabelValue, len(orderedTags))
+	for i, tag := range orderedTags {
+		labelKeys[i] = &metricspb.LabelKey{Key: tag.Name}
+		labelValues[i] = &metricspb.LabelValue{Value: tag.Value}
+	}
+
+	return
+}
+
+func timestampFromMs(timeAtMs int64) *timestamp.Timestamp {
+	secs, ns := timeAtMs/1e3, (timeAtMs%1e3)*1e6
+	return &timestamp.Timestamp{
+		Seconds: secs,
+		Nanos:   int32(ns),
+	}
+}

--- a/receiver/prometheusreceiver/receiver_test.go
+++ b/receiver/prometheusreceiver/receiver_test.go
@@ -1,0 +1,1382 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusreceiver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/textparse"
+	"github.com/prometheus/prometheus/scrape"
+
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+)
+
+func TestReceiver(t *testing.T) {
+	// Start a Prometheus server with various configurations
+	nreqs := int64(0)
+	done := make(chan bool)
+	cst := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		select {
+		case <-done:
+			http.Error(rw, "Shutdown already", http.StatusBadRequest)
+		default:
+		}
+
+		// The number of requests
+		ireqPlus1 := atomic.AddInt64(&nreqs, 1)
+		if ireqPlus1 > int64(len(pages)) {
+			close(done)
+			http.Error(rw, "No more pages", http.StatusBadRequest)
+			return
+		}
+
+		page := pages[ireqPlus1-1]
+		rw.Write([]byte(page))
+	}))
+	defer cst.Close()
+
+	ux, _ := url.Parse(cst.URL)
+	rawConfig := fmt.Sprintf(`
+scrape_configs:
+  - job_name: 'test'
+
+    scrape_interval: 80ms
+
+    static_configs:
+      - targets: ['%s']`, ux.Host)
+
+	ma := new(metricsAppender)
+	cfg, err := config.Load(rawConfig)
+	if err != nil {
+		t.Fatalf("Failed to load the Prometheus configuration: %v", err)
+	}
+
+	recv, _ := receiverFromConfig(context.Background(), ma, cfg)
+	defer recv.Cancel()
+
+	// Wait until all the requests are sent.
+	<-done
+
+	recv.Flush()
+
+	ma.forEachExportMetricsServiceRequest(func(ereq *agentmetricspb.ExportMetricsServiceRequest) {
+		blob, _ := json.MarshalIndent(ereq, "", "  ")
+		t.Logf("\n%s\n\n", blob)
+	})
+}
+
+func TestProcessNonHistogramLikeMetrics(t *testing.T) {
+	ma := new(metricsAppender)
+	ca := newCustomAppender(ma)
+
+	values := []struct {
+		metricName string
+		metadata   *scrape.MetricMetadata
+		scheme     string
+		labelsList labels.Labels
+		wantErr    string
+		timeAtMs   int64
+		ref        uint64
+		value      float64
+		want       []*agentmetricspb.ExportMetricsServiceRequest
+	}{
+		{
+			metricName: "call_counts",
+			labelsList: labels.Labels{
+				{Name: "client", Value: "mt-java@0.2.7"},
+				{Name: "os", Value: "windows"},
+				{Name: "method", Value: "java.sql.Statement.executeQuery"},
+				{Name: "status", Value: "OK"},
+			},
+			value:    100.9,
+			timeAtMs: 1549154046078,
+			metadata: &scrape.MetricMetadata{
+				Unit:   "1",
+				Help:   "The number of calls",
+				Metric: "call_counts",
+				Type:   textparse.MetricType("counter"),
+			},
+			want: []*agentmetricspb.ExportMetricsServiceRequest{
+				{
+					Metrics: []*metricspb.Metric{
+						{
+
+							Descriptor_: &metricspb.Metric_MetricDescriptor{
+								MetricDescriptor: &metricspb.MetricDescriptor{
+									Name:        "call_counts",
+									Description: "The number of calls",
+									Unit:        "1",
+									Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+									LabelKeys: []*metricspb.LabelKey{
+										{Key: "client"},
+										{Key: "os"},
+										{Key: "method"},
+										{Key: "status"},
+									},
+								},
+							},
+							Timeseries: []*metricspb.TimeSeries{
+								{
+									StartTimestamp: timestampFromMs(1549154046078),
+									LabelValues: []*metricspb.LabelValue{
+										{Value: "mt-java@0.2.7"},
+										{Value: "windows"},
+										{Value: "java.sql.Statement.executeQuery"},
+										{Value: "OK"},
+									},
+									Points: []*metricspb.Point{
+										{
+											Timestamp: timestampFromMs(1549154046078),
+											Value: &metricspb.Point_Int64Value{
+												Int64Value: 101,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tt := range values {
+		err := ca.processNonHistogramLikeMetrics(tt.metricName, tt.metadata, tt.scheme, tt.labelsList, tt.ref, tt.timeAtMs, tt.value)
+		if tt.wantErr != "" {
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("#%d: unexpected error %v wanted %s", i, err, tt.wantErr)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("#%d: unexpected error: %v", i, err)
+			continue
+		}
+		ca.flush()
+
+		got := ma.clearAllExportMetricsServiceRequest()
+		if !reflect.DeepEqual(got, tt.want) {
+			gb, wb := asJSON(got), asJSON(tt.want)
+			if gb != wb {
+				t.Errorf("#%d:\nGot:\n%s\n\nWant:\n%s\n\n", i, gb, wb)
+			}
+		}
+	}
+}
+
+func asJSON(v interface{}) string {
+	blob, _ := json.MarshalIndent(v, "", "  ")
+	return string(blob)
+}
+
+type metricsAppender struct {
+	mu    sync.Mutex
+	ereqs []*agentmetricspb.ExportMetricsServiceRequest
+}
+
+var _ metricsSink = (*metricsAppender)(nil)
+
+func (ma *metricsAppender) ReceiveMetrics(ctx context.Context, ereq *agentmetricspb.ExportMetricsServiceRequest) error {
+	ma.mu.Lock()
+	defer ma.mu.Unlock()
+
+	ma.ereqs = append(ma.ereqs, ereq)
+
+	return nil
+}
+
+func (ma *metricsAppender) clearAllExportMetricsServiceRequest() []*agentmetricspb.ExportMetricsServiceRequest {
+	ma.mu.Lock()
+	defer ma.mu.Unlock()
+
+	ereqs := ma.ereqs[:]
+	ma.ereqs = ma.ereqs[:0]
+
+	return ereqs
+}
+
+func (ma *metricsAppender) forEachExportMetricsServiceRequest(fn func(ereq *agentmetricspb.ExportMetricsServiceRequest)) {
+	ma.mu.Lock()
+	defer ma.mu.Unlock()
+
+	for _, ereq := range ma.ereqs {
+		fn(ereq)
+	}
+}
+
+var pages = []string{
+	`
+# HELP opdemo_latency The various latencies of the methods
+# TYPE opdemo_latency histogram
+opdemo_latency_bucket{client="cli",method="repl",le="0"} 0
+opdemo_latency_bucket{client="cli",method="repl",le="10"} 56
+opdemo_latency_bucket{client="cli",method="repl",le="50"} 272
+opdemo_latency_bucket{client="cli",method="repl",le="100"} 482
+opdemo_latency_bucket{client="cli",method="repl",le="200"} 497
+opdemo_latency_bucket{client="cli",method="repl",le="400"} 535
+opdemo_latency_bucket{client="cli",method="repl",le="800"} 588
+opdemo_latency_bucket{client="cli",method="repl",le="1000"} 609
+opdemo_latency_bucket{client="cli",method="repl",le="1400"} 627
+opdemo_latency_bucket{client="cli",method="repl",le="2000"} 630
+opdemo_latency_bucket{client="cli",method="repl",le="5000"} 653
+opdemo_latency_bucket{client="cli",method="repl",le="10000"} 680
+opdemo_latency_bucket{client="cli",method="repl",le="15000"} 695
+opdemo_latency_bucket{client="cli",method="repl",le="+Inf"} 702
+opdemo_latency_sum{client="cli",method="repl"} 669824.6063739995
+opdemo_latency_count{client="cli",method="repl"} 702
+# HELP opdemo_process_counts The various counts
+# TYPE opdemo_process_counts counter
+opdemo_process_counts{client="cli",method="repl"} 702`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 13.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 15.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 15.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 1.413127
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 14.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 14.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 14.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 14.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 14.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 14.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 15.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 15.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 19.856447999999997
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 15.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 15.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 15.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 17.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 17.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 1.559018
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 16.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 16.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 16.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 16.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 16.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 16.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 17.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 17.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 17.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 21.197789999999998
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 17.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 17.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 1.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 18.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 20.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 20.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 1.72292
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 19.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 19.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 19.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 19.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 19.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 19.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 20.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 20.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 20.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 22.761886999999994
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 20.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 20.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 1.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 19.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 22.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 22.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 2.020241
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 21.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 21.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 21.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 21.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 21.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 21.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 22.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 22.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 23.859748999999994
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 22.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 22.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 1.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 22.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 25.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 25.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 2.2258959999999997
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 24.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 24.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 24.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 24.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 24.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 24.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 25.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 25.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 25.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 25.51304399999999
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 25.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 25.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 2.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 24.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 27.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 27.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 2.354682
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 26.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 26.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 26.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 26.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 26.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 26.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 27.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 27.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 27.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 26.768423999999992
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 27.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 27.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 2.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 26.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 30.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 30.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 2.589916
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 29.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 29.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 29.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 29.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 29.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 29.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 30.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 30.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 30.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 28.888423999999993
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 30.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 30.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 2.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 28.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 32.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 32.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 2.7239299999999997
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 31.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 31.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 31.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 31.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 31.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 31.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 32.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 32.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 32.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 30.145545999999992
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 32.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 32.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 3.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 31.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 35.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 35.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 2.927028999999999
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 34.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 34.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 34.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 34.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 34.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 34.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 35.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 35.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 35.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 32.041439
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 35.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 35.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 3.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 33.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 37.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 37.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 3.059655
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 36.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 36.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 36.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 36.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 36.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 36.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 37.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 37.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 37.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 33.182669999999995
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 37.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 37.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 3.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 36.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 40.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 40.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 3.2418199999999993
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 39.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 39.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 39.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 39.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 39.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 39.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 40.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 40.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 40.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 35.05305899999999
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 40.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 40.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 4.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 38.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 42.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 42.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 3.345085999999999
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 1.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 41.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 41.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 41.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 41.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 41.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 41.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 42.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 42.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 36.209157999999995
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 42.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 42.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 5.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 41.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 45.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 45.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 3.5096209999999988
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 1.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 44.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 44.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 44.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 44.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 44.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 44.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 45.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 45.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 38.07137699999999
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 45.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 45.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 5.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 42.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 47.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 47.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 3.798140999999999
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 1.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 46.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 46.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 46.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 46.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 46.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 46.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 47.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 47.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 47.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 39.12458199999999
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 47.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 47.0`,
+	`
+# HELP java_sql_client_latency The distribution of the latencies of various calls in milliseconds
+# TYPE java_sql_client_latency histogram
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.05",} 6.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.1",} 45.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="0.5",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1.5",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2.5",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="25.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="50.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="400.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="600.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="800.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="1500.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="2500.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="5000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="10000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="20000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="40000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="100000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="200000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="500000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",le="+Inf",} 50.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 50.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 3.9551329999999987
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.0",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.001",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.005",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.01",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.05",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.1",} 0.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="0.5",} 1.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.0",} 49.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1.5",} 49.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.0",} 49.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2.5",} 49.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5.0",} 49.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10.0",} 49.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="25.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="50.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="400.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="600.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="800.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="1500.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="2500.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="5000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="10000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="20000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="40000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="100000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="200000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="500000.0",} 50.0
+java_sql_client_latency_bucket{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",le="+Inf",} 50.0
+java_sql_client_latency_count{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 50.0
+java_sql_client_latency_sum{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 40.71351599999999
+# HELP java_sql_client_calls The number of various calls of methods
+# TYPE java_sql_client_calls counter
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.ResultSet.close",java_sql_status="OK",} 50.0
+java_sql_client_calls{java_sql_error="",java_sql_method="java.sql.Statement.executeQuery",java_sql_status="OK",} 50.0`,
+}


### PR DESCRIPTION
Hand over prometheus exporter code that I had
parked in https://github.com/orijtech/promreceiver

That code was written for OpenCensus Authors, and was just
waiting for a final destination. This change finishes that.

Fixes #480