### PR TITLE
Add span attribute key mapping support (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,9 +277,13 @@ agent/client health information/inventory metadata to downstream exporters.
 
 ### <a name="global-attributes"></a> Global Attributes
 
-The collector also takes some global configurations that modify its behavior for all receivers / exporters. One of the configurations
-available is to add Attributes or Tags to all spans passing through this collector. These additional attributes can be configured to either overwrite
-attributes if they already exists on the span, or respect the original values. An example of this is provided below.
+The collector also takes some global configurations that modify its behavior for all receivers / exporters. 
+
+1. Add Attributes to all spans passing through this collector. These additional attributes can be configured to either overwrite existing keys if they already exists on the span, or respect the original values.
+2. The key of each attribute can also be mapped to different stringss using the `key-mapping` configuration. The key matching is case sensitive.
+
+An example using these configurations of this is provided below.
+
 ```yaml
 global:
   attributes:
@@ -290,6 +294,14 @@ global:
       some_int: 1234
       some_float: 3.14159
       some_bool: false
+    key-mapping:
+      # key-mapping is used to replace the attribute key with different keys
+      - key: servertracer.http.responsecode
+        replacement: http.status_code
+      - key:  servertracer.http.responsephrase
+        replacement: http.message
+        overwrite: true # replace attribute key even if the replacement string is already a key on the span attributes
+        keep: true # keep the attribute with the original key
 ```
 
 ### <a name="tail-sampling"></a>Intelligent Sampling

--- a/README.md
+++ b/README.md
@@ -279,8 +279,8 @@ agent/client health information/inventory metadata to downstream exporters.
 
 The collector also takes some global configurations that modify its behavior for all receivers / exporters. 
 
-1. Add Attributes to all spans passing through this collector. These additional attributes can be configured to either overwrite existing keys if they already exists on the span, or respect the original values.
-2. The key of each attribute can also be mapped to different stringss using the `key-mapping` configuration. The key matching is case sensitive.
+1. Add Attributes to all spans passing through this collector. These additional attributes can be configured to either overwrite existing keys if they already exist on the span, or respect the original values.
+2. The key of each attribute can also be mapped to different strings using the `key-mapping` configuration. The key matching is case sensitive.
 
 An example using these configurations of this is provided below.
 

--- a/cmd/occollector/app/builder/processor_builder.go
+++ b/cmd/occollector/app/builder/processor_builder.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+
+	"github.com/census-instrumentation/opencensus-service/processor/attributekeyprocessor"
 )
 
 // SenderType indicates the type of sender
@@ -126,8 +128,9 @@ type QueuedSpanProcessorCfg struct {
 // AttributesCfg holds configuration for attributes that can be added to all spans
 // going through a processor.
 type AttributesCfg struct {
-	Overwrite bool                   `mapstructure:"overwrite"`
-	Values    map[string]interface{} `mapstructure:"values"`
+	Overwrite       bool                                   `mapstructure:"overwrite"`
+	Values          map[string]interface{}                 `mapstructure:"values"`
+	KeyReplacements []attributekeyprocessor.KeyReplacement `mapstructure:"key-mapping,omitempty"`
 }
 
 // GlobalProcessorCfg holds global configuration values that apply to all processors

--- a/cmd/occollector/app/builder/processor_builder_test.go
+++ b/cmd/occollector/app/builder/processor_builder_test.go
@@ -1,0 +1,89 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/census-instrumentation/opencensus-service/processor/attributekeyprocessor"
+)
+
+func TestGlobalProcessorCfg_InitFromViper(t *testing.T) {
+	tests := []struct {
+		name string
+		file string
+		want *AttributesCfg
+	}{
+		{
+			name: "key_mapping",
+			file: "./testdata/global_attributes_key_mapping.yaml",
+			want: &AttributesCfg{
+				KeyReplacements: []attributekeyprocessor.KeyReplacement{
+					{
+						Key:    "servertracer.http.responsecode",
+						NewKey: "http.status_code",
+					},
+					{
+						Key:          "servertracer.http.responsephrase",
+						NewKey:       "http.message",
+						Overwrite:    true,
+						KeepOriginal: true,
+					},
+				},
+			},
+		},
+		{
+			name: "all_settings",
+			file: "./testdata/global_attributes_all.yaml",
+			want: &AttributesCfg{
+				Overwrite: true,
+				Values:    map[string]interface{}{"some_string": "hello world"},
+				KeyReplacements: []attributekeyprocessor.KeyReplacement{
+					{
+						Key:    "servertracer.http.responsecode",
+						NewKey: "http.status_code",
+					},
+					{
+						Key:          "servertracer.http.responsephrase",
+						NewKey:       "http.message",
+						Overwrite:    true,
+						KeepOriginal: true,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := loadViperFromFile(tt.file)
+			if err != nil {
+				t.Fatalf("Failed to load viper from test file: %v", err)
+			}
+
+			cfg := NewDefaultMultiSpanProcessorCfg().InitFromViper(v)
+
+			got := cfg.Global.Attributes
+			if got == nil {
+				t.Fatalf("got nil, wan non-nil")
+			}
+
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("Mismatched global configuration\n-Got +Want:\n\t%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/occollector/app/builder/processor_builder_test.go
+++ b/cmd/occollector/app/builder/processor_builder_test.go
@@ -78,7 +78,7 @@ func TestGlobalProcessorCfg_InitFromViper(t *testing.T) {
 
 			got := cfg.Global.Attributes
 			if got == nil {
-				t.Fatalf("got nil, wan non-nil")
+				t.Fatalf("got nil, want non-nil")
 			}
 
 			if diff := cmp.Diff(got, tt.want); diff != "" {

--- a/cmd/occollector/app/builder/testdata/global_attributes_all.yaml
+++ b/cmd/occollector/app/builder/testdata/global_attributes_all.yaml
@@ -1,0 +1,12 @@
+global:
+  attributes:
+    overwrite: true
+    values:
+      some_string: "hello world"
+    key-mapping:
+      - key: servertracer.http.responsecode
+        replacement: http.status_code
+      - key:  servertracer.http.responsephrase
+        replacement: http.message
+        overwrite: true
+        keep: true

--- a/cmd/occollector/app/builder/testdata/global_attributes_key_mapping.yaml
+++ b/cmd/occollector/app/builder/testdata/global_attributes_key_mapping.yaml
@@ -1,0 +1,9 @@
+global:
+  attributes:
+    key-mapping:
+      - key: servertracer.http.responsecode
+        replacement: http.status_code
+      - key: servertracer.http.responsephrase
+        replacement: http.message
+        overwrite: true
+        keep: true

--- a/cmd/occollector/app/collector/processors.go
+++ b/cmd/occollector/app/collector/processors.go
@@ -312,7 +312,11 @@ func startProcessor(v *viper.Viper, logger *zap.Logger) (consumer.TraceConsumer,
 	}
 
 	// Wraps processors in a single one to be connected to all enabled receivers.
-	if multiProcessorCfg.Global != nil && multiProcessorCfg.Global.Attributes != nil {
+	hasAttributesProcessing := multiProcessorCfg.Global != nil &&
+		multiProcessorCfg.Global.Attributes != nil &&
+		(len(multiProcessorCfg.Global.Attributes.Values) > 0 ||
+			len(multiProcessorCfg.Global.Attributes.KeyReplacements) > 0)
+	if hasAttributesProcessing {
 		logger.Info(
 			"Found global attributes config",
 			zap.Bool("overwrite", multiProcessorCfg.Global.Attributes.Overwrite),

--- a/cmd/occollector/app/collector/processors_test.go
+++ b/cmd/occollector/app/collector/processors_test.go
@@ -1,0 +1,106 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/census-instrumentation/opencensus-service/processor/addattributesprocessor"
+	"github.com/census-instrumentation/opencensus-service/processor/attributekeyprocessor"
+	"github.com/census-instrumentation/opencensus-service/processor/multiconsumer"
+	"github.com/census-instrumentation/opencensus-service/processor/processortest"
+)
+
+func Test_startProcessor(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupViperCfg func() *viper.Viper
+		wantExamplar  func(t *testing.T) interface{}
+	}{
+		{
+			name: "incomplete_global_attrib_config",
+			setupViperCfg: func() *viper.Viper {
+				v := viper.New()
+				v.Set("logging-exporter", true)
+				v.Set("global.attributes.overwrite", true)
+				return v
+			},
+			wantExamplar: func(t *testing.T) interface{} {
+				return multiconsumer.NewTraceProcessor(nil)
+			},
+		},
+		{
+			name: "global_attrib_config_values",
+			setupViperCfg: func() *viper.Viper {
+				v := viper.New()
+				v.Set("logging-exporter", true)
+				v.Set("global.attributes.values", map[string]interface{}{"foo": "bar"})
+				return v
+			},
+			wantExamplar: func(t *testing.T) interface{} {
+				nopProcessor := processortest.NewNopTraceProcessor(nil)
+				addAttributesProcessor, err := addattributesprocessor.NewTraceProcessor(nopProcessor)
+				if err != nil {
+					t.Fatalf("addattributesprocessor.NewTraceProcessor() = %v", err)
+				}
+				return addAttributesProcessor
+			},
+		},
+		{
+			name: "global_attrib_config_key_mapping",
+			setupViperCfg: func() *viper.Viper {
+				v := viper.New()
+				v.Set("logging-exporter", true)
+				v.Set("global.attributes.key-mapping",
+					[]map[string]interface{}{
+						{
+							"key":         "foo",
+							"replacement": "bar",
+						},
+					})
+				return v
+			},
+			wantExamplar: func(t *testing.T) interface{} {
+				nopProcessor := processortest.NewNopTraceProcessor(nil)
+				attributeKeyProcessor, err := attributekeyprocessor.NewTraceProcessor(nopProcessor)
+				if err != nil {
+					t.Fatalf("attributekeyprocessor.NewTraceProcessor() = %v", err)
+				}
+				return attributeKeyProcessor
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			consumer, closeFns := startProcessor(tt.setupViperCfg(), zap.NewNop())
+			if consumer == nil {
+				t.Errorf("startProcessor() got nil consumer")
+			}
+			consumerExamplar := tt.wantExamplar(t)
+			if reflect.TypeOf(consumer) != reflect.TypeOf(consumerExamplar) {
+				t.Errorf("startProcessor() got consumer type %q want %q",
+					reflect.TypeOf(consumer),
+					reflect.TypeOf(consumerExamplar))
+			}
+			for _, closeFn := range closeFns {
+				closeFn()
+			}
+		})
+	}
+}

--- a/processor/attributekeyprocessor/attributekeyprocessor.go
+++ b/processor/attributekeyprocessor/attributekeyprocessor.go
@@ -1,0 +1,100 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributekeyprocessor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/census-instrumentation/opencensus-service/consumer"
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/processor"
+)
+
+// KeyReplacement identifies a key and its respective replacement.
+type KeyReplacement struct {
+	// Key the attribute key to be replaced.
+	Key string `mapstructure:"key"`
+	// NewKey is the value that will be used as the new key for the attribute.
+	NewKey string `mapstructure:"replacement"`
+	// Overwrite is set to true to indicate that the replacement should be
+	// performed even if the new key already exists on the attributes.
+	// In this case the original value associated with the new key is lost.
+	Overwrite bool `mapstructure:"overwrite"`
+	// KeepOriginal is set to true to indicate that the original key
+	// should not be removed from the attributes.
+	KeepOriginal bool `mapstructure:"keep"`
+}
+
+type attributekeyprocessor struct {
+	nextConsumer consumer.TraceConsumer
+	replacements []KeyReplacement
+}
+
+var _ processor.TraceProcessor = (*attributekeyprocessor)(nil)
+
+// NewTraceProcessor returns a processor.TraceProcessor
+func NewTraceProcessor(nextConsumer consumer.TraceConsumer, replacements ...KeyReplacement) (processor.TraceProcessor, error) {
+	if nextConsumer == nil {
+		return nil, errors.New("nextConsumer is nil")
+	}
+
+	lenReplacements := len(replacements)
+	if lenReplacements > 0 {
+		seenKeys := make(map[string]bool, lenReplacements)
+		seenNewKeys := make(map[string]bool, lenReplacements)
+		for _, replacement := range replacements {
+			if seenKeys[replacement.Key] {
+				return nil, fmt.Errorf("replacement key %q already specified", replacement.Key)
+			}
+			seenKeys[replacement.Key] = true
+			if seenNewKeys[replacement.NewKey] {
+				return nil, fmt.Errorf("replacement new key %q already specified", replacement.NewKey)
+			}
+			seenNewKeys[replacement.NewKey] = true
+		}
+	}
+
+	return &attributekeyprocessor{
+		nextConsumer: nextConsumer,
+		replacements: replacements,
+	}, nil
+}
+
+func (akp *attributekeyprocessor) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+	if len(akp.replacements) == 0 {
+		return akp.nextConsumer.ConsumeTraceData(ctx, td)
+	}
+	for _, span := range td.Spans {
+		if span == nil || span.Attributes == nil || len(span.Attributes.AttributeMap) == 0 {
+			// Nothing to do
+			continue
+		}
+
+		attribMap := span.Attributes.AttributeMap
+		for _, replacement := range akp.replacements {
+			if keyValue, oldKeyPresent := attribMap[replacement.Key]; oldKeyPresent {
+				if _, newKeyPresent := attribMap[replacement.NewKey]; !newKeyPresent || replacement.Overwrite {
+					attribMap[replacement.NewKey] = keyValue
+					if !replacement.KeepOriginal {
+						delete(attribMap, replacement.Key)
+					}
+				}
+			}
+		}
+	}
+	return akp.nextConsumer.ConsumeTraceData(ctx, td)
+}

--- a/processor/attributekeyprocessor/attributekeyprocessor.go
+++ b/processor/attributekeyprocessor/attributekeyprocessor.go
@@ -55,16 +55,15 @@ func NewTraceProcessor(nextConsumer consumer.TraceConsumer, replacements ...KeyR
 	lenReplacements := len(replacements)
 	if lenReplacements > 0 {
 		seenKeys := make(map[string]bool, lenReplacements)
-		seenNewKeys := make(map[string]bool, lenReplacements)
 		for _, replacement := range replacements {
 			if seenKeys[replacement.Key] {
 				return nil, fmt.Errorf("replacement key %q already specified", replacement.Key)
 			}
 			seenKeys[replacement.Key] = true
-			if seenNewKeys[replacement.NewKey] {
+			if seenKeys[replacement.NewKey] {
 				return nil, fmt.Errorf("replacement new key %q already specified", replacement.NewKey)
 			}
-			seenNewKeys[replacement.NewKey] = true
+			seenKeys[replacement.NewKey] = true
 		}
 	}
 

--- a/processor/attributekeyprocessor/attributekeyprocessor_test.go
+++ b/processor/attributekeyprocessor/attributekeyprocessor_test.go
@@ -1,0 +1,317 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributekeyprocessor
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/census-instrumentation/opencensus-service/consumer"
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/exporter/exportertest"
+	"github.com/census-instrumentation/opencensus-service/processor"
+	"github.com/census-instrumentation/opencensus-service/processor/processortest"
+)
+
+func TestNewTraceProcessor(t *testing.T) {
+	nopProcessor := processortest.NewNopTraceProcessor(nil)
+	type args struct {
+		nextConsumer consumer.TraceConsumer
+		replacements []KeyReplacement
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    processor.TraceProcessor
+		wantErr bool
+	}{
+		{
+			name:    "nextConsumer_nil",
+			wantErr: true,
+		},
+		{
+			name: "empty_replacements",
+			args: args{
+				nextConsumer: nopProcessor,
+			},
+			want: &attributekeyprocessor{
+				nextConsumer: nopProcessor,
+			},
+		},
+		{
+			name: "duplicated_key",
+			args: args{
+				nextConsumer: nopProcessor,
+				replacements: []KeyReplacement{
+					{
+						Key:    "foo",
+						NewKey: "baz",
+					},
+					{
+						Key:    "bar",
+						NewKey: "biz",
+					},
+					{
+						Key:    "foo",
+						NewKey: "bit",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicated_newKey",
+			args: args{
+				nextConsumer: nopProcessor,
+				replacements: []KeyReplacement{
+					{
+						Key:    "foo",
+						NewKey: "baz",
+					},
+					{
+						Key:    "bar",
+						NewKey: "biz",
+					},
+					{
+						Key:    "biz",
+						NewKey: "baz",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "happy_path",
+			args: args{
+				nextConsumer: nopProcessor,
+				replacements: []KeyReplacement{
+					{
+						Key:    "foo",
+						NewKey: "baz",
+					},
+					{
+						Key:    "bar",
+						NewKey: "biz",
+					},
+				},
+			},
+			want: &attributekeyprocessor{
+				nextConsumer: nopProcessor,
+				replacements: []KeyReplacement{
+					{
+						Key:    "foo",
+						NewKey: "baz",
+					},
+					{
+						Key:    "bar",
+						NewKey: "biz",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewTraceProcessor(tt.args.nextConsumer, tt.args.replacements...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewTraceProcessor() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewTraceProcessor() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_attributekeyprocessor_ConsumeTraceData(t *testing.T) {
+	tests := []struct {
+		name string
+		args []KeyReplacement
+		td   data.TraceData
+		want []data.TraceData
+	}{
+		{
+			name: "keyMap_nil",
+			want: []data.TraceData{
+				{},
+			},
+		},
+		{
+			name: "span_nil",
+			args: []KeyReplacement{
+				{
+					Key:    "foo",
+					NewKey: "bar",
+				},
+			},
+			td: data.TraceData{
+				Spans: make([]*tracepb.Span, 1, 1),
+			},
+			want: []data.TraceData{
+				{
+					Spans: make([]*tracepb.Span, 1, 1),
+				},
+			},
+		},
+		{
+			name: "span_Attributes_nil",
+			args: []KeyReplacement{
+				{
+					Key:    "foo",
+					NewKey: "bar",
+				},
+			},
+			td: data.TraceData{
+				Spans: []*tracepb.Span{
+					{
+						Name: &tracepb.TruncatableString{Value: "test"},
+					},
+				},
+			},
+			want: []data.TraceData{
+				{
+					Spans: []*tracepb.Span{
+						{
+							Name: &tracepb.TruncatableString{Value: "test"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "span_Attributes_AttributeMap_nil",
+			args: []KeyReplacement{
+				{
+					Key:    "foo",
+					NewKey: "bar",
+				},
+			},
+			td: data.TraceData{
+				Spans: []*tracepb.Span{
+					{
+						Name:       &tracepb.TruncatableString{Value: "test"},
+						Attributes: &tracepb.Span_Attributes{},
+					},
+				},
+			},
+			want: []data.TraceData{
+				{
+					Spans: []*tracepb.Span{
+						{
+							Name:       &tracepb.TruncatableString{Value: "test"},
+							Attributes: &tracepb.Span_Attributes{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "span_replace_key",
+			args: []KeyReplacement{
+				{
+					Key:          "foo",
+					NewKey:       "bar",
+					KeepOriginal: true,
+				},
+				{
+					Key:    "servertracer.http.responsecode",
+					NewKey: "http.status_code",
+				},
+				{
+					Key:       "servertracer.http.responsephrase",
+					NewKey:    "http.message",
+					Overwrite: true,
+				},
+			},
+			td: data.TraceData{
+				Spans: []*tracepb.Span{
+					{
+						Name: &tracepb.TruncatableString{Value: "test"},
+						Attributes: &tracepb.Span_Attributes{
+							AttributeMap: map[string]*tracepb.AttributeValue{
+								"servertracer.http.responsecode": {
+									Value: &tracepb.AttributeValue_IntValue{IntValue: 503},
+								},
+								"servertracer.http.responsephrase": {
+									Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "Service Unavailable"}},
+								},
+								"http.message": {
+									Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "Server Internal Error"}},
+								},
+								"foo": {
+									Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "foo"}},
+								},
+								"biz": {
+									Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "foo"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []data.TraceData{
+				{
+					Spans: []*tracepb.Span{
+						{
+							Name: &tracepb.TruncatableString{Value: "test"},
+							Attributes: &tracepb.Span_Attributes{
+								AttributeMap: map[string]*tracepb.AttributeValue{
+									"http.status_code": {
+										Value: &tracepb.AttributeValue_IntValue{IntValue: 503},
+									},
+									"http.message": {
+										Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "Service Unavailable"}},
+									},
+									"bar": {
+										Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "foo"}},
+									},
+									"foo": {
+										Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "foo"}},
+									},
+									"biz": {
+										Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "foo"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sinkExporter := &exportertest.SinkTraceExporter{}
+			akp, err := NewTraceProcessor(sinkExporter, tt.args...)
+			if err != nil {
+				t.Errorf("NewTraceProcessor() error = %v, want nil", err)
+				return
+			}
+
+			if err := akp.ConsumeTraceData(context.Background(), tt.td); err != nil {
+				t.Fatalf("ConsumeTraceData() error = %v, want nil", err)
+			}
+
+			if diff := cmp.Diff(sinkExporter.AllTraces(), tt.want); diff != "" {
+				t.Errorf("Mismatched TraceData\n-Got +Want:\n\t%s", diff)
+			}
+		})
+	}
+}

--- a/processor/attributekeyprocessor/attributekeyprocessor_test.go
+++ b/processor/attributekeyprocessor/attributekeyprocessor_test.go
@@ -76,27 +76,6 @@ func TestNewTraceProcessor(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "duplicated_newKey",
-			args: args{
-				nextConsumer: nopProcessor,
-				replacements: []KeyReplacement{
-					{
-						Key:    "foo",
-						NewKey: "baz",
-					},
-					{
-						Key:    "bar",
-						NewKey: "biz",
-					},
-					{
-						Key:    "bit",
-						NewKey: "biz",
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
 			name: "key_cycle",
 			args: args{
 				nextConsumer: nopProcessor,
@@ -120,7 +99,7 @@ func TestNewTraceProcessor(t *testing.T) {
 				replacements: []KeyReplacement{
 					{
 						Key:    "foo",
-						NewKey: "baz",
+						NewKey: "biz",
 					},
 					{
 						Key:    "bar",
@@ -133,7 +112,7 @@ func TestNewTraceProcessor(t *testing.T) {
 				replacements: []KeyReplacement{
 					{
 						Key:    "foo",
-						NewKey: "baz",
+						NewKey: "biz",
 					},
 					{
 						Key:    "bar",

--- a/processor/attributekeyprocessor/attributekeyprocessor_test.go
+++ b/processor/attributekeyprocessor/attributekeyprocessor_test.go
@@ -89,8 +89,25 @@ func TestNewTraceProcessor(t *testing.T) {
 						NewKey: "biz",
 					},
 					{
-						Key:    "biz",
-						NewKey: "baz",
+						Key:    "bit",
+						NewKey: "biz",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "key_cycle",
+			args: args{
+				nextConsumer: nopProcessor,
+				replacements: []KeyReplacement{
+					{
+						Key:    "foo",
+						NewKey: "bar",
+					},
+					{
+						Key:    "bar",
+						NewKey: "foo",
 					},
 				},
 			},
@@ -239,6 +256,12 @@ func Test_attributekeyprocessor_ConsumeTraceData(t *testing.T) {
 					NewKey:    "http.message",
 					Overwrite: true,
 				},
+				{
+					Key:          "server.process.instance",
+					NewKey:       "process",
+					Overwrite:    true,
+					KeepOriginal: true,
+				},
 			},
 			td: data.TraceData{
 				Spans: []*tracepb.Span{
@@ -254,6 +277,12 @@ func Test_attributekeyprocessor_ConsumeTraceData(t *testing.T) {
 								},
 								"http.message": {
 									Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "Server Internal Error"}},
+								},
+								"server.process.instance": {
+									Value: &tracepb.AttributeValue_IntValue{IntValue: 3},
+								},
+								"process": {
+									Value: &tracepb.AttributeValue_IntValue{IntValue: 5},
 								},
 								"foo": {
 									Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "foo"}},
@@ -278,6 +307,12 @@ func Test_attributekeyprocessor_ConsumeTraceData(t *testing.T) {
 									},
 									"http.message": {
 										Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "Service Unavailable"}},
+									},
+									"server.process.instance": {
+										Value: &tracepb.AttributeValue_IntValue{IntValue: 3},
+									},
+									"process": {
+										Value: &tracepb.AttributeValue_IntValue{IntValue: 3},
 									},
 									"bar": {
 										Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "foo"}},


### PR DESCRIPTION
Many libraries and services didn't implement consistent naming for their span attribute keys, this feature provides the capability of making the attribute keys consistent for different libraries and services without the need to change their code.