### PR TITLE
Add exporterhelper to wrap all exporters with observability.

### DIFF
--- a/cmd/occollector/app/collector/processors.go
+++ b/cmd/occollector/app/collector/processors.go
@@ -248,7 +248,8 @@ func startProcessor(v *viper.Viper, logger *zap.Logger) (processor.SpanProcessor
 	_ = metricsExporters
 
 	if builder.LoggingExporterEnabled(v) {
-		dbgProc := processor.NewTraceExporterProcessor(loggingexporter.NewTraceExporter(logger))
+		tle, _ := loggingexporter.NewTraceExporter(logger)
+		dbgProc := processor.NewTraceExporterProcessor(tle)
 		// TODO: Add this to the exporters list and avoid treating it specially. Don't know all the implications.
 		nameToSpanProcessor["debug"] = dbgProc
 		spanProcessors = append(spanProcessors, dbgProc)

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -1,0 +1,66 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"go.opencensus.io/trace"
+)
+
+var (
+	okStatus = trace.Status{Code: trace.StatusCodeOK}
+)
+
+// ExporterOptions contains options concerning how an Exporter is configured.
+type ExporterOptions struct {
+	// TOOD: Retry logic must be in the same place as metrics recording because
+	// if a request is retried we should not record metrics otherwise number of
+	// spans received + dropped will be different than the number of received spans
+	// in the receiver.
+	recordMetrics bool
+	spanName      string
+}
+
+// ExporterOption apply changes to ExporterOptions.
+type ExporterOption func(*ExporterOptions)
+
+// WithRecordMetrics makes new Exporter to record metrics for every request.
+func WithRecordMetrics(recordMetrics bool) ExporterOption {
+	return func(o *ExporterOptions) {
+		o.recordMetrics = recordMetrics
+	}
+}
+
+// WithSpanName makes new Exporter to wrap every request with a Span.
+func WithSpanName(spanName string) ExporterOption {
+	return func(o *ExporterOptions) {
+		o.spanName = spanName
+	}
+}
+
+// Construct the ExporterOptions from multiple ExporterOption.
+func newExporterOptions(options ...ExporterOption) ExporterOptions {
+	var opts ExporterOptions
+	for _, op := range options {
+		op(&opts)
+	}
+	return opts
+}
+
+func errToStatus(err error) trace.Status {
+	if err != nil {
+		return trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()}
+	}
+	return okStatus
+}

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -1,0 +1,61 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package exporterhelper
+
+import (
+	"errors"
+	"testing"
+
+	"go.opencensus.io/trace"
+)
+
+func TestDefaultOptions(t *testing.T) {
+	checkRecordMetrics(t, newExporterOptions(), false)
+	checkSpanName(t, newExporterOptions(), "")
+}
+
+func TestWithRecordMetrics(t *testing.T) {
+	checkRecordMetrics(t, newExporterOptions(WithRecordMetrics(true)), true)
+	checkRecordMetrics(t, newExporterOptions(WithRecordMetrics(false)), false)
+}
+
+func TestWithSpanName(t *testing.T) {
+	checkSpanName(t, newExporterOptions(WithSpanName("my_span")), "my_span")
+	checkSpanName(t, newExporterOptions(WithSpanName("")), "")
+}
+
+func TestErrorToStatus(t *testing.T) {
+	if g, w := errToStatus(nil), okStatus; g != w {
+		t.Fatalf("Status: Want %v Got %v", w, g)
+	}
+
+	errorStatus := trace.Status{Code: trace.StatusCodeUnknown, Message: "my_error"}
+	if g, w := errToStatus(errors.New("my_error")), errorStatus; g != w {
+		t.Fatalf("Status: Want %v Got %v", w, g)
+	}
+}
+
+func checkRecordMetrics(t *testing.T, opts ExporterOptions, recordMetrics bool) {
+	if opts.recordMetrics != recordMetrics {
+		t.Errorf("Wrong recordMetrics Want: %t Got: %t", opts.recordMetrics, recordMetrics)
+		return
+	}
+}
+
+func checkSpanName(t *testing.T, opts ExporterOptions, spanName string) {
+	if opts.spanName != spanName {
+		t.Errorf("Wrong spanName Want: %s Got: %s", opts.spanName, spanName)
+		return
+	}
+}

--- a/exporter/exporterhelper/constants.go
+++ b/exporter/exporterhelper/constants.go
@@ -1,0 +1,28 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"errors"
+)
+
+var (
+	// ErrEmptyExporterFormat is returned when an empty name is given.
+	ErrEmptyExporterFormat = errors.New("empty exporter format")
+	// ErrNilPushTraceData is returned when a nil pushTraceData is given.
+	ErrNilPushTraceData = errors.New("nil pushTraceData")
+	// ErrNilPushMetricsData is returned when a nil pushMetricsData is given.
+	ErrNilPushMetricsData = errors.New("nil pushMetricsData")
+)

--- a/exporter/exporterhelper/constants.go
+++ b/exporter/exporterhelper/constants.go
@@ -26,3 +26,10 @@ var (
 	// ErrNilPushMetricsData is returned when a nil pushMetricsData is given.
 	ErrNilPushMetricsData = errors.New("nil pushMetricsData")
 )
+
+const (
+	numDroppedMetricsAttribute  = "num_dropped_metrics"
+	numReceivedMetricsAttribute = "num_received_metrics"
+	numDroppedSpansAttribute    = "num_dropped_spans"
+	numReceivedSpansAttribute   = "num_received_spans"
+)

--- a/exporter/exporterhelper/constants.go
+++ b/exporter/exporterhelper/constants.go
@@ -19,12 +19,12 @@ import (
 )
 
 var (
-	// ErrEmptyExporterFormat is returned when an empty name is given.
-	ErrEmptyExporterFormat = errors.New("empty exporter format")
-	// ErrNilPushTraceData is returned when a nil pushTraceData is given.
-	ErrNilPushTraceData = errors.New("nil pushTraceData")
-	// ErrNilPushMetricsData is returned when a nil pushMetricsData is given.
-	ErrNilPushMetricsData = errors.New("nil pushMetricsData")
+	// errEmptyExporterFormat is returned when an empty name is given.
+	errEmptyExporterFormat = errors.New("empty exporter format")
+	// errNilPushTraceData is returned when a nil pushTraceData is given.
+	errNilPushTraceData = errors.New("nil pushTraceData")
+	// errNilPushMetricsData is returned when a nil pushMetricsData is given.
+	errNilPushMetricsData = errors.New("nil pushMetricsData")
 )
 
 const (

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -24,11 +24,6 @@ import (
 	"github.com/census-instrumentation/opencensus-service/exporter"
 )
 
-const (
-	numDroppedMetricsAttribute  = "num_dropped_metrics"
-	numReceivedMetricsAttribute = "num_received_metrics"
-)
-
 // PushMetricsData is a helper function that is similar to ConsumeMetricsData but also returns
 // the number of dropped metrics.
 type PushMetricsData func(ctx context.Context, td data.MetricsData) (droppedMetrics int, err error)

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -51,11 +51,11 @@ func (me *metricsExporter) ConsumeMetricsData(ctx context.Context, md data.Metri
 // TODO: Add support for retries.
 func NewMetricsExporter(exporterFormat string, pushMetricsData PushMetricsData, options ...ExporterOption) (exporter.MetricsExporter, error) {
 	if exporterFormat == "" {
-		return nil, ErrEmptyExporterFormat
+		return nil, errEmptyExporterFormat
 	}
 
 	if pushMetricsData == nil {
-		return nil, ErrNilPushMetricsData
+		return nil, errNilPushMetricsData
 	}
 
 	opts := newExporterOptions(options...)

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -1,0 +1,95 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"context"
+
+	"github.com/census-instrumentation/opencensus-service/observability"
+	"go.opencensus.io/trace"
+
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/exporter"
+)
+
+const (
+	numDroppedMetricsAttribute  = "num_dropped_metrics"
+	numReceivedMetricsAttribute = "num_received_metrics"
+)
+
+// PushMetricsData is a helper function that is similar to ConsumeMetricsData but also returns
+// the number of dropped metrics.
+type PushMetricsData func(ctx context.Context, td data.MetricsData) (droppedMetrics int, err error)
+
+type metricsExporter struct {
+	exporterFormat  string
+	pushMetricsData PushMetricsData
+}
+
+var _ (exporter.MetricsExporter) = (*metricsExporter)(nil)
+
+func (me *metricsExporter) MetricsExportFormat() string {
+	return me.exporterFormat
+}
+
+func (me *metricsExporter) ConsumeMetricsData(ctx context.Context, md data.MetricsData) error {
+	exporterCtx := observability.ContextWithExporterName(ctx, me.exporterFormat)
+	_, err := me.pushMetricsData(exporterCtx, md)
+	return err
+}
+
+// NewMetricsExporter creates an MetricsExporter that can record metrics and can wrap every request with a Span.
+// If no options are passed it just adds the exporter format as a tag in the Context.
+// TODO: Add support for recordMetrics.
+// TODO: Add support for retries.
+func NewMetricsExporter(exporterFormat string, pushMetricsData PushMetricsData, options ...ExporterOption) (exporter.MetricsExporter, error) {
+	if exporterFormat == "" {
+		return nil, ErrEmptyExporterFormat
+	}
+
+	if pushMetricsData == nil {
+		return nil, ErrNilPushMetricsData
+	}
+
+	opts := newExporterOptions(options...)
+
+	if opts.spanName != "" {
+		pushMetricsData = pushMetricsDataWithSpan(pushMetricsData, opts.spanName)
+	}
+
+	return &metricsExporter{
+		exporterFormat:  exporterFormat,
+		pushMetricsData: pushMetricsData,
+	}, nil
+}
+
+func pushMetricsDataWithSpan(next PushMetricsData, spanName string) PushMetricsData {
+	return func(ctx context.Context, md data.MetricsData) (int, error) {
+		ctx, span := trace.StartSpan(ctx, spanName)
+		defer span.End()
+		// Call next stage.
+		droppedMetrics, err := next(ctx, md)
+		if span.IsRecordingEvents() {
+			span.AddAttributes(
+				trace.Int64Attribute(numReceivedMetricsAttribute, int64(len(md.Metrics))),
+				trace.Int64Attribute(numDroppedMetricsAttribute, int64(droppedMetrics)),
+			)
+			if err != nil {
+				span.SetStatus(errToStatus(err))
+			}
+		}
+		return droppedMetrics, err
+	}
+}

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -1,0 +1,147 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package exporterhelper
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"go.opencensus.io/trace"
+
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/exporter"
+)
+
+func TestMetricsExporter_InvalidName(t *testing.T) {
+	if _, err := NewMetricsExporter("", newPushMetricsData(0, nil)); err != ErrEmptyExporterFormat {
+		t.Fatalf("NewMetricsExporter returns: Want %v Got %v", ErrEmptyExporterFormat, err)
+	}
+}
+
+func TestMetricsExporter_NilPushMetricsData(t *testing.T) {
+	if _, err := NewMetricsExporter(fakeExporterName, nil); err != ErrNilPushMetricsData {
+		t.Fatalf("NewMetricsExporter returns: Want %v Got %v", ErrNilPushMetricsData, err)
+	}
+}
+func TestMetricsExporter_Default(t *testing.T) {
+	td := data.MetricsData{}
+	te, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, nil))
+	if err != nil {
+		t.Fatalf("NewMetricsExporter returns: Want nil Got %v", err)
+	}
+	if err := te.ConsumeMetricsData(context.Background(), td); err != nil {
+		t.Fatalf("ConsumeMetricsData returns: Want nil Got %v", err)
+	}
+	if g, w := te.MetricsExportFormat(), fakeExporterName; g != w {
+		t.Fatalf("MetricsExportFormat returns: Want %s Got %s", w, g)
+	}
+}
+
+func TestMetricsExporter_Default_ReturnError(t *testing.T) {
+	td := data.MetricsData{}
+	want := errors.New("my_error")
+	te, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, want))
+	if err != nil {
+		t.Fatalf("NewMetricsExporter returns: Want nil Got %v", err)
+	}
+	if err := te.ConsumeMetricsData(context.Background(), td); err != want {
+		t.Fatalf("ConsumeMetricsData returns: Want %v Got %v", want, err)
+	}
+}
+
+func TestMetricsExporter_WithSpan(t *testing.T) {
+	te, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, nil), WithSpanName(fakeSpanName))
+	if err != nil {
+		t.Fatalf("NewMetricsExporter returns: Want nil Got %v", err)
+	}
+	checkWrapSpanForMetricsExporter(t, te, nil, 0)
+}
+
+func TestMetricsExporter_WithSpan_NonZeroDropped(t *testing.T) {
+	te, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(1, nil), WithSpanName(fakeSpanName))
+	if err != nil {
+		t.Fatalf("NewMetricsExporter returns: Want nil Got %v", err)
+	}
+	checkWrapSpanForMetricsExporter(t, te, nil, 1)
+}
+
+func TestMetricsExporter_WithSpan_ReturnError(t *testing.T) {
+	want := errors.New("my_error")
+	te, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, want), WithSpanName(fakeSpanName))
+	if err != nil {
+		t.Fatalf("NewMetricsExporter returns: Want nil Got %v", err)
+	}
+	checkWrapSpanForMetricsExporter(t, te, want, 0)
+}
+
+func newPushMetricsData(droppedSpans int, retError error) PushMetricsData {
+	return func(ctx context.Context, td data.MetricsData) (int, error) {
+		return droppedSpans, retError
+	}
+}
+
+func generateMetricsTraffic(t *testing.T, te exporter.MetricsExporter, numRequests int, wantError error) {
+	td := data.MetricsData{Metrics: make([]*metricspb.Metric, 1, 1)}
+	ctx, span := trace.StartSpan(context.Background(), fakeParentSpanName, trace.WithSampler(trace.AlwaysSample()))
+	defer span.End()
+	for i := 0; i < numRequests; i++ {
+		if err := te.ConsumeMetricsData(ctx, td); err != wantError {
+			t.Fatalf("Want %v Got %v", wantError, err)
+		}
+	}
+}
+
+func checkWrapSpanForMetricsExporter(t *testing.T, te exporter.MetricsExporter, wantError error, droppedSpans int) {
+	ocSpansSaver := new(testOCTraceExporter)
+	trace.RegisterExporter(ocSpansSaver)
+	defer trace.UnregisterExporter(ocSpansSaver)
+
+	const numRequests = 5
+	generateMetricsTraffic(t, te, numRequests, wantError)
+
+	// Inspection time!
+	ocSpansSaver.mu.Lock()
+	defer ocSpansSaver.mu.Unlock()
+
+	if len(ocSpansSaver.spanData) == 0 {
+		t.Fatal("No exported span data.")
+	}
+
+	gotSpanData := ocSpansSaver.spanData[:]
+	if g, w := len(gotSpanData), numRequests+1; g != w {
+		t.Fatalf("Spandata count: Want %d Got %d", w, g)
+	}
+
+	parentSpan := gotSpanData[numRequests]
+	if g, w := parentSpan.Name, fakeParentSpanName; g != w {
+		t.Fatalf("Parent span name: Want %s Got %s\nSpanData %v", w, g, parentSpan)
+	}
+
+	for _, sd := range gotSpanData[:numRequests] {
+		if g, w := sd.ParentSpanID, parentSpan.SpanContext.SpanID; g != w {
+			t.Fatalf("Exporter span not a child: Want %d Got %d\nSpanData %v", w, g, sd)
+		}
+		if g, w := sd.Status, errToStatus(wantError); g != w {
+			t.Fatalf("Status: Want %v Got %v\nSpanData %v", w, g, sd)
+		}
+		if g, w := sd.Attributes[numReceivedMetricsAttribute], int64(1); g != w {
+			t.Fatalf("Number of received spans attribute: Want %d Got %d\nSpanData %v", w, g, sd)
+		}
+		if g, w := sd.Attributes[numDroppedMetricsAttribute], int64(droppedSpans); g != w {
+			t.Fatalf("Number of dropped spans attribute: Want %d Got %d\nSpanData %v", w, g, sd)
+		}
+	}
+}

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -26,14 +26,14 @@ import (
 )
 
 func TestMetricsExporter_InvalidName(t *testing.T) {
-	if _, err := NewMetricsExporter("", newPushMetricsData(0, nil)); err != ErrEmptyExporterFormat {
-		t.Fatalf("NewMetricsExporter returns: Want %v Got %v", ErrEmptyExporterFormat, err)
+	if _, err := NewMetricsExporter("", newPushMetricsData(0, nil)); err != errEmptyExporterFormat {
+		t.Fatalf("NewMetricsExporter returns: Want %v Got %v", errEmptyExporterFormat, err)
 	}
 }
 
 func TestMetricsExporter_NilPushMetricsData(t *testing.T) {
-	if _, err := NewMetricsExporter(fakeExporterName, nil); err != ErrNilPushMetricsData {
-		t.Fatalf("NewMetricsExporter returns: Want %v Got %v", ErrNilPushMetricsData, err)
+	if _, err := NewMetricsExporter(fakeExporterName, nil); err != errNilPushMetricsData {
+		t.Fatalf("NewMetricsExporter returns: Want %v Got %v", errNilPushMetricsData, err)
 	}
 }
 func TestMetricsExporter_Default(t *testing.T) {

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -1,0 +1,107 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"context"
+
+	"go.opencensus.io/trace"
+
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/exporter"
+	"github.com/census-instrumentation/opencensus-service/observability"
+)
+
+const (
+	numDroppedSpansAttribute  = "num_dropped_spans"
+	numReceivedSpansAttribute = "num_received_spans"
+)
+
+// PushTraceData is a helper function that is similar to ConsumeTraceData but also returns
+// the number of dropped spans.
+type PushTraceData func(ctx context.Context, td data.TraceData) (droppedSpans int, err error)
+
+type traceExporter struct {
+	exporterFormat string
+	pushTraceData  PushTraceData
+}
+
+var _ (exporter.TraceExporter) = (*traceExporter)(nil)
+
+func (te *traceExporter) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+	exporterCtx := observability.ContextWithExporterName(ctx, te.exporterFormat)
+	_, err := te.pushTraceData(exporterCtx, td)
+	return err
+}
+
+func (te *traceExporter) TraceExportFormat() string {
+	return te.exporterFormat
+}
+
+// NewTraceExporter creates an TraceExporter that can record metrics and can wrap every request with a Span.
+// If no options are passed it just adds the exporter format as a tag in the Context.
+// TODO: Add support for retries.
+func NewTraceExporter(exporterFormat string, pushTraceData PushTraceData, options ...ExporterOption) (exporter.TraceExporter, error) {
+	if exporterFormat == "" {
+		return nil, ErrEmptyExporterFormat
+	}
+
+	if pushTraceData == nil {
+		return nil, ErrNilPushTraceData
+	}
+
+	opts := newExporterOptions(options...)
+	if opts.recordMetrics {
+		pushTraceData = pushTraceDataWithMetrics(pushTraceData)
+	}
+
+	if opts.spanName != "" {
+		pushTraceData = pushTraceDataWithSpan(pushTraceData, opts.spanName)
+	}
+
+	return &traceExporter{
+		exporterFormat: exporterFormat,
+		pushTraceData:  pushTraceData,
+	}, nil
+}
+
+func pushTraceDataWithMetrics(next PushTraceData) PushTraceData {
+	return func(ctx context.Context, td data.TraceData) (int, error) {
+		// TOOD: Add retry logic here if we want to support because we need to record special metrics.
+		droppedSpans, err := next(ctx, td)
+		// TODO: How to record the reason of dropping?
+		observability.RecordTraceExporterMetrics(ctx, len(td.Spans), droppedSpans)
+		return droppedSpans, err
+	}
+}
+
+func pushTraceDataWithSpan(next PushTraceData, spanName string) PushTraceData {
+	return func(ctx context.Context, td data.TraceData) (int, error) {
+		ctx, span := trace.StartSpan(ctx, spanName)
+		defer span.End()
+		// Call next stage.
+		droppedSpans, err := next(ctx, td)
+		if span.IsRecordingEvents() {
+			span.AddAttributes(
+				trace.Int64Attribute(numReceivedSpansAttribute, int64(len(td.Spans))),
+				trace.Int64Attribute(numDroppedSpansAttribute, int64(droppedSpans)),
+			)
+			if err != nil {
+				span.SetStatus(errToStatus(err))
+			}
+		}
+		return droppedSpans, err
+	}
+}

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -50,11 +50,11 @@ func (te *traceExporter) TraceExportFormat() string {
 // TODO: Add support for retries.
 func NewTraceExporter(exporterFormat string, pushTraceData PushTraceData, options ...ExporterOption) (exporter.TraceExporter, error) {
 	if exporterFormat == "" {
-		return nil, ErrEmptyExporterFormat
+		return nil, errEmptyExporterFormat
 	}
 
 	if pushTraceData == nil {
-		return nil, ErrNilPushTraceData
+		return nil, errNilPushTraceData
 	}
 
 	opts := newExporterOptions(options...)

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -24,11 +24,6 @@ import (
 	"github.com/census-instrumentation/opencensus-service/observability"
 )
 
-const (
-	numDroppedSpansAttribute  = "num_dropped_spans"
-	numReceivedSpansAttribute = "num_received_spans"
-)
-
 // PushTraceData is a helper function that is similar to ConsumeTraceData but also returns
 // the number of dropped spans.
 type PushTraceData func(ctx context.Context, td data.TraceData) (droppedSpans int, err error)

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -1,0 +1,216 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package exporterhelper
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"go.opencensus.io/trace"
+
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/exporter"
+	"github.com/census-instrumentation/opencensus-service/observability"
+	"github.com/census-instrumentation/opencensus-service/observability/observabilitytest"
+)
+
+const (
+	fakeReceiverName   = "fake_receiver_trace"
+	fakeExporterName   = "fake_exporter_trace"
+	fakeSpanName       = "fake_span_name"
+	fakeParentSpanName = "fake_parent_span_name"
+)
+
+func TestTraceExporter_InvalidName(t *testing.T) {
+	if _, err := NewTraceExporter("", newPushTraceData(0, nil)); err != ErrEmptyExporterFormat {
+		t.Fatalf("NewTraceExporter returns: Want %v Got %v", ErrEmptyExporterFormat, err)
+	}
+}
+
+func TestTraceExporter_NilPushTraceData(t *testing.T) {
+	if _, err := NewTraceExporter(fakeExporterName, nil); err != ErrNilPushTraceData {
+		t.Fatalf("NewTraceExporter returns: Want %v Got %v", ErrNilPushTraceData, err)
+	}
+}
+func TestTraceExporter_Default(t *testing.T) {
+	td := data.TraceData{}
+	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, nil))
+	if err != nil {
+		t.Fatalf("NewTraceExporter returns: Want nil Got %v", err)
+	}
+	if err := te.ConsumeTraceData(context.Background(), td); err != nil {
+		t.Fatalf("ConsumeTraceData returns: Want nil Got %v", err)
+	}
+	if g, w := te.TraceExportFormat(), fakeExporterName; g != w {
+		t.Fatalf("TraceExportFormat returns: Want %s Got %s", w, g)
+	}
+}
+
+func TestTraceExporter_Default_ReturnError(t *testing.T) {
+	td := data.TraceData{}
+	want := errors.New("my_error")
+	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, want))
+	if err != nil {
+		t.Fatalf("NewTraceExporter returns: Want nil Got %v", err)
+	}
+	if err := te.ConsumeTraceData(context.Background(), td); err != want {
+		t.Fatalf("ConsumeTraceData returns: Want %v Got %v", want, err)
+	}
+}
+
+func TestTraceExporter_WithRecordMetrics(t *testing.T) {
+	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, nil), WithRecordMetrics(true))
+	if err != nil {
+		t.Fatalf("NewTraceExporter returns: Want nil Got %v", err)
+	}
+	checkRecordedMetricsForTraceExporter(t, te, nil, 0)
+}
+
+func TestTraceExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
+	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(1, nil), WithRecordMetrics(true))
+	if err != nil {
+		t.Fatalf("NewTraceExporter returns: Want nil Got %v", err)
+	}
+	checkRecordedMetricsForTraceExporter(t, te, nil, 1)
+}
+
+func TestTraceExporter_WithRecordMetrics_ReturnError(t *testing.T) {
+	want := errors.New("my_error")
+	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, want), WithRecordMetrics(true))
+	if err != nil {
+		t.Fatalf("NewTraceExporter returns: Want nil Got %v", err)
+	}
+	checkRecordedMetricsForTraceExporter(t, te, want, 0)
+}
+
+func TestTraceExporter_WithSpan(t *testing.T) {
+	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, nil), WithSpanName(fakeSpanName))
+	if err != nil {
+		t.Fatalf("NewTraceExporter returns: Want nil Got %v", err)
+	}
+	checkWrapSpanForTraceExporter(t, te, nil, 0)
+}
+
+func TestTraceExporter_WithSpan_NonZeroDropped(t *testing.T) {
+	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(1, nil), WithSpanName(fakeSpanName))
+	if err != nil {
+		t.Fatalf("NewTraceExporter returns: Want nil Got %v", err)
+	}
+	checkWrapSpanForTraceExporter(t, te, nil, 1)
+}
+
+func TestTraceExporter_WithSpan_ReturnError(t *testing.T) {
+	want := errors.New("my_error")
+	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, want), WithSpanName(fakeSpanName))
+	if err != nil {
+		t.Fatalf("NewTraceExporter returns: Want nil Got %v", err)
+	}
+	checkWrapSpanForTraceExporter(t, te, want, 0)
+}
+
+func newPushTraceData(droppedSpans int, retError error) PushTraceData {
+	return func(ctx context.Context, td data.TraceData) (int, error) {
+		return droppedSpans, retError
+	}
+}
+
+func checkRecordedMetricsForTraceExporter(t *testing.T, te exporter.TraceExporter, wantError error, droppedSpans int) {
+	doneFn := observabilitytest.SetupRecordedMetricsTest()
+	defer doneFn()
+
+	spans := make([]*tracepb.Span, 2, 2)
+	td := data.TraceData{Spans: spans}
+	ctx := observability.ContextWithReceiverName(context.Background(), fakeReceiverName)
+	const numBatches = 7
+	for i := 0; i < numBatches; i++ {
+		if err := te.ConsumeTraceData(ctx, td); err != wantError {
+			t.Fatalf("Want %v Got %v", wantError, err)
+		}
+	}
+
+	if err := observabilitytest.CheckValueViewExporterReceivedSpans(fakeReceiverName, te.TraceExportFormat(), numBatches*len(spans)); err != nil {
+		t.Fatalf("CheckValueViewExporterReceivedSpans: Want nil Got %v", err)
+	}
+	if err := observabilitytest.CheckValueViewExporterDroppedSpans(fakeReceiverName, te.TraceExportFormat(), numBatches*droppedSpans); err != nil {
+		t.Fatalf("CheckValueViewExporterDroppedSpans: Want nil Got %v", err)
+	}
+}
+
+func generateTraceTraffic(t *testing.T, te exporter.TraceExporter, numRequests int, wantError error) {
+	td := data.TraceData{Spans: make([]*tracepb.Span, 1, 1)}
+	ctx, span := trace.StartSpan(context.Background(), fakeParentSpanName, trace.WithSampler(trace.AlwaysSample()))
+	defer span.End()
+	for i := 0; i < numRequests; i++ {
+		if err := te.ConsumeTraceData(ctx, td); err != wantError {
+			t.Fatalf("Want %v Got %v", wantError, err)
+		}
+	}
+}
+
+func checkWrapSpanForTraceExporter(t *testing.T, te exporter.TraceExporter, wantError error, droppedSpans int) {
+	ocSpansSaver := new(testOCTraceExporter)
+	trace.RegisterExporter(ocSpansSaver)
+	defer trace.UnregisterExporter(ocSpansSaver)
+
+	const numRequests = 5
+	generateTraceTraffic(t, te, numRequests, wantError)
+
+	// Inspection time!
+	ocSpansSaver.mu.Lock()
+	defer ocSpansSaver.mu.Unlock()
+
+	if len(ocSpansSaver.spanData) == 0 {
+		t.Fatal("No exported span data.")
+	}
+
+	gotSpanData := ocSpansSaver.spanData[:]
+	if g, w := len(gotSpanData), numRequests+1; g != w {
+		t.Fatalf("Spandata count: Want %d Got %d", w, g)
+	}
+
+	parentSpan := gotSpanData[numRequests]
+	if g, w := parentSpan.Name, fakeParentSpanName; g != w {
+		t.Fatalf("Parent span name: Want %s Got %s\nSpanData %v", w, g, parentSpan)
+	}
+
+	for _, sd := range gotSpanData[:numRequests] {
+		if g, w := sd.ParentSpanID, parentSpan.SpanContext.SpanID; g != w {
+			t.Fatalf("Exporter span not a child: Want %d Got %d\nSpanData %v", w, g, sd)
+		}
+		if g, w := sd.Status, errToStatus(wantError); g != w {
+			t.Fatalf("Status: Want %v Got %v\nSpanData %v", w, g, sd)
+		}
+		if g, w := sd.Attributes[numReceivedSpansAttribute], int64(1); g != w {
+			t.Fatalf("Number of received spans attribute: Want %d Got %d\nSpanData %v", w, g, sd)
+		}
+		if g, w := sd.Attributes[numDroppedSpansAttribute], int64(droppedSpans); g != w {
+			t.Fatalf("Number of dropped spans attribute: Want %d Got %d\nSpanData %v", w, g, sd)
+		}
+	}
+}
+
+type testOCTraceExporter struct {
+	mu       sync.Mutex
+	spanData []*trace.SpanData
+}
+
+func (tote *testOCTraceExporter) ExportSpan(sd *trace.SpanData) {
+	tote.mu.Lock()
+	defer tote.mu.Unlock()
+
+	tote.spanData = append(tote.spanData, sd)
+}

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -36,14 +36,14 @@ const (
 )
 
 func TestTraceExporter_InvalidName(t *testing.T) {
-	if _, err := NewTraceExporter("", newPushTraceData(0, nil)); err != ErrEmptyExporterFormat {
-		t.Fatalf("NewTraceExporter returns: Want %v Got %v", ErrEmptyExporterFormat, err)
+	if _, err := NewTraceExporter("", newPushTraceData(0, nil)); err != errEmptyExporterFormat {
+		t.Fatalf("NewTraceExporter returns: Want %v Got %v", errEmptyExporterFormat, err)
 	}
 }
 
 func TestTraceExporter_NilPushTraceData(t *testing.T) {
-	if _, err := NewTraceExporter(fakeExporterName, nil); err != ErrNilPushTraceData {
-		t.Fatalf("NewTraceExporter returns: Want %v Got %v", ErrNilPushTraceData, err)
+	if _, err := NewTraceExporter(fakeExporterName, nil); err != errNilPushTraceData {
+		t.Fatalf("NewTraceExporter returns: Want %v Got %v", errNilPushTraceData, err)
 	}
 }
 func TestTraceExporter_Default(t *testing.T) {

--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -20,37 +20,35 @@ import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/census-instrumentation/opencensus-service/data"
-	"github.com/census-instrumentation/opencensus-service/observability/observabilitytest"
 	"go.uber.org/zap"
 )
 
 func TestLoggingTraceExporterNoErrors(t *testing.T) {
-	lte := NewTraceExporter(zap.NewNop())
+	lte, err := NewTraceExporter(zap.NewNop())
+	if err != nil {
+		t.Fatalf("Wanted nil got %v", err)
+	}
 	td := data.TraceData{
 		Spans: make([]*tracepb.Span, 7),
 	}
 	if err := lte.ConsumeTraceData(context.Background(), td); err != nil {
-		t.Fatalf("Wanted nil got error")
+		t.Fatalf("Wanted nil got %v", err)
 	}
 	if "logging_trace" != lte.TraceExportFormat() {
 		t.Errorf("Wanted logging_trace got %v", lte.TraceExportFormat())
 	}
 }
 
-func TestLoggingTraceExporterRecordMetrics(t *testing.T) {
-	lte := NewTraceExporter(zap.NewNop())
-	if err := observabilitytest.CheckRecordedMetricsForTraceExporter(lte); err != nil {
-		t.Fatalf("When test LoggingTraceExporter recording metrics: want nil got %v", err)
-	}
-}
-
 func TestLoggingMetricsExporterNoErrors(t *testing.T) {
-	lme := NewMetricsExporter(zap.NewNop())
+	lme, err := NewMetricsExporter(zap.NewNop())
+	if err != nil {
+		t.Fatalf("Wanted nil got %v", err)
+	}
 	md := data.MetricsData{
 		Metrics: make([]*metricspb.Metric, 7),
 	}
 	if err := lme.ConsumeMetricsData(context.Background(), md); err != nil {
-		t.Fatalf("Wanted nil got error")
+		t.Fatalf("Wanted nil got %v", err)
 	}
 	if "logging_metrics" != lme.MetricsExportFormat() {
 		t.Errorf("Wanted logging_metrics got %v", lme.MetricsExportFormat())

--- a/observability/observability_test.go
+++ b/observability/observability_test.go
@@ -30,7 +30,8 @@ const (
 )
 
 func TestTracePieplineRecordedMetrics(t *testing.T) {
-	defer observabilitytest.SetupRecordedMetricsTest()()
+	doneFn := observabilitytest.SetupRecordedMetricsTest()
+	defer doneFn()
 
 	receiverCtx := observability.ContextWithReceiverName(context.Background(), receiverName)
 	observability.RecordTraceReceiverMetrics(receiverCtx, 17, 13)

--- a/observability/observabilitytest/observabilitytest.go
+++ b/observability/observabilitytest/observabilitytest.go
@@ -25,24 +25,13 @@ import (
 	"github.com/census-instrumentation/opencensus-service/observability"
 )
 
-type nopMetricsExporter int
-
-var _ view.Exporter = (*nopMetricsExporter)(nil)
-
-func (cme *nopMetricsExporter) ExportView(vd *view.Data) {}
-
 // SetupRecordedMetricsTest does setup the testing environment to check the metrics recorded by receivers, producers or exporters.
-// The returned function should be deferred "defer SetupRecordedMetricsTest()()".
-func SetupRecordedMetricsTest() func() {
-	// Register a nop metrics exporter for the OC library.
-	nmp := new(nopMetricsExporter)
-	view.RegisterExporter(nmp)
-
-	// Now for the stats exporter
+// The returned function should be deferred.
+func SetupRecordedMetricsTest() (doneFn func()) {
+	// Register views
 	view.Register(observability.AllViews...)
 
 	return func() {
-		view.UnregisterExporter(nmp)
 		view.Unregister(observability.AllViews...)
 	}
 }

--- a/observability/observabilitytest/observabilitytest.go
+++ b/observability/observabilitytest/observabilitytest.go
@@ -15,24 +15,14 @@
 package observabilitytest
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"sort"
-	"time"
 
-	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/census-instrumentation/opencensus-service/data"
-	"github.com/census-instrumentation/opencensus-service/exporter"
-	"github.com/census-instrumentation/opencensus-service/internal"
-	"github.com/census-instrumentation/opencensus-service/observability"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
-)
 
-const (
-	fakeReceiverName = "fake_receiver_trace"
-	fakeExporterName = "fake_exporter_trace"
+	"github.com/census-instrumentation/opencensus-service/observability"
 )
 
 type nopMetricsExporter int
@@ -55,53 +45,6 @@ func SetupRecordedMetricsTest() func() {
 		view.UnregisterExporter(nmp)
 		view.Unregister(observability.AllViews...)
 	}
-}
-
-// CheckRecordedMetricsForTraceExporter checks that the given TraceExporter records the correct set of metrics with the correct
-// set of tags by sending few TraceData to the exporter. The exporter should be able to handle the requests correctly without
-// dropping.
-func CheckRecordedMetricsForTraceExporter(te exporter.TraceExporter) error {
-	defer SetupRecordedMetricsTest()()
-
-	now := time.Now().UTC()
-	spans := []*tracepb.Span{
-		{
-			TraceId:      []byte{0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E},
-			SpanId:       []byte{0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7},
-			ParentSpanId: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-			Name:         &tracepb.TruncatableString{Value: "ServerSpan"},
-			Kind:         tracepb.Span_SERVER,
-			StartTime:    internal.TimeToTimestamp(now.Add(-15 * time.Millisecond)),
-			EndTime:      internal.TimeToTimestamp(now),
-			Status:       &tracepb.Status{Code: int32(0), Message: "OK"},
-			Tracestate:   &tracepb.Span_Tracestate{},
-			Links: &tracepb.Span_Links{
-				Link: []*tracepb.Span_Link{
-					{
-						TraceId: []byte{0x4F, 0x4E, 0x4D, 0x4C, 0x4B, 0x4A, 0x49, 0x48, 0x47, 0x46, 0x45, 0x44, 0x43, 0x42, 0x41, 0x40},
-						SpanId:  []byte{0x7F, 0x7E, 0x7D, 0x7C, 0x7B, 0x7A, 0x79, 0x78},
-						Type:    tracepb.Span_Link_PARENT_LINKED_SPAN,
-					},
-				},
-			},
-		},
-	}
-	td := data.TraceData{Spans: spans}
-	ctx := observability.ContextWithReceiverName(context.Background(), fakeReceiverName)
-	const numBatches = 7
-	for i := 0; i < numBatches; i++ {
-		if err := te.ConsumeTraceData(ctx, td); err != nil {
-			return fmt.Errorf("Want nil got %v", err)
-		}
-	}
-
-	if err := CheckValueViewExporterReceivedSpans(fakeReceiverName, te.TraceExportFormat(), numBatches*len(spans)); err != nil {
-		return err
-	}
-	if err := CheckValueViewExporterDroppedSpans(fakeReceiverName, te.TraceExportFormat(), 0); err != nil {
-		return err
-	}
-	return nil
 }
 
 // CheckValueViewExporterReceivedSpans checks that for the current exported value in the ViewExporterReceivedSpans

--- a/receiver/end_to_end_test.go
+++ b/receiver/end_to_end_test.go
@@ -43,7 +43,7 @@ func Example_endToEnd() {
 
 	// Once we have the span receiver which will connect to the
 	// various exporter pipeline i.e. *tracepb.Span->OpenCensus.SpanData
-	lsr := loggingexporter.NewTraceExporter(zap.NewNop())
+	lsr, _ := loggingexporter.NewTraceExporter(zap.NewNop())
 	for _, tr := range trl {
 		if err := tr.StartTraceReception(context.Background(), lsr); err != nil {
 			log.Fatalf("Failed to start trace receiver: %v", err)

--- a/receiver/opencensusreceiver/octrace/observability_test.go
+++ b/receiver/opencensusreceiver/octrace/observability_test.go
@@ -39,7 +39,8 @@ import (
 // test is to ensure exactness, but with the mentioned views registered, the
 // output will be quite noisy.
 func TestEnsureRecordedMetrics(t *testing.T) {
-	defer observabilitytest.SetupRecordedMetricsTest()()
+	doneFn := observabilitytest.SetupRecordedMetricsTest()
+	defer doneFn()
 
 	_, port, doneReceiverFn := ocReceiverOnGRPCServer(t, exportertest.NewNopTraceExporter())
 	defer doneReceiverFn()
@@ -67,7 +68,8 @@ func TestEnsureRecordedMetrics(t *testing.T) {
 }
 
 func TestEnsureRecordedMetrics_zeroLengthSpansSender(t *testing.T) {
-	defer observabilitytest.SetupRecordedMetricsTest()()
+	doneFn := observabilitytest.SetupRecordedMetricsTest()
+	defer doneFn()
 
 	_, port, doneFn := ocReceiverOnGRPCServer(t, exportertest.NewNopTraceExporter())
 	defer doneFn()


### PR DESCRIPTION
Only Logging and OpenCensus exporters changed in this PR, I will update all the others in a followup PR.