### PR TITLE
receiver/opencensus: Restore gRPC Gateway test.

### DIFF
--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -36,8 +36,6 @@ import (
 )
 
 func TestGrpcGateway_endToEnd(t *testing.T) {
-	t.Skip("gRPC Gateway version changed, fix this test.")
-
 	addr := ":35993"
 
 	// Set the buffer count to 1 to make it flush the test span immediately.
@@ -136,6 +134,7 @@ func TestGrpcGateway_endToEnd(t *testing.T) {
 					},
 				},
 			},
+			SourceFormat: "oc_trace",
 		},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-service/issues/492.

Test failure has been fixed with https://github.com/census-instrumentation/opencensus-service/pull/501 and https://github.com/census-instrumentation/opencensus-service/pull/506.