### PR TITLE
receiver: Add a prototype VM metrics receiver.

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,7 @@ type Receivers struct {
 	Zipkin     *ReceiverConfig       `mapstructure:"zipkin"`
 	Jaeger     *ReceiverConfig       `mapstructure:"jaeger"`
 	Scribe     *ScribeReceiverConfig `mapstructure:"zipkin-scribe"`
+	VMMetrics  *ReceiverConfig       `mapstructure:"vmmetrics"`
 
 	// Prometheus contains the Prometheus configurations.
 	// Such as:
@@ -372,6 +373,14 @@ func (tlsCreds *TLSCredentials) ToOpenCensusReceiverServerOption() (opt opencens
 func (c *Config) OpenCensusReceiverTLSCredentialsServerOption() (opt opencensusreceiver.Option, ok bool, err error) {
 	tlsCreds := c.OpenCensusReceiverTLSServerCredentials()
 	return tlsCreds.ToOpenCensusReceiverServerOption()
+}
+
+// VMMetricsReceiverEnabled returns true if Config is non-nil.
+func (c *Config) VMMetricsReceiverEnabled() bool {
+	if c == nil {
+		return false
+	}
+	return c.Receivers != nil && c.Receivers.VMMetrics != nil
 }
 
 // CheckLogicalConflicts serves to catch logical errors such as

--- a/receiver/vmmetricsreceiver/.nocover
+++ b/receiver/vmmetricsreceiver/.nocover
@@ -1,0 +1,1 @@
+FIXME: This will get re-written and moved.

--- a/receiver/vmmetricsreceiver/doc.go
+++ b/receiver/vmmetricsreceiver/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package vmmetricsreceiver has the logic for scraping VM metrics
+// and then passing them onto a metric consumer instance.
+package vmmetricsreceiver

--- a/receiver/vmmetricsreceiver/example_config.yaml
+++ b/receiver/vmmetricsreceiver/example_config.yaml
@@ -1,0 +1,11 @@
+receivers:
+  vmmetrics:
+    scrape_interval: 10s
+
+zpages:
+  port: 55679
+
+exporters:
+  prometheus:
+    namespace: "vmmetrics_test"
+    address: "localhost:8888"

--- a/receiver/vmmetricsreceiver/metrics_receiver.go
+++ b/receiver/vmmetricsreceiver/metrics_receiver.go
@@ -1,0 +1,109 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vmmetricsreceiver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/spf13/viper"
+
+	"github.com/census-instrumentation/opencensus-service/consumer"
+)
+
+var (
+	errAlreadyStarted     = errors.New("already started")
+	errAlreadyStopped     = errors.New("already stopped")
+	errNilMetricsConsumer = errors.New("expecting a non-nil MetricsConsumer")
+)
+
+// Configuration defines the behavior and targets of the VM metrics scrapers.
+type Configuration struct {
+	scrapeInterval time.Duration `mapstructure:"scrape_interval"`
+	mountPoint     string        `mapstructure:"mount_point"`
+	metricPrefix   string        `mapstructure:"metric_prefix"`
+}
+
+// Receiver is the type used to handle metrics from VM metrics.
+type Receiver struct {
+	mu sync.Mutex
+
+	vmc *VMMetricsCollector
+
+	stopOnce  sync.Once
+	startOnce sync.Once
+}
+
+// New creates a new vmmetricsreceiver.Receiver reference.
+func New(v *viper.Viper, consumer consumer.MetricsConsumer) (*Receiver, error) {
+	if consumer == nil {
+		return nil, errNilMetricsConsumer
+	}
+
+	var cfg Configuration
+
+	// Unmarshal our config values (using viper's mapstructure)
+	err := v.Unmarshal(&cfg)
+	if err != nil {
+		return nil, fmt.Errorf("vmmetrics receiver failed to parse config: %s", err)
+	}
+
+	vmc, err := NewVMMetricsCollector(cfg.scrapeInterval, cfg.mountPoint, cfg.metricPrefix, consumer)
+	if err != nil {
+		return nil, err
+	}
+
+	vmr := &Receiver{
+		vmc: vmc,
+	}
+	return vmr, nil
+}
+
+// StartMetricsReception scrapes VM metrics based on the OS platform.
+func (vmr *Receiver) StartMetricsReception(ctx context.Context, asyncErrorChan chan<- error) error {
+	vmr.mu.Lock()
+	defer vmr.mu.Unlock()
+
+	var err = errAlreadyStarted
+	vmr.startOnce.Do(func() {
+		switch runtime.GOOS {
+		case "linux":
+			vmr.vmc.StartCollection()
+		case "darwin", "freebsd", "windows":
+			// TODO: add support for other platforms.
+			return
+		}
+
+		err = nil
+	})
+	return err
+}
+
+// StopMetricsReception stops and cancels the underlying VM metrics scrapers.
+func (vmr *Receiver) StopMetricsReception(ctx context.Context) error {
+	vmr.mu.Lock()
+	defer vmr.mu.Unlock()
+
+	var err = errAlreadyStopped
+	vmr.stopOnce.Do(func() {
+		vmr.vmc.StopCollection()
+		err = nil
+	})
+	return err
+}

--- a/receiver/vmmetricsreceiver/transform_stats_to_metrics.go
+++ b/receiver/vmmetricsreceiver/transform_stats_to_metrics.go
@@ -14,6 +14,8 @@
 
 package vmmetricsreceiver
 
+// TODO(songy23): remove this file and use Metrics Gauge and Cumulative APIs.
+
 import (
 	"errors"
 	"time"

--- a/receiver/vmmetricsreceiver/transform_stats_to_metrics.go
+++ b/receiver/vmmetricsreceiver/transform_stats_to_metrics.go
@@ -18,13 +18,14 @@ package vmmetricsreceiver
 
 import (
 	"errors"
-	"time"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
+
+	"github.com/census-instrumentation/opencensus-service/internal"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 )
@@ -160,8 +161,8 @@ func viewDataToTimeseries(vd *view.Data) ([]*metricspb.TimeSeries, error) {
 	// the timestamps for all the row data will be the exact same
 	// per aggregation. However, the values will differ.
 	// Each row has its own tags.
-	startTimestamp := timeToProtoTimestamp(vd.Start)
-	endTimestamp := timeToProtoTimestamp(vd.End)
+	startTimestamp := internal.TimeToTimestamp(vd.Start)
+	endTimestamp := internal.TimeToTimestamp(vd.End)
 
 	mType := measureTypeFromMeasure(vd.View.Measure)
 	timeseries := make([]*metricspb.TimeSeries, 0, len(vd.Rows))
@@ -182,14 +183,6 @@ func viewDataToTimeseries(vd *view.Data) ([]*metricspb.TimeSeries, error) {
 	}
 
 	return timeseries, nil
-}
-
-func timeToProtoTimestamp(t time.Time) *timestamp.Timestamp {
-	unixNano := t.UnixNano()
-	return &timestamp.Timestamp{
-		Seconds: int64(unixNano / 1e9),
-		Nanos:   int32(unixNano % 1e9),
-	}
 }
 
 func rowToPoint(v *view.View, row *view.Row, endTimestamp *timestamp.Timestamp, mType measureType) *metricspb.Point {

--- a/receiver/vmmetricsreceiver/transform_stats_to_metrics.go
+++ b/receiver/vmmetricsreceiver/transform_stats_to_metrics.go
@@ -255,9 +255,9 @@ func labelValuesFromTags(tags []tag.Tag) []*metricspb.LabelValue {
 	}
 
 	labelValues := make([]*metricspb.LabelValue, 0, len(tags))
-	for _, tag_ := range tags {
+	for _, tag := range tags {
 		labelValues = append(labelValues, &metricspb.LabelValue{
-			Value: tag_.Value,
+			Value: tag.Value,
 
 			// It is imperative that we set the "HasValue" attribute,
 			// in order to distinguish missing a label from the empty string.
@@ -267,7 +267,7 @@ func labelValuesFromTags(tags []tag.Tag) []*metricspb.LabelValue {
 			// so the best case that we can use to distinguish missing labels/tags from the
 			// empty string is by checking if the Tag.Key.Name() != "" to indicate that we have
 			// a value.
-			HasValue: tag_.Key.Name() != "",
+			HasValue: tag.Key.Name() != "",
 		})
 	}
 	return labelValues

--- a/receiver/vmmetricsreceiver/transform_stats_to_metrics.go
+++ b/receiver/vmmetricsreceiver/transform_stats_to_metrics.go
@@ -1,0 +1,274 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vmmetricsreceiver
+
+import (
+	"errors"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+)
+
+var (
+	errNilMeasure  = errors.New("expecting a non-nil stats.Measure")
+	errNilView     = errors.New("expecting a non-nil view.View")
+	errNilViewData = errors.New("expecting a non-nil view.Data")
+)
+
+func viewDataToMetric(vd *view.Data) (*metricspb.Metric, error) {
+	if vd == nil {
+		return nil, errNilViewData
+	}
+
+	descriptor, err := viewToMetricDescriptor(vd.View)
+	if err != nil {
+		return nil, err
+	}
+
+	timeseries, err := viewDataToTimeseries(vd)
+	if err != nil {
+		return nil, err
+	}
+
+	metric := &metricspb.Metric{
+		MetricDescriptor: descriptor,
+		Timeseries:       timeseries,
+	}
+	return metric, nil
+}
+
+func viewToMetricDescriptor(v *view.View) (*metricspb.MetricDescriptor, error) {
+	if v == nil {
+		return nil, errNilView
+	}
+	if v.Measure == nil {
+		return nil, errNilMeasure
+	}
+
+	desc := &metricspb.MetricDescriptor{
+		Name:        stringOrCall(v.Name, v.Measure.Name),
+		Description: stringOrCall(v.Description, v.Measure.Description),
+		Unit:        v.Measure.Unit(),
+		Type:        aggregationToMetricDescriptorType(v),
+		LabelKeys:   tagKeysToLabelKeys(v.TagKeys),
+	}
+	return desc, nil
+}
+
+func stringOrCall(first string, call func() string) string {
+	if first != "" {
+		return first
+	}
+	return call()
+}
+
+type measureType uint
+
+const (
+	measureUnknown measureType = iota
+	measureInt64
+	measureFloat64
+)
+
+func measureTypeFromMeasure(m stats.Measure) measureType {
+	switch m.(type) {
+	default:
+		return measureUnknown
+	case *stats.Float64Measure:
+		return measureFloat64
+	case *stats.Int64Measure:
+		return measureInt64
+	}
+}
+
+func aggregationToMetricDescriptorType(v *view.View) metricspb.MetricDescriptor_Type {
+	if v == nil || v.Aggregation == nil {
+		return metricspb.MetricDescriptor_UNSPECIFIED
+	}
+	if v.Measure == nil {
+		return metricspb.MetricDescriptor_UNSPECIFIED
+	}
+
+	switch v.Aggregation.Type {
+	case view.AggTypeCount:
+		// Cumulative on int64
+		return metricspb.MetricDescriptor_CUMULATIVE_INT64
+
+	case view.AggTypeDistribution:
+		// Cumulative types
+		return metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION
+
+	case view.AggTypeLastValue:
+		// Gauge types
+		switch measureTypeFromMeasure(v.Measure) {
+		case measureFloat64:
+			return metricspb.MetricDescriptor_GAUGE_DOUBLE
+		case measureInt64:
+			return metricspb.MetricDescriptor_GAUGE_INT64
+		}
+
+	case view.AggTypeSum:
+		// Cumulative types
+		switch measureTypeFromMeasure(v.Measure) {
+		case measureFloat64:
+			return metricspb.MetricDescriptor_CUMULATIVE_DOUBLE
+		case measureInt64:
+			return metricspb.MetricDescriptor_CUMULATIVE_INT64
+		}
+	}
+
+	// For all other cases, return unspecified.
+	return metricspb.MetricDescriptor_UNSPECIFIED
+}
+
+func tagKeysToLabelKeys(tagKeys []tag.Key) []*metricspb.LabelKey {
+	labelKeys := make([]*metricspb.LabelKey, 0, len(tagKeys))
+	for _, tagKey := range tagKeys {
+		labelKeys = append(labelKeys, &metricspb.LabelKey{
+			Key: tagKey.Name(),
+		})
+	}
+	return labelKeys
+}
+
+func viewDataToTimeseries(vd *view.Data) ([]*metricspb.TimeSeries, error) {
+	if vd == nil || len(vd.Rows) == 0 {
+		return nil, nil
+	}
+
+	// Given that view.Data only contains Start, End
+	// the timestamps for all the row data will be the exact same
+	// per aggregation. However, the values will differ.
+	// Each row has its own tags.
+	startTimestamp := timeToProtoTimestamp(vd.Start)
+	endTimestamp := timeToProtoTimestamp(vd.End)
+
+	mType := measureTypeFromMeasure(vd.View.Measure)
+	timeseries := make([]*metricspb.TimeSeries, 0, len(vd.Rows))
+	// It is imperative that the ordering of "LabelValues" matches those
+	// of the Label keys in the metric descriptor.
+	for _, row := range vd.Rows {
+		labelValues := labelValuesFromTags(row.Tags)
+		point := rowToPoint(vd.View, row, endTimestamp, mType)
+		timeseries = append(timeseries, &metricspb.TimeSeries{
+			StartTimestamp: startTimestamp,
+			LabelValues:    labelValues,
+			Points:         []*metricspb.Point{point},
+		})
+	}
+
+	if len(timeseries) == 0 {
+		return nil, nil
+	}
+
+	return timeseries, nil
+}
+
+func timeToProtoTimestamp(t time.Time) *timestamp.Timestamp {
+	unixNano := t.UnixNano()
+	return &timestamp.Timestamp{
+		Seconds: int64(unixNano / 1e9),
+		Nanos:   int32(unixNano % 1e9),
+	}
+}
+
+func rowToPoint(v *view.View, row *view.Row, endTimestamp *timestamp.Timestamp, mType measureType) *metricspb.Point {
+	pt := &metricspb.Point{
+		Timestamp: endTimestamp,
+	}
+
+	switch data := row.Data.(type) {
+	case *view.CountData:
+		pt.Value = &metricspb.Point_Int64Value{Int64Value: data.Value}
+
+	case *view.DistributionData:
+		pt.Value = &metricspb.Point_DistributionValue{
+			DistributionValue: &metricspb.DistributionValue{
+				Count: data.Count,
+				Sum:   float64(data.Count) * data.Mean, // because Mean := Sum/Count
+				// TODO: Add Exemplar
+				Buckets: bucketsToProtoBuckets(data.CountPerBucket),
+				BucketOptions: &metricspb.DistributionValue_BucketOptions{
+					Type: &metricspb.DistributionValue_BucketOptions_Explicit_{
+						Explicit: &metricspb.DistributionValue_BucketOptions_Explicit{
+							Bounds: v.Aggregation.Buckets,
+						},
+					},
+				},
+				SumOfSquaredDeviation: data.SumOfSquaredDev,
+			}}
+
+	case *view.LastValueData:
+		setPointValue(pt, data.Value, mType)
+
+	case *view.SumData:
+		setPointValue(pt, data.Value, mType)
+	}
+
+	return pt
+}
+
+// Not returning anything from this function because metricspb.Point.is_Value is an unexported
+// interface hence we just have to set its value by pointer.
+func setPointValue(pt *metricspb.Point, value float64, mType measureType) {
+	if mType == measureInt64 {
+		pt.Value = &metricspb.Point_Int64Value{Int64Value: int64(value)}
+	} else {
+		pt.Value = &metricspb.Point_DoubleValue{DoubleValue: value}
+	}
+}
+
+func bucketsToProtoBuckets(countPerBucket []int64) []*metricspb.DistributionValue_Bucket {
+	distBuckets := make([]*metricspb.DistributionValue_Bucket, len(countPerBucket))
+	for i := 0; i < len(countPerBucket); i++ {
+		count := countPerBucket[i]
+
+		distBuckets[i] = &metricspb.DistributionValue_Bucket{
+			Count: count,
+		}
+	}
+
+	return distBuckets
+}
+
+func labelValuesFromTags(tags []tag.Tag) []*metricspb.LabelValue {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	labelValues := make([]*metricspb.LabelValue, 0, len(tags))
+	for _, tag_ := range tags {
+		labelValues = append(labelValues, &metricspb.LabelValue{
+			Value: tag_.Value,
+
+			// It is imperative that we set the "HasValue" attribute,
+			// in order to distinguish missing a label from the empty string.
+			// https://godoc.org/github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1#LabelValue.HasValue
+			//
+			// OpenCensus-Go uses non-pointers for tags as seen by this function's arguments,
+			// so the best case that we can use to distinguish missing labels/tags from the
+			// empty string is by checking if the Tag.Key.Name() != "" to indicate that we have
+			// a value.
+			HasValue: tag_.Key.Name() != "",
+		})
+	}
+	return labelValues
+}

--- a/receiver/vmmetricsreceiver/vm_metrics_collector.go
+++ b/receiver/vmmetricsreceiver/vm_metrics_collector.go
@@ -1,0 +1,215 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vmmetricsreceiver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/prometheus/procfs"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/trace"
+
+	"github.com/census-instrumentation/opencensus-service/consumer"
+	"github.com/census-instrumentation/opencensus-service/data"
+
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+)
+
+// VMMetricsCollector is a struct that contains views related to VM and process metrics (cpu, mem, etc),
+// collects and reports metrics for those views.
+type VMMetricsCollector struct {
+	consumer consumer.MetricsConsumer
+
+	startTime      time.Time
+	views          []*view.View
+	fs             procfs.FS
+	scrapeInterval time.Duration
+	metricPrefix   string
+	done           chan struct{}
+}
+
+var mRuntimeAllocMem = stats.Int64("process/memory_alloc", "Number of bytes currently allocated in use", "By")
+var viewAllocMem = &view.View{
+	Name:        mRuntimeAllocMem.Name(),
+	Description: mRuntimeAllocMem.Description(),
+	Measure:     mRuntimeAllocMem,
+	Aggregation: view.LastValue(),
+	TagKeys:     nil,
+}
+
+var mRuntimeTotalAllocMem = stats.Int64("process/total_memory_alloc", "Number of allocations in total", "By")
+var viewTotalAllocMem = &view.View{
+	Name:        mRuntimeTotalAllocMem.Name(),
+	Description: mRuntimeTotalAllocMem.Description(),
+	Measure:     mRuntimeTotalAllocMem,
+	Aggregation: view.LastValue(),
+	TagKeys:     nil,
+}
+
+var mRuntimeSysMem = stats.Int64("process/sys_memory_alloc", "Number of bytes given to the process to use in total", "By")
+var viewSysMem = &view.View{
+	Name:        mRuntimeSysMem.Name(),
+	Description: mRuntimeSysMem.Description(),
+	Measure:     mRuntimeSysMem,
+	Aggregation: view.LastValue(),
+	TagKeys:     nil,
+}
+
+var mCPUSeconds = stats.Int64("process/cpu_seconds", "CPU seconds for this process", "1")
+var viewCPUSeconds = &view.View{
+	Name:        mCPUSeconds.Name(),
+	Description: mCPUSeconds.Description(),
+	Measure:     mCPUSeconds,
+	Aggregation: view.LastValue(),
+	TagKeys:     nil,
+}
+
+var mUserCPUSeconds = stats.Float64("system/cpu_seconds/user", "Total kernel/system user CPU seconds", "s")
+var viewUserCPUSeconds = &view.View{
+	Name:        mUserCPUSeconds.Name(),
+	Description: mUserCPUSeconds.Description(),
+	Measure:     mUserCPUSeconds,
+	Aggregation: view.Sum(),
+	TagKeys:     nil,
+}
+
+var mSystemCPUSeconds = stats.Float64("system/cpu_seconds/system", "Total kernel/system system CPU seconds", "s")
+var viewSystemCPUSeconds = &view.View{
+	Name:        mSystemCPUSeconds.Name(),
+	Description: mSystemCPUSeconds.Description(),
+	Measure:     mSystemCPUSeconds,
+	Aggregation: view.Sum(),
+	TagKeys:     nil,
+}
+
+var mIdleCPUSeconds = stats.Float64("system/cpu_seconds/idle", "Total kernel/system idle CPU seconds", "s")
+var viewIdleCPUSeconds = &view.View{
+	Name:        mIdleCPUSeconds.Name(),
+	Description: mIdleCPUSeconds.Description(),
+	Measure:     mIdleCPUSeconds,
+	Aggregation: view.Sum(),
+	TagKeys:     nil,
+}
+
+var views = []*view.View{viewAllocMem, viewTotalAllocMem, viewSysMem, viewCPUSeconds, viewUserCPUSeconds, viewSystemCPUSeconds, viewIdleCPUSeconds}
+
+// NewVMMetricsCollector creates a new set of ProcessMetrics (mem, cpu) that can be used to measure
+// basic information about this process.
+func NewVMMetricsCollector(si time.Duration, mpoint, mprefix string, consumer consumer.MetricsConsumer) (*VMMetricsCollector, error) {
+	if mpoint == "" {
+		mpoint = procfs.DefaultMountPoint
+	}
+	if si <= 0 {
+		si = 10 * time.Second
+	}
+	fs, err := procfs.NewFS(mpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new VMMetricsCollector: %s", err)
+	}
+	vmc := &VMMetricsCollector{
+		consumer:       consumer,
+		startTime:      time.Now(),
+		views:          views,
+		fs:             fs,
+		scrapeInterval: si,
+		metricPrefix:   mprefix,
+		done:           make(chan struct{}),
+	}
+	view.Register(vmc.views...)
+	return vmc, nil
+}
+
+// StartCollection starts a ticker'd goroutine that will update the PMV measurements every 5 seconds
+func (vmc *VMMetricsCollector) StartCollection() {
+	ticker := time.NewTicker(vmc.scrapeInterval)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				vmc.scrape()
+				vmc.export()
+
+			case <-vmc.done:
+				return
+			}
+		}
+	}()
+}
+
+// StopCollection stops the collection of the process metric information
+func (vmc *VMMetricsCollector) StopCollection() {
+	close(vmc.done)
+}
+
+func (vmc *VMMetricsCollector) scrape() {
+	ms := &runtime.MemStats{}
+	runtime.ReadMemStats(ms)
+	stats.Record(context.Background(), mRuntimeAllocMem.M(int64(ms.Alloc)))
+	stats.Record(context.Background(), mRuntimeTotalAllocMem.M(int64(ms.TotalAlloc)))
+	stats.Record(context.Background(), mRuntimeSysMem.M(int64(ms.Sys)))
+
+	pid := os.Getpid()
+	proc, err := procfs.NewProc(pid)
+	if err == nil {
+		if procStat, err := proc.NewStat(); err == nil {
+			stats.Record(context.Background(), mCPUSeconds.M(int64(procStat.CPUTime())))
+		}
+	}
+
+	if stat, err := vmc.fs.NewStat(); err == nil {
+		cpuStat := stat.CPUTotal
+		stats.Record(context.Background(), mUserCPUSeconds.M(cpuStat.User))
+		stats.Record(context.Background(), mSystemCPUSeconds.M(cpuStat.System))
+		stats.Record(context.Background(), mIdleCPUSeconds.M(cpuStat.Idle))
+	}
+}
+
+func (vmc *VMMetricsCollector) export() {
+	vds := []*view.Data{}
+	for _, v := range vmc.views {
+		if rows, err := view.RetrieveData(v.Name); err == nil {
+			vd := view.Data{
+				View:  v,
+				Start: vmc.startTime,
+				End:   time.Now(),
+				Rows:  rows,
+			}
+			vds = append(vds, &vd)
+		}
+	}
+	vmc.uploadViewData(vds)
+}
+
+func (vmc *VMMetricsCollector) uploadViewData(vds []*view.Data) {
+	if len(vds) == 0 {
+		return
+	}
+
+	ctx, span := trace.StartSpan(context.Background(), "VMMetricsCollector.uploadViewData")
+	defer span.End()
+
+	metrics := make([]*metricspb.Metric, 0, len(vds))
+	for _, vd := range vds {
+		if metric, err := viewDataToMetric(vd); err == nil {
+			metrics = append(metrics, metric)
+		}
+	}
+	vmc.consumer.ConsumeMetricsData(ctx, data.MetricsData{Metrics: metrics})
+}

--- a/receiver/vmmetricsreceiver/vm_metrics_collector.go
+++ b/receiver/vmmetricsreceiver/vm_metrics_collector.go
@@ -45,6 +45,13 @@ type VMMetricsCollector struct {
 	done           chan struct{}
 }
 
+const (
+	defaultMountPoint = procfs.DefaultMountPoint // "/proc"
+	defaultScrapeInterval = 10 * time.Second
+)
+
+// TODO(songy23): remove all measures and views and use Metrics APIs instead.
+
 var mRuntimeAllocMem = stats.Int64("process/memory_alloc", "Number of bytes currently allocated in use", "By")
 var viewAllocMem = &view.View{
 	Name:        mRuntimeAllocMem.Name(),
@@ -114,10 +121,10 @@ var views = []*view.View{viewAllocMem, viewTotalAllocMem, viewSysMem, viewCPUSec
 // basic information about this process.
 func NewVMMetricsCollector(si time.Duration, mpoint, mprefix string, consumer consumer.MetricsConsumer) (*VMMetricsCollector, error) {
 	if mpoint == "" {
-		mpoint = procfs.DefaultMountPoint
+		mpoint = defaultMountPoint
 	}
 	if si <= 0 {
-		si = 10 * time.Second
+		si = defaultScrapeInterval
 	}
 	fs, err := procfs.NewFS(mpoint)
 	if err != nil {

--- a/receiver/vmmetricsreceiver/vm_metrics_constants.go
+++ b/receiver/vmmetricsreceiver/vm_metrics_constants.go
@@ -1,0 +1,145 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vmmetricsreceiver
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+// Measure and view constants for VM and process metrics.
+// TODO(songy23): remove all measures and views and use Metrics APIs instead.
+
+var mRuntimeAllocMem = stats.Int64("process/memory_alloc", "Number of bytes currently allocated in use", "By")
+var viewAllocMem = &view.View{
+	Name:        mRuntimeAllocMem.Name(),
+	Description: mRuntimeAllocMem.Description(),
+	Measure:     mRuntimeAllocMem,
+	Aggregation: view.LastValue(),
+	TagKeys:     nil,
+}
+
+var mRuntimeTotalAllocMem = stats.Int64("process/total_memory_alloc", "Number of allocations in total", "By")
+var viewTotalAllocMem = &view.View{
+	Name:        mRuntimeTotalAllocMem.Name(),
+	Description: mRuntimeTotalAllocMem.Description(),
+	Measure:     mRuntimeTotalAllocMem,
+	Aggregation: view.LastValue(),
+	TagKeys:     nil,
+}
+
+var mRuntimeSysMem = stats.Int64("process/sys_memory_alloc", "Number of bytes given to the process to use in total", "By")
+var viewSysMem = &view.View{
+	Name:        mRuntimeSysMem.Name(),
+	Description: mRuntimeSysMem.Description(),
+	Measure:     mRuntimeSysMem,
+	Aggregation: view.LastValue(),
+	TagKeys:     nil,
+}
+
+var mCPUSeconds = stats.Int64("process/cpu_seconds", "CPU seconds for this process", "1")
+var viewCPUSeconds = &view.View{
+	Name:        mCPUSeconds.Name(),
+	Description: mCPUSeconds.Description(),
+	Measure:     mCPUSeconds,
+	Aggregation: view.LastValue(),
+	TagKeys:     nil,
+}
+
+var mUserCPUSeconds = stats.Float64("system/cpu_seconds/user", "Total kernel/system user CPU seconds", "s")
+var viewUserCPUSeconds = &view.View{
+	Name:        mUserCPUSeconds.Name(),
+	Description: mUserCPUSeconds.Description(),
+	Measure:     mUserCPUSeconds,
+	Aggregation: view.Sum(),
+	TagKeys:     nil,
+}
+
+var mNiceCPUSeconds = stats.Float64("system/cpu_seconds/nice", "Total kernel/system nice CPU seconds", "s")
+var viewNiceCPUSeconds = &view.View{
+	Name:        mNiceCPUSeconds.Name(),
+	Description: mNiceCPUSeconds.Description(),
+	Measure:     mNiceCPUSeconds,
+	Aggregation: view.Sum(),
+	TagKeys:     nil,
+}
+
+var mSystemCPUSeconds = stats.Float64("system/cpu_seconds/system", "Total kernel/system system CPU seconds", "s")
+var viewSystemCPUSeconds = &view.View{
+	Name:        mSystemCPUSeconds.Name(),
+	Description: mSystemCPUSeconds.Description(),
+	Measure:     mSystemCPUSeconds,
+	Aggregation: view.Sum(),
+	TagKeys:     nil,
+}
+
+var mIdleCPUSeconds = stats.Float64("system/cpu_seconds/idle", "Total kernel/system idle CPU seconds", "s")
+var viewIdleCPUSeconds = &view.View{
+	Name:        mIdleCPUSeconds.Name(),
+	Description: mIdleCPUSeconds.Description(),
+	Measure:     mIdleCPUSeconds,
+	Aggregation: view.Sum(),
+	TagKeys:     nil,
+}
+
+var mIowaitCPUSeconds = stats.Float64("system/cpu_seconds/iowait", "Total kernel/system Iowait CPU seconds", "s")
+var viewIowaitCPUSeconds = &view.View{
+	Name:        mIowaitCPUSeconds.Name(),
+	Description: mIowaitCPUSeconds.Description(),
+	Measure:     mIowaitCPUSeconds,
+	Aggregation: view.Sum(),
+	TagKeys:     nil,
+}
+
+var mProcessesCreated = stats.Int64("system/processes/created", "Total number of times a process was created", "1")
+var viewProcessesCreated = &view.View{
+	Name:        mProcessesCreated.Name(),
+	Description: mProcessesCreated.Description(),
+	Measure:     mProcessesCreated,
+	Aggregation: view.Sum(),
+	TagKeys:     nil,
+}
+
+var mProcessesRunning = stats.Int64("system/processes/running", "Total number of running processes", "1")
+var viewProcessesRunning = &view.View{
+	Name:        mProcessesRunning.Name(),
+	Description: mProcessesRunning.Description(),
+	Measure:     mProcessesRunning,
+	Aggregation: view.Sum(),
+	TagKeys:     nil,
+}
+
+var mProcessesBlocked = stats.Int64("system/processes/blocked", "Total number of blocked processes", "1")
+var viewProcessesBlocked = &view.View{
+	Name:        mProcessesBlocked.Name(),
+	Description: mProcessesBlocked.Description(),
+	Measure:     mProcessesBlocked,
+	Aggregation: view.Sum(),
+	TagKeys:     nil,
+}
+
+var vmViews = []*view.View{
+	viewAllocMem,
+	viewTotalAllocMem,
+	viewSysMem,
+	viewCPUSeconds,
+	viewUserCPUSeconds,
+	viewNiceCPUSeconds,
+	viewSystemCPUSeconds,
+	viewIdleCPUSeconds,
+	viewIowaitCPUSeconds,
+	viewProcessesCreated,
+	viewProcessesRunning,
+	viewProcessesBlocked}


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-service/issues/514.

Only for POC purpose. Expose process and system telemetry and let users have access to it.

![vm-metrics-receiver](https://user-images.githubusercontent.com/10536136/55595600-8b92a600-56f9-11e9-9490-02ea8b10cfdd.png)
