### PR TITLE
During exporter initialization, log error and continue to run.

### DIFF
--- a/cmd/ocagent/main.go
+++ b/cmd/ocagent/main.go
@@ -113,9 +113,11 @@ func runOCAgent() {
 		log.Fatalf("Failed to start net/http/pprof: %v", err)
 	}
 
-	traceExporters, metricsExporters, closeFns, err := config.ExportersFromViperConfig(logger, viperCfg)
-	if err != nil {
-		log.Fatalf("Config: failed to create exporters from YAML: %v", err)
+	traceExporters, metricsExporters, closeFns, errs := config.ExportersFromViperConfig(logger, viperCfg)
+	if len(errs) > 0 {
+		for _, err := range errs {
+			log.Printf("Config: failed to create exporter from YAML: %v", err)
+		}
 	}
 
 	commonSpanSink := multiconsumer.NewTraceProcessor(traceExporters)

--- a/cmd/occollector/app/collector/processors.go
+++ b/cmd/occollector/app/collector/processors.go
@@ -38,9 +38,11 @@ import (
 
 func createExporters(v *viper.Viper, logger *zap.Logger) ([]func(), []consumer.TraceConsumer, []consumer.MetricsConsumer) {
 	// TODO: (@pjanotti) this is slightly modified from agent but in the end duplication, need to consolidate style and visibility.
-	traceExporters, metricsExporters, doneFns, err := config.ExportersFromViperConfig(logger, v)
-	if err != nil {
-		logger.Fatal("Failed to create config for exporters", zap.Error(err))
+	traceExporters, metricsExporters, doneFns, errs := config.ExportersFromViperConfig(logger, v)
+	if len(errs) > 0 {
+		for _, err := range errs {
+			logger.Error("Failed to create config for exporter %v", zap.Error(err))
+		}
 	}
 
 	wrappedDoneFns := make([]func(), 0, len(doneFns))


### PR DESCRIPTION
In a case where there are multiple exporters and if one them doesn't work for whatever reason, it should still continue to run and export metrics/traces through other exporters.
