### PR TITLE
Use go-cmp to show the diff for test failures.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ test:
 	$(GOTEST) $(GOTEST_OPT) $(ALL_PKGS)
 
 .PHONY: travis-ci
-travis-ci: fmt vet lint test-with-cover
+travis-ci: fmt install-go-cmp vet lint test-with-cover
 
 .PHONY: test-with-cover
-test-with-cover: 
+test-with-cover:
 	@echo Verifying that all packages have test files to count in coverage
 	@scripts/check-test-files.sh $(subst github.com/census-instrumentation/opencensus-service/,./,$(ALL_PKGS))
 	@echo pre-compiling tests
@@ -86,6 +86,10 @@ vet:
 install-tools:
 	go get golang.org/x/lint/golint
 
+.PHONY: install-go-cmp
+install-go-cmp:
+	go get -u github.com/google/go-cmp/cmp
+
 .PHONY: agent
 agent:
 	GO111MODULE=on CGO_ENABLED=0 go build -o ./bin/ocagent_$(GOOS) $(BUILD_INFO) ./cmd/ocagent
@@ -112,7 +116,7 @@ docker-agent:
 	COMPONENT=agent $(MAKE) docker-component
 
 .PHONY: docker-collector
-docker-collector: 
+docker-collector:
 	COMPONENT=collector $(MAKE) docker-component
 
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/gogo/googleapis v1.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/golang/protobuf v1.3.1
+	github.com/google/go-cmp v0.2.0
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/gophercloud/gophercloud v0.0.0-20190206021053-df38e1611dbe // indirect

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -15,12 +15,12 @@
 package jaegerreceiver
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	"go.opencensus.io/exporter/jaeger"
 	"go.opencensus.io/trace"
@@ -228,10 +228,7 @@ func testJaegerAgent(t *testing.T, agentEndpoint string, receiverConfig *Configu
 		},
 	}
 
-	if !reflect.DeepEqual(got, want) {
-		gj, wj := exportertest.ToJSON(got), exportertest.ToJSON(want)
-		if !bytes.Equal(gj, wj) {
-			t.Errorf("Mismatched responses\nGot:\n\t%v\n\t%s\nWant:\n\t%v\n\t%s", got, gj, want, wj)
-		}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Mismatched responses\n-Got +Want:\n\t%s", diff)
 	}
 }

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -15,12 +15,12 @@
 package jaegerreceiver
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	"go.opencensus.io/exporter/jaeger"
 	"go.opencensus.io/trace"
@@ -212,10 +212,7 @@ func TestReception(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(got, want) {
-		gj, wj := exportertest.ToJSON(got), exportertest.ToJSON(want)
-		if !bytes.Equal(gj, wj) {
-			t.Errorf("Mismatches responses\nGot:\n\t%v\n\t%s\nWant:\n\t%v\n\t%s", got, gj, want, wj)
-		}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Mismatched responses\n-Got +Want:\n\t%s", diff)
 	}
 }


### PR DESCRIPTION
The original error message is extremely difficult to debug, for example (https://travis-ci.org/census-instrumentation/opencensus-service/builds/515417341#L1486):
```bash
Got:
[{identifier:<> library_info:<> service_info:<name:"issaTest" > attributes:<key:"bool" value:"true" > attributes:<key:"int64" value:"10000000" > attributes:<key:"string" value:"yes" >  <nil> [trace_id:"\001\002\003\004\005\006\007\010\t\n\013\014\r\016\017\200" span_id:"\257\256\255\254\253\252\251\250" parent_span_id:"\037\036\035\034\033\032\031\030" name:<value:"DBSearch" > start_time:<seconds:1542158650 nanos:536343000 > end_time:<seconds:1542159250 nanos:536343000 > attributes:<attribute_map:<key:"error" value:<bool_value:true > > attribute_map:<key:"status.code" value:<int_value:5 > > attribute_map:<key:"status.message" value:<string_value:<value:"Stale indices" > > > > links:<link:<trace_id:"\361\362\363\364\365\366\367\370\371\372\373\374\375\376\377\200" span_id:"\317\316\315\314\313\312\311\310" type:PARENT_LINKED_SPAN > > status:<code:5 message:"Stale indices" >  trace_id:"\361\362\363\364\365\366\367\370\371\372\373\374\375\376\377\200" span_id:"\317\316\315\314\313\312\311\310" name:<value:"ProxyFetch" > start_time:<seconds:1542159250 nanos:536343000 > end_time:<seconds:1542159252 nanos:536343000 > attributes:<attribute_map:<key:"error" value:<bool_value:true > > attribute_map:<key:"status.code" value:<int_value:13 > > attribute_map:<key:"status.message" value:<string_value:<value:"Frontend crash" > > > > links:<link:<trace_id:"\361\362\363\364\365\366\367\370\371\372\373\374\375\376\377\200" span_id:"\257\256\255\254\253\252\251\250" type:PARENT_LINKED_SPAN > > status:<code:13 message:"Frontend crash" > ] }]
...
Want:
[{identifier:<> library_info:<> service_info:<name:"issaTest" > attributes:<key:"bool" value:"true" > attributes:<key:"int64" value:"10000000" > attributes:<key:"string" value:"yes" >  <nil> [trace_id:"\001\002\003\004\005\006\007\010\t\n\013\014\r\016\017\200" span_id:"\257\256\255\254\253\252\251\250" parent_span_id:"\037\036\035\034\033\032\031\030" name:<value:"DBSearch" > start_time:<seconds:1542158650 nanos:536343000 > end_time:<seconds:1542159250 nanos:536343000 > attributes:<attribute_map:<key:"status.code" value:<int_value:5 > > attribute_map:<key:"status.message" value:<string_value:<value:"Stale indices" > > > > links:<link:<trace_id:"\361\362\363\364\365\366\367\370\371\372\373\374\375\376\377\200" span_id:"\317\316\315\314\313\312\311\310" type:PARENT_LINKED_SPAN > > status:<code:5 message:"Stale indices" >  trace_id:"\361\362\363\364\365\366\367\370\371\372\373\374\375\376\377\200" span_id:"\317\316\315\314\313\312\311\310" name:<value:"ProxyFetch" > start_time:<seconds:1542159250 nanos:536343000 > end_time:<seconds:1542159252 nanos:536343000 > attributes:<attribute_map:<key:"status.code" value:<int_value:13 > > attribute_map:<key:"status.message" value:<string_value:<value:"Frontend crash" > > > > links:<link:<trace_id:"\361\362\363\364\365\366\367\370\371\372\373\374\375\376\377\200" span_id:"\257\256\255\254\253\252\251\250" type:PARENT_LINKED_SPAN > > status:<code:13 message:"Frontend crash" > ] }]
...
```

Using [go-cmp](https://github.com/google/go-cmp) and showing the diff is a lot more helpful IMO.