### PR TITLE
Set default project when on GCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ exporters:
     topic: "opencensus-spans"
 
   stackdriver:
-    project: "your-project-id"
+    project: "my-project-id" # optional, defaults to agent project if run on GCP
     enable_tracing: true
 
   zipkin:

--- a/cmd/ocagent/config.yaml
+++ b/cmd/ocagent/config.yaml
@@ -7,7 +7,7 @@ receivers:
 
 exporters:
     stackdriver:
-        project: "project-id"
+        project: "project-id" # Optional if on GCP, defaults to agent project
         enable_tracing: true
 
     zipkin:

--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -62,12 +62,12 @@ func StackdriverTraceExportersFromViper(v *viper.Viper) (tps []consumer.TraceCon
 
 	// TODO:  For each ProjectID, create a different exporter
 	// or at least a unique Stackdriver client per ProjectID.
-	if sc.ProjectID == "" {
-		return nil, nil, nil, fmt.Errorf("Stackdriver config requires a project ID")
-	}
 
 	sde, serr := stackdriver.NewExporter(stackdriver.Options{
-		ProjectID:    sc.ProjectID,
+		// If the project ID is an empty string, it will be set by default based on
+		// the project this is running on in GCP.
+		ProjectID: sc.ProjectID,
+
 		MetricPrefix: sc.MetricPrefix,
 
 		// Stackdriver Metrics mandates a minimum of 60 seconds for


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-service/issues/510

This will make it easier to create sample Kubernetes deployment configs for the agent for GCP, since the project ID won't need to be substituted into the exporter, but can just be left blank.

The `stackdriver.NewExporter` already defaults the project based on the GCP metadata if the project ID is set to the empty string, see this [code link](https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/blob/e393203a62e3c9286501f3195fe2f2ca1e35e115/stackdriver.go#L279)