### PR TITLE
exporter: Add Wavefront exporter

### DIFF
--- a/exporter/wavefrontexporter/.nocover
+++ b/exporter/wavefrontexporter/.nocover
@@ -1,0 +1,1 @@
+Empty test file

--- a/exporter/wavefrontexporter/README.md
+++ b/exporter/wavefrontexporter/README.md
@@ -18,9 +18,9 @@ exporters:
     # One of "proxy" or "direct_ingestion" is required
     proxy:
       Host: "<Proxy_IP_or_FQDN>"
-      MetricsPort: port
-      TracingPort: port
-      DistributionPort: port
+      MetricsPort: <wf_metrics_port>
+      TracingPort: <wf_trace_port>
+      DistributionPort: <wf_distribution_port>
     direct_ingestion:
       Server: "<wavefront_url>"
       Token: "<wavefront_token>"

--- a/exporter/wavefrontexporter/README.md
+++ b/exporter/wavefrontexporter/README.md
@@ -1,0 +1,62 @@
+# Wavefront Agent Exporter
+
+- [Format](#format)
+- [Proxy Example](#proxy-example)
+- [Direct Ingestion Example](#direct-ingestion-example)
+
+### Configuration
+Wavefront exporter supports sending data using Direct Ingestion (`direct_ingestion`) or via Wavefront Proxy (`proxy`).
+
+In the Service's YAML configuration file, under section "exporters" and sub-section "wavefront", please configure these fields. 
+
+### Format
+```yaml
+exporters:
+  wavefront:
+    enable_traces: true|false
+
+    # One of "proxy" or "direct_ingestion" is required
+    proxy:
+      Host: "<Proxy_IP_or_FQDN>"
+      MetricsPort: port
+      TracingPort: port
+      DistributionPort: port
+    direct_ingestion:
+      Server: "<wavefront_url>"
+      Token: "<wavefront_token>"
+
+    # The following are optional
+    override_source: "<source_name>"
+    application_name: "<app_name>"
+    service_name: "<service_name>"
+    custom_tags:
+      - "<key1>" : "<val1>"
+      - "<key2>" : "<val2>"
+      # ...
+    max_queue_size: number
+    verbose_logging: true|false
+```
+
+### Proxy Example
+```yaml
+exporters:
+  wavefront:
+    proxy:
+      Host: "localhost"
+      TracingPort: 30000
+    enable_traces: true
+```
+
+### Direct Ingestion Example
+```yaml
+exporters:
+  wavefront:
+    direct_ingestion:
+      Server: "https://<MYINSTANCE>.wavefront.com"
+      Token: "MY_WAVEFRONT_TOKEN_HERE"
+    enable_traces: true
+```
+
+### References
+- [https://github.com/wavefrontHQ/opencensus-exporter](https://github.com/wavefrontHQ/opencensus-exporter) 
+- [https://github.com/wavefrontHQ/wavefront-sdk-go](https://github.com/wavefrontHQ/wavefront-sdk-go)

--- a/exporter/wavefrontexporter/wavefront.go
+++ b/exporter/wavefrontexporter/wavefront.go
@@ -1,0 +1,91 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wavefrontexporter
+
+import (
+	"errors"
+
+	"github.com/wavefronthq/opencensus-exporter/wavefront"
+	"github.com/wavefronthq/wavefront-sdk-go/senders"
+
+	"github.com/spf13/viper"
+
+	"github.com/census-instrumentation/opencensus-service/consumer"
+	"github.com/census-instrumentation/opencensus-service/exporter/exporterwrapper"
+)
+
+type wavefrontConfig struct {
+	ProxyConfiguration       *senders.ProxyConfiguration  `mapstructure:"proxy,omitempty"`
+	DirectConfiguration      *senders.DirectConfiguration `mapstructure:"direct_ingestion,omitempty"`
+	wavefront.ServiceOptions `mapstructure:",squash"`
+
+	EnableTracing bool `mapstructure:"enable_tracing,omitempty"`
+	EnableMetrics bool `mapstructure:"enable_metrics,omitempty"`
+}
+
+// WavefrontTraceExportersFromViper unmarshals the viper and returns trace and metric consumers.
+func WavefrontTraceExportersFromViper(v *viper.Viper) (tps []consumer.TraceConsumer, mps []consumer.MetricsConsumer, doneFns []func() error, err error) {
+	var cfg struct {
+		Wavefront *wavefrontConfig `mapstructure:"wavefront,omitempty"`
+	}
+	if err := v.Unmarshal(&cfg); err != nil {
+		return nil, nil, nil, err
+	}
+
+	wc := cfg.Wavefront
+	if wc == nil {
+		return nil, nil, nil, nil
+	}
+	if !wc.EnableTracing && !wc.EnableMetrics {
+		return nil, nil, nil, nil
+	}
+
+	var ws senders.Sender
+
+	switch {
+	case wc.ProxyConfiguration != nil:
+		ws, err = senders.NewProxySender(wc.ProxyConfiguration)
+	case wc.DirectConfiguration != nil:
+		ws, err = senders.NewDirectSender(wc.DirectConfiguration)
+	default:
+		err = errors.New("At least one of 'proxy' or 'direct_ingestion' must be specified")
+	}
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	we, err := wavefront.NewExporter(ws, wavefront.WithServiceOptions(&wc.ServiceOptions))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	doneFns = append(doneFns, func() error {
+		we.Stop()
+		ws.Close()
+		return nil
+	})
+
+	wew, err := exporterwrapper.NewExporterWrapper("wavefront", "ocservice.exporter.Wavefront.ConsumeTraceData", we)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	tps = append(tps, wew)
+
+	// TODO: Metrics Exporter. NewExporterWrapper only creates Trace Exporter now.
+	// mps = append(mps, wew)
+
+	return
+}

--- a/exporter/wavefrontexporter/wavefront_test.go
+++ b/exporter/wavefrontexporter/wavefront_test.go
@@ -1,0 +1,17 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wavefrontexporter
+
+// TODO: Add tests.

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,8 @@ require (
 	github.com/uber/jaeger-client-go v2.16.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.0.0+incompatible
 	github.com/uber/tchannel-go v1.10.0
+	github.com/wavefronthq/opencensus-exporter v0.0.0-20190506162721-983d7cdaceaf
+	github.com/wavefronthq/wavefront-sdk-go v0.9.2
 	github.com/yancl/opencensus-go-exporter-kafka v0.0.0-20181029030031-9c471c1bfbeb
 	go.opencensus.io v0.21.0
 	go.uber.org/atomic v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8/go.mod h1:Iev9Q3MErcn+w3UOJD/DkEzllvugfdx7bGcMOFhvr/4=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDfD5VcY4CIfh1hRXBUavxrvELjTiOE=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
+github.com/caio/go-tdigest v2.3.0+incompatible h1:zP6nR0nTSUzlSqqr7F/LhslPlSZX/fZeGmgmwj2cxxY=
+github.com/caio/go-tdigest v2.3.0+incompatible/go.mod h1:sHQM/ubZStBUmF1WbB8FAm8q9GjDajLC5T7ydxE3JHI=
 github.com/cenk/backoff v2.0.0+incompatible/go.mod h1:7FtoeaSnHoZnmZzz47cM35Y9nSW7tNyaidugnHTaFDE=
 github.com/census-instrumentation/opencensus-proto v0.0.2/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.0 h1:LzQXZOgg4CQfE6bFvXGM30YZL1WW/M337pXml+GrcZ4=
@@ -231,6 +233,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/leesper/go_rng v0.0.0-20171009123644-5344a9259b21/go.mod h1:N0SVk0uhy+E1PZ3C9ctsPRlvOPAFPkCNlcPBDkt0N3U=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lightstep/lightstep-tracer-go v0.15.6/go.mod h1:6AMpwZpsyCFwSovxzM78e+AsYxE8sGwiM6C3TytaWeI=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
@@ -382,6 +385,10 @@ github.com/uber/jaeger-lib v2.0.0+incompatible h1:iMSCV0rmXEogjNWPh2D0xk9YVKvrtG
 github.com/uber/jaeger-lib v2.0.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/uber/tchannel-go v1.10.0 h1:YOihLHuvkwT3nzvpgqFtexFW+pb5vD1Tz7h/bIWApgE=
 github.com/uber/tchannel-go v1.10.0/go.mod h1:Rrgz1eL8kMjW/nEzZos0t+Heq0O4LhnUJVA32OvWKHo=
+github.com/wavefronthq/opencensus-exporter v0.0.0-20190506162721-983d7cdaceaf h1:KO5PCIdHHzqs9c9fanhFuBxhK5eRiRz1ZGTqTrm17FU=
+github.com/wavefronthq/opencensus-exporter v0.0.0-20190506162721-983d7cdaceaf/go.mod h1:2pXfsubgEW9xaV795VimF4TNNQDyl6YpLCwTInzUvCU=
+github.com/wavefronthq/wavefront-sdk-go v0.9.2 h1:/LvWgZYNjHFUg+ZUX+qv+7e+M8sEMi0lM15zPp681Gk=
+github.com/wavefronthq/wavefront-sdk-go v0.9.2/go.mod h1:hQI6y8M9OtTCtc0xdwh+dCER4osxXdEAeCpacjpDZEU=
 github.com/yancl/opencensus-go-exporter-kafka v0.0.0-20181029030031-9c471c1bfbeb h1:DSch+h+LW/9zO8ImnA2KzFylC/ShRAAgRPJVlx6FMSA=
 github.com/yancl/opencensus-go-exporter-kafka v0.0.0-20181029030031-9c471c1bfbeb/go.mod h1:zfby7AY8Vh0VWAMyiFKkTvMyYKAmWTT5x3DSAOJM6xM=
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=
@@ -399,6 +406,7 @@ golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -451,9 +459,12 @@ golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52 h1:JG/0uqcGdTNgq7FdU+61l5P
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181023010539-40a48ad93fbe/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+gonum.org/v1/gonum v0.0.0-20190506115330-fb5cd163d924/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
+gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 google.golang.org/api v0.0.0-20180506000402-20530fd5d65a/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181017004218-3f6e8463aa1d/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ import (
 	"github.com/census-instrumentation/opencensus-service/exporter/opencensusexporter"
 	"github.com/census-instrumentation/opencensus-service/exporter/prometheusexporter"
 	"github.com/census-instrumentation/opencensus-service/exporter/stackdriverexporter"
+	"github.com/census-instrumentation/opencensus-service/exporter/wavefrontexporter"
 	"github.com/census-instrumentation/opencensus-service/exporter/zipkinexporter"
 	"github.com/census-instrumentation/opencensus-service/receiver/opencensusreceiver"
 	"github.com/census-instrumentation/opencensus-service/receiver/prometheusreceiver"
@@ -457,6 +458,7 @@ func ExportersFromViperConfig(logger *zap.Logger, v *viper.Viper) ([]consumer.Tr
 		name string
 		fn   func(*viper.Viper) ([]consumer.TraceConsumer, []consumer.MetricsConsumer, []func() error, error)
 	}{
+		{name: "wavefront", fn: wavefrontexporter.WavefrontTraceExportersFromViper},
 		{name: "datadog", fn: datadogexporter.DatadogTraceExportersFromViper},
 		{name: "stackdriver", fn: stackdriverexporter.StackdriverTraceExportersFromViper},
 		{name: "zipkin", fn: zipkinexporter.ZipkinExportersFromViper},


### PR DESCRIPTION
Add Wavefront exporter to agent.

This exporter currently uses `exporterwrapper` on the existing opencensus-go's `trace.Exporter` work from:
https://github.com/wavefrontHQ/opencensus-exporter
The above exporter supports exporting both traces and stats.

Sample usage is provided in README as a PR hasn't been opened for opencensus-website yet.

I've left the copyright/license lines blank as I was unsure. Above repo is Apache-2.0.

CC @songy23 @odeke-em 