### PR TITLE
Add metric labels and trace attributes to stackdriver exporter

### DIFF
--- a/exporter/stackdriverexporter/stackdriverexporter_test.go
+++ b/exporter/stackdriverexporter/stackdriverexporter_test.go
@@ -35,13 +35,6 @@ func TestStackdriverTraceExportersFromViper(t *testing.T) {
 			name: "empty config",
 		},
 		{
-			name: "no project",
-			config: map[string]interface{}{
-				"enable_tracing": true,
-			},
-			wantErr: "no project found",
-		},
-		{
 			name: "tracing enabled",
 			config: map[string]interface{}{
 				"project":        "no-such-project",


### PR DESCRIPTION
Add ability to set trace attributes and metric labels as described in https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/blob/master/stackdriver.go#L210-L228

We set these when using Stackdriver exporter directly in our applications to set pod, namespace, etc inside Kubernetes.

Should also allow one to add labels to address https://github.com/census-instrumentation/opencensus-service/issues/519
