### PR TITLE
receiver/vmmetrics: Allow to have a different process mount point.

### DIFF
--- a/receiver/vmmetricsreceiver/example_config.yaml
+++ b/receiver/vmmetricsreceiver/example_config.yaml
@@ -1,6 +1,6 @@
 receivers:
   vmmetrics:
-    scrape_interval: 10s
+    scrape_interval: 10
     mount_point: "/proc"
     # process_mount_point: "/data/proc" # Should only be used for Daemon Set within a container.
 

--- a/receiver/vmmetricsreceiver/example_config.yaml
+++ b/receiver/vmmetricsreceiver/example_config.yaml
@@ -1,6 +1,8 @@
 receivers:
   vmmetrics:
     scrape_interval: 10s
+    mount_point: "/proc"
+    # process_mount_point: "/data/proc" # Should only be used for Daemon Set within a container.
 
 zpages:
   port: 55679

--- a/receiver/vmmetricsreceiver/metrics_receiver.go
+++ b/receiver/vmmetricsreceiver/metrics_receiver.go
@@ -60,7 +60,7 @@ func New(v *viper.Viper, consumer consumer.MetricsConsumer) (*Receiver, error) {
 	var cfg Configuration
 
 	// Unmarshal our config values (using viper's mapstructure)
-	err := v.Unmarshal(&cfg)
+	err := unmarshal(&cfg, v.AllSettings())
 	if err != nil {
 		return nil, fmt.Errorf("vmmetrics receiver failed to parse config: %s", err)
 	}
@@ -107,4 +107,22 @@ func (vmr *Receiver) StopMetricsReception(ctx context.Context) error {
 		err = nil
 	})
 	return err
+}
+
+// TODO(songya): investigate why viper.Unmarshal didn't work, remove this method and use viper.Unmarshal instead.
+func unmarshal(cfg *Configuration, settings map[string]interface{}) error {
+	if interval, ok := settings["scrape_interval"]; ok {
+		intervalInSecs := interval.(int)
+		cfg.scrapeInterval = time.Duration(intervalInSecs * int(time.Second))
+	}
+	if mountPoint, ok := settings["mount_point"]; ok {
+		cfg.mountPoint = mountPoint.(string)
+	}
+	if processMountPoint, ok := settings["process_mount_point"]; ok {
+		cfg.processMountPoint = processMountPoint.(string)
+	}
+	if prefix, ok := settings["metric_prefix"]; ok {
+		cfg.metricPrefix = prefix.(string)
+	}
+	return nil
 }

--- a/receiver/vmmetricsreceiver/metrics_receiver.go
+++ b/receiver/vmmetricsreceiver/metrics_receiver.go
@@ -35,9 +35,10 @@ var (
 
 // Configuration defines the behavior and targets of the VM metrics scrapers.
 type Configuration struct {
-	scrapeInterval time.Duration `mapstructure:"scrape_interval"`
-	mountPoint     string        `mapstructure:"mount_point"`
-	metricPrefix   string        `mapstructure:"metric_prefix"`
+	scrapeInterval    time.Duration `mapstructure:"scrape_interval"`
+	mountPoint        string        `mapstructure:"mount_point"`
+	processMountPoint string        `mapstructure:"process_mount_point"`
+	metricPrefix      string        `mapstructure:"metric_prefix"`
 }
 
 // Receiver is the type used to handle metrics from VM metrics.
@@ -64,7 +65,7 @@ func New(v *viper.Viper, consumer consumer.MetricsConsumer) (*Receiver, error) {
 		return nil, fmt.Errorf("vmmetrics receiver failed to parse config: %s", err)
 	}
 
-	vmc, err := NewVMMetricsCollector(cfg.scrapeInterval, cfg.mountPoint, cfg.metricPrefix, consumer)
+	vmc, err := NewVMMetricsCollector(cfg.scrapeInterval, cfg.mountPoint, cfg.processMountPoint, cfg.metricPrefix, consumer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In cases like when OC-Agent is running as a daemon set, the mount point of daemon set process may be different from the default one. Adding an option to allow users specify a different mount point for Agent process.