### PR TITLE
Implement Configuration V2 loading and validation

### DIFF
--- a/internal/configv2/configv2.go
+++ b/internal/configv2/configv2.go
@@ -1,0 +1,406 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configv2 implements loading of configuration V2 from Viper configuration.
+// The implementation relies on registered factories that allow creating
+// default configuration for each type of receiver/exporter/option.
+package configv2
+
+import (
+	"fmt"
+
+	"github.com/census-instrumentation/opencensus-service/internal/models"
+	"github.com/spf13/viper"
+)
+
+// These are errors that can be returned by Load(). Note that error codes are not part
+// of Load()'s public API, they are for internal unit testing only.
+type configErrorCode int
+
+const (
+	_ configErrorCode = iota // skip 0, start errors codes from 1
+	errUnknownReceiverType
+	errUnknownExporterType
+	errUnknownOptionType
+	errMissingReceiverType
+	errMissingExporterType
+	errMissingOptionType
+	errDuplicateReceiverName
+	errDuplicateExporterName
+	errDuplicateOptionName
+	errMissingPipelines
+	errMissingPipelineName
+	errPipelineMustHaveReceiver
+	errPipelineMustHaveExporter
+	errPipelineMustHaveOperations
+	errPipelineReceiverNotExists
+	errPipelineOptionNotExists
+	errPipelineExporterNotExists
+	errMetricPipelineCannotHaveOperations
+	errUnmarshalError
+)
+
+type configError struct {
+	msg  string          // human readable error message
+	code configErrorCode // internal error code
+}
+
+func (e *configError) Error() string {
+	return e.msg
+}
+
+// Load loads a ConfigV2 from Viper
+func Load(v *viper.Viper) (*models.ConfigV2, error) {
+
+	// Unmarshal everything that can be automatically unmarshaled (currently only pipelines)
+	var config models.ConfigV2
+	if err := v.Unmarshal(&config); err != nil {
+		return nil, err
+	}
+
+	// Load the rest of entities that are not automatically unmarshaled: receivers, exporters, options.
+
+	receivers, err := loadReceivers(v)
+	if err != nil {
+		return nil, err
+	}
+	config.Receivers = receivers
+
+	exporters, err := loadExporters(v)
+	if err != nil {
+		return nil, err
+	}
+	config.Exporters = exporters
+
+	options, err := loadOptions(v)
+	if err != nil {
+		return nil, err
+	}
+	config.Options = options
+
+	// Config is loaded. Now validate it.
+
+	if err := validateConfig(&config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func loadReceivers(v *viper.Viper) ([]models.ReceiverCfg, error) {
+	// Get the list of all "receivers" items from config source
+	subs, err := getViperSubSequenceOfMaps(v, models.ReceiversKeyName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate over receivers and create a config for each
+	receivers := make([]models.ReceiverCfg, 0)
+	for _, sub := range subs {
+		// Find receiver factory based on "type" that we read from config source
+		typeStr := sub.GetString(models.TypeKeyName)
+		if typeStr == "" {
+			return nil, &configError{code: errMissingReceiverType, msg: fmt.Sprintf("missing receiver type")}
+		}
+
+		factory := models.GetReceiverFactory(typeStr)
+		if factory == nil {
+			return nil, &configError{code: errUnknownReceiverType, msg: fmt.Sprintf("unknown receiver type %q", typeStr)}
+		}
+
+		// Create the default config for this receiver
+		receiverCfg := factory.CreateDefaultConfig()
+
+		// Now that the default config struct is created we can Unmarshal into it
+		// and it will apply user-defined config on top of the default.
+		if err := sub.Unmarshal(receiverCfg); err != nil {
+			return nil, &configError{
+				code: errUnmarshalError,
+				msg:  fmt.Sprintf("error reading settings for receiver type %q: %v", typeStr, err),
+			}
+		}
+		receivers = append(receivers, receiverCfg)
+	}
+
+	return receivers, nil
+}
+
+func loadExporters(v *viper.Viper) ([]models.ExporterCfg, error) {
+	// Get the list of all "exporters" items from config source
+	subs, err := getViperSubSequenceOfMaps(v, models.ExportersKeyName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate over exporters and create a config for each
+	exporters := make([]models.ExporterCfg, 0)
+	for _, sub := range subs {
+		// Find exporter factory based on "type" that we read from config source
+		typeStr := sub.GetString(models.TypeKeyName)
+		if typeStr == "" {
+			return nil, &configError{code: errMissingExporterType, msg: fmt.Sprintf("missing exporter type")}
+		}
+
+		factory := models.GetExporterFactory(typeStr)
+		if factory == nil {
+			return nil, &configError{code: errUnknownExporterType, msg: fmt.Sprintf("unknown exporter type %q", typeStr)}
+		}
+
+		// Create the default config for this exporter
+		exporterCfg := factory.CreateDefaultConfig()
+
+		// Now that the default config struct is created we can Unmarshal into it
+		// and it will apply user-defined config on top of the default.
+		if err := sub.Unmarshal(exporterCfg); err != nil {
+			return nil, &configError{
+				code: errUnmarshalError,
+				msg:  fmt.Sprintf("error reading settings for exporter type %q: %v", typeStr, err),
+			}
+		}
+		exporters = append(exporters, exporterCfg)
+	}
+
+	return exporters, nil
+}
+
+func loadOptions(v *viper.Viper) ([]models.OptionCfg, error) {
+	// Get the list of all "options" items from config source
+	subs, err := getViperSubSequenceOfMaps(v, models.OptionsKeyName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate over options and create a config for each
+	options := make([]models.OptionCfg, 0)
+	for _, sub := range subs {
+		// Find option factory based on "type" that we read from config source
+		typeStr := sub.GetString(models.TypeKeyName)
+		if typeStr == "" {
+			return nil, &configError{code: errMissingOptionType, msg: fmt.Sprintf("missing option type")}
+		}
+
+		factory := models.GetOptionFactory(typeStr)
+		if factory == nil {
+			return nil, &configError{code: errUnknownOptionType, msg: fmt.Sprintf("unknown option type %q", typeStr)}
+		}
+
+		// Create the default config for this options
+		optionCfg := factory.CreateDefaultConfig()
+
+		// Now that the default config struct is created we can Unmarshal into it
+		// and it will apply user-defined config on top of the default.
+		if err := sub.Unmarshal(optionCfg); err != nil {
+			return nil, &configError{
+				code: errUnmarshalError,
+				msg:  fmt.Sprintf("error reading settings for option type %q: %v", typeStr, err),
+			}
+		}
+		options = append(options, optionCfg)
+	}
+
+	return options, nil
+}
+
+func validateConfig(cfg *models.ConfigV2) error {
+	if err := validateReceivers(cfg.Receivers); err != nil {
+		return err
+	}
+
+	if err := validateExporters(cfg.Exporters); err != nil {
+		return err
+	}
+
+	if err := validateOptions(cfg.Options); err != nil {
+		return err
+	}
+
+	if err := validatePipelines(cfg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateReceivers(receivers []models.ReceiverCfg) error {
+	m := make(map[string]bool)
+	for _, r := range receivers {
+		if m[r.GetName()] {
+			return &configError{code: errDuplicateReceiverName, msg: fmt.Sprintf("duplicate receiver name %q", r.GetName())}
+		}
+		m[r.GetName()] = true
+	}
+
+	return nil
+}
+
+func validateExporters(exporters []models.ExporterCfg) error {
+	m := make(map[string]bool)
+	for _, r := range exporters {
+		if m[r.GetName()] {
+			return &configError{code: errDuplicateExporterName, msg: fmt.Sprintf("duplicate exporter name %q", r.GetName())}
+		}
+		m[r.GetName()] = true
+	}
+
+	return nil
+}
+
+func validateOptions(options []models.OptionCfg) error {
+	m := make(map[string]bool)
+	for _, r := range options {
+		if m[r.GetName()] {
+			return &configError{code: errDuplicateOptionName, msg: fmt.Sprintf("duplicate option name %q", r.GetName())}
+		}
+		m[r.GetName()] = true
+	}
+
+	return nil
+}
+
+func validatePipelines(cfg *models.ConfigV2) error {
+	// Must have at least one pipeline
+	if len(cfg.Pipelines.Traces) < 1 && len(cfg.Pipelines.Metrics) < 1 {
+		return &configError{code: errMissingPipelines, msg: "must have at least one pipeline"}
+	}
+
+	// Validate trace pipelines
+	for _, pipeline := range cfg.Pipelines.Traces {
+		// Perform common pipeline validation
+		if err := validatePipeline(cfg, pipeline); err != nil {
+			return err
+		}
+		// Also validate options
+		if err := validatePipelineOptions(cfg, pipeline); err != nil {
+			return err
+		}
+	}
+
+	for _, pipeline := range cfg.Pipelines.Metrics {
+		// For metrics pipeline we only do common validation since it cannot have options
+		if err := validatePipeline(cfg, pipeline); err != nil {
+			return err
+		}
+
+		if len(pipeline.Operations) > 0 {
+			return &configError{
+				code: errMetricPipelineCannotHaveOperations,
+				msg:  fmt.Sprintf("metrics pipeline %q cannot have ordered operation", pipeline.Name),
+			}
+		}
+	}
+	return nil
+}
+
+func validatePipeline(cfg *models.ConfigV2, pipeline *models.Pipeline) error {
+	if pipeline.Name == "" {
+		return &configError{code: errMissingPipelineName, msg: "pipeline must have a name"}
+	}
+
+	if err := validatePipelineReceivers(cfg, pipeline); err != nil {
+		return err
+	}
+
+	if err := validatePipelineExporters(cfg, pipeline); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validatePipelineReceivers(cfg *models.ConfigV2, pipeline *models.Pipeline) error {
+	if len(pipeline.Receivers) == 0 {
+		return &configError{
+			code: errPipelineMustHaveReceiver,
+			msg:  fmt.Sprintf("pipeline %q must have at least one receiver", pipeline.Name),
+		}
+	}
+
+	// Validate pipeline receiver name references
+	for _, ref := range pipeline.Receivers {
+		// Check that the name referenced in the pipeline's Receivers exists in the top-level Receivers
+		found := false
+		for _, rcv := range cfg.Receivers {
+			if rcv.GetName() == ref.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return &configError{
+				code: errPipelineReceiverNotExists,
+				msg:  fmt.Sprintf("pipeline %q references receiver %q which does not exists", pipeline.Name, ref.Name),
+			}
+		}
+	}
+
+	return nil
+}
+
+func validatePipelineExporters(cfg *models.ConfigV2, pipeline *models.Pipeline) error {
+	if len(pipeline.Exporters) == 0 {
+		return &configError{
+			code: errPipelineMustHaveExporter,
+			msg:  fmt.Sprintf("pipeline %q must have at least one exporter", pipeline.Name),
+		}
+	}
+
+	// Validate pipeline exporter name references
+	for _, ref := range pipeline.Exporters {
+		// Check that the name referenced in the pipeline's Exporters exists in the top-level Exporters
+		found := false
+		for _, exp := range cfg.Exporters {
+			if exp.GetName() == ref.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return &configError{
+				code: errPipelineExporterNotExists,
+				msg:  fmt.Sprintf("pipeline %q references exporter %q which does not exists", pipeline.Name, ref.Name),
+			}
+		}
+	}
+
+	return nil
+}
+
+func validatePipelineOptions(cfg *models.ConfigV2, pipeline *models.Pipeline) error {
+	if len(pipeline.Operations) == 0 {
+		return &configError{
+			code: errPipelineMustHaveOperations,
+			msg:  fmt.Sprintf("pipeline %q must have at least one ordered operation", pipeline.Name),
+		}
+	}
+
+	// Validate pipeline option name references
+	for _, ref := range pipeline.Operations {
+		// Check that the name referenced in the pipeline's Operations exists in the top-level Options
+		found := false
+		for _, exp := range cfg.Options {
+			if exp.GetName() == ref.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return &configError{
+				code: errPipelineOptionNotExists,
+				msg:  fmt.Sprintf("pipeline %q references option %s which does not exists", pipeline.Name, ref.Name),
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/configv2/configv2_test.go
+++ b/internal/configv2/configv2_test.go
@@ -1,0 +1,1007 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configv2
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/census-instrumentation/opencensus-service/exporter"
+	"github.com/census-instrumentation/opencensus-service/internal/models"
+	"github.com/census-instrumentation/opencensus-service/processor"
+	"github.com/census-instrumentation/opencensus-service/receiver"
+)
+
+func assertEqual(t *testing.T, actual, expected interface{}, errorMsg string) {
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("%s: expected %v, actual is %v", errorMsg, expected, actual)
+	}
+}
+
+// ExampleReceiverCfg: for testing purposes we are defining an example config and factory
+// for "examplereceiver" receiver type.
+type ExampleReceiverCfg struct {
+	models.ReceiverCommon `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	ExtraSetting          string                   `mapstructure:"extra"`
+}
+
+type ExampleReceiverFactory struct {
+}
+
+// Type gets the type of the Receiver config created by this factory.
+func (f *ExampleReceiverFactory) Type() string {
+	return "examplereceiver"
+}
+
+// CreateDefaultConfig creates the default configuration for the Receiver.
+func (f *ExampleReceiverFactory) CreateDefaultConfig() models.ReceiverCfg {
+	return &ExampleReceiverCfg{
+		ReceiverCommon: models.ReceiverCommon{
+			Type:    "examplereceiver",
+			Name:    "examplereceiver",
+			Address: "localhost",
+			Port:    1000,
+			Enabled: false,
+		},
+		ExtraSetting: "some string",
+	}
+}
+
+func (f *ExampleReceiverFactory) CreateTraceReceiver(cfg models.ReceiverCfg) (*receiver.TraceReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+func (f *ExampleReceiverFactory) CreateMetricsReceiver(cfg models.ReceiverCfg) (*receiver.MetricsReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+// MultiProtoReceiverCfg: for testing purposes we are defining an example multi protocol
+// config and factory for "multireceiver" receiver type.
+type MultiProtoReceiverCfg struct {
+	models.MultiReceiverCommon `mapstructure:",squash"`   // squash ensures fields are correctly decoded in embedded struct
+	Protocols                  []MultiProtoReceiverOneCfg `mapstructure:"protocols"`
+}
+
+type MultiProtoReceiverOneCfg struct {
+	models.ProtocolReceiver `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	ExtraSetting            string                   `mapstructure:"extra"`
+}
+
+type MultiProtoReceiverFactory struct {
+}
+
+// Type gets the type of the Receiver config created by this factory.
+func (f *MultiProtoReceiverFactory) Type() string {
+	return "multireceiver"
+}
+
+// CreateDefaultConfig creates the default configuration for the Receiver.
+func (f *MultiProtoReceiverFactory) CreateDefaultConfig() models.ReceiverCfg {
+	return &MultiProtoReceiverCfg{
+		MultiReceiverCommon: models.MultiReceiverCommon{
+			Type: "multireceiver",
+			Name: "multireceiver",
+		},
+		Protocols: []MultiProtoReceiverOneCfg{
+			{
+				ProtocolReceiver: models.ProtocolReceiver{
+					Protocol: "http",
+					Enabled:  false,
+					Address:  "example.com",
+					Port:     8888,
+				},
+				ExtraSetting: "extra string 1",
+			},
+			{
+				ProtocolReceiver: models.ProtocolReceiver{
+					Protocol: "tcp",
+					Enabled:  false,
+					Address:  "omnition.com",
+					Port:     9999,
+				},
+				ExtraSetting: "extra string 2",
+			},
+		},
+	}
+}
+
+func (f *MultiProtoReceiverFactory) CreateTraceReceiver(cfg models.ReceiverCfg) (*receiver.TraceReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+func (f *MultiProtoReceiverFactory) CreateMetricsReceiver(cfg models.ReceiverCfg) (*receiver.MetricsReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+// ExampleExporterCfg: for testing purposes we are defining an example config and factory
+// for "exampleexporter" exporter type.
+type ExampleExporterCfg struct {
+	models.ExporterCommon `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	ExtraSetting          string                   `mapstructure:"extra"`
+}
+
+func (cfg *ExampleExporterCfg) GetName() string {
+	return cfg.Name
+}
+
+type ExampleExporterFactory struct {
+}
+
+// Type gets the type of the Exporter config created by this factory.
+func (f *ExampleExporterFactory) Type() string {
+	return "exampleexporter"
+}
+
+// CreateDefaultConfig creates the default configuration for the Exporter.
+func (f *ExampleExporterFactory) CreateDefaultConfig() models.ExporterCfg {
+	return &ExampleExporterCfg{
+		ExporterCommon: models.ExporterCommon{
+			Type:    "exampleexporter",
+			Name:    "exampleexporter",
+			Enabled: false,
+		},
+		ExtraSetting: "some export string",
+	}
+}
+
+func (f *ExampleExporterFactory) CreateTraceExporter(cfg models.ExporterCfg) (*exporter.TraceExporter, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+func (f *ExampleExporterFactory) CreateMetricsExporter(cfg models.ExporterCfg) (*exporter.MetricsExporter, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+// ExampleOptionCfg: for testing purposes we are defining an example config and factory
+// for "exampleoption" option type.
+type ExampleOptionCfg struct {
+	models.OptionCommon `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	ExtraSetting        string                   `mapstructure:"extra"`
+}
+
+type ExampleOptionFactory struct {
+}
+
+// Type gets the type of the Option config created by this factory.
+func (f *ExampleOptionFactory) Type() string {
+	return "exampleoption"
+}
+
+// CreateDefaultConfig creates the default configuration for the Option.
+func (f *ExampleOptionFactory) CreateDefaultConfig() models.OptionCfg {
+	return &ExampleOptionCfg{
+		OptionCommon: models.OptionCommon{
+			Type:    "exampleoption",
+			Name:    "exampleoption",
+			Enabled: false,
+		},
+		ExtraSetting: "some export string",
+	}
+}
+
+func (f *ExampleOptionFactory) CreateTraceProcessor(cfg models.OptionCfg) (*processor.TraceProcessor, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+func (f *ExampleOptionFactory) CreateMetricsProcessor(cfg models.OptionCfg) (*processor.MetricsProcessor, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+// Register all factories
+var _ = models.RegisterReceiverFactory(&ExampleReceiverFactory{})
+var _ = models.RegisterReceiverFactory(&MultiProtoReceiverFactory{})
+var _ = models.RegisterExporterFactory(&ExampleExporterFactory{})
+var _ = models.RegisterOptionFactory(&ExampleOptionFactory{})
+
+func TestDecodeConfig(t *testing.T) {
+
+	var yaml = `
+receivers:
+  - type: examplereceiver
+  - type: examplereceiver
+    name: myreceiver
+    address: "127.0.0.1"
+    port: 12345
+    enabled: true
+    extra: "some string"
+
+options:
+  - type: exampleoption
+    enabled: false
+
+exporters:
+  - type: exampleexporter
+  - type: exampleexporter
+    name: myexporter
+    extra: "some export string 2"
+    enabled: true
+
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: examplereceiver
+      ordered-operations:
+        - name: exampleoption
+      exporters:
+        - name: exampleexporter
+  metrics:
+`
+	v, err := readConfigFromYamlStr(yaml)
+	if err != nil {
+		t.Fatalf("unable to read yaml, %v", err)
+	}
+
+	config, err := Load(v)
+	if err != nil {
+		t.Fatalf("unable to load config, %v", err)
+	}
+
+	// Verify receivers
+	assertEqual(t, len(config.Receivers), 2, "Incorrect receivers count")
+
+	assertEqual(t, config.Receivers[0],
+		&ExampleReceiverCfg{
+			ReceiverCommon: models.ReceiverCommon{
+				Type:    "examplereceiver",
+				Name:    "examplereceiver",
+				Address: "localhost",
+				Port:    1000,
+				Enabled: false,
+			},
+			ExtraSetting: "some string",
+		}, "Did not load receiver 0 config correctly")
+
+	assertEqual(t, config.Receivers[1],
+		&ExampleReceiverCfg{
+			ReceiverCommon: models.ReceiverCommon{
+				Type:    "examplereceiver",
+				Name:    "myreceiver",
+				Address: "127.0.0.1",
+				Port:    12345,
+				Enabled: true,
+			},
+			ExtraSetting: "some string",
+		}, "Did not load receiver 1 config correctly")
+
+	// Verify exporters
+	assertEqual(t, len(config.Exporters), 2, "Incorrect exporters count")
+
+	assertEqual(t, config.Exporters[0],
+		&ExampleExporterCfg{
+			ExporterCommon: models.ExporterCommon{
+				Type:    "exampleexporter",
+				Name:    "exampleexporter",
+				Enabled: false,
+			},
+			ExtraSetting: "some export string",
+		}, "Did not load exporter 0 config correctly")
+
+	assertEqual(t, config.Exporters[1],
+		&ExampleExporterCfg{
+			ExporterCommon: models.ExporterCommon{
+				Type:    "exampleexporter",
+				Name:    "myexporter",
+				Enabled: true,
+			},
+			ExtraSetting: "some export string 2",
+		}, "Did not load exporter 1 config correctly")
+
+	// Verify Options
+	assertEqual(t, len(config.Options), 1, "Incorrect options count")
+
+	assertEqual(t, config.Options[0],
+		&ExampleOptionCfg{
+			OptionCommon: models.OptionCommon{
+				Type:    "exampleoption",
+				Name:    "exampleoption",
+				Enabled: false,
+			},
+			ExtraSetting: "some export string",
+		}, "Did not load option 0 config correctly")
+
+	// Verify Pipelines
+	assertEqual(t, len(config.Pipelines.Traces), 1, "Incorrect traces pipelines count")
+	assertEqual(t, len(config.Pipelines.Metrics), 0, "Incorrect metrics pipelines count")
+
+	assertEqual(t, config.Pipelines.Traces[0],
+		&models.Pipeline{
+			Name: "default",
+			Receivers: []models.PipelineReceiver{
+				{Name: "examplereceiver"},
+			},
+			Operations: []models.PipelineOperation{
+				{Name: "exampleoption"},
+			},
+			Exporters: []models.PipelineExporter{
+				{Name: "exampleexporter"},
+			},
+		}, "Did not load pipeline 0 config correctly")
+}
+
+func TestDecodeConfig_MultiProto(t *testing.T) {
+
+	var yaml = `
+receivers:
+  - type: multireceiver
+  - type: multireceiver
+    name: myreceiver
+    protocols:
+      - protocol: http
+        address: "127.0.0.1"
+        port: 12345
+        enabled: true
+        extra: "some string 1"
+      - protocol: tcp
+        address: "0.0.0.0"
+        port: 4567
+        enabled: true
+        extra: "some string 2"
+
+options:
+  - type: exampleoption
+    enabled: false
+
+exporters:
+  - type: exampleexporter
+    extra: "locahost:1010"
+
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: myreceiver
+      ordered-operations:
+        - name: exampleoption
+      exporters:
+        - name: exampleexporter
+  metrics:
+    - name: default
+      receivers:
+        - name: myreceiver
+      exporters:
+        - name: exampleexporter
+`
+	v, err := readConfigFromYamlStr(yaml)
+	if err != nil {
+		t.Fatalf("unable to read yaml, %v", err)
+	}
+
+	config, err := Load(v)
+	if err != nil {
+		t.Fatalf("unable to load config, %v", err)
+	}
+
+	assertEqual(t, len(config.Receivers), 2, "Incorrect receivers count")
+
+	assertEqual(t, config.Receivers[0],
+		&MultiProtoReceiverCfg{
+			MultiReceiverCommon: models.MultiReceiverCommon{
+				Type: "multireceiver",
+				Name: "multireceiver",
+			},
+			Protocols: []MultiProtoReceiverOneCfg{
+				{
+					ProtocolReceiver: models.ProtocolReceiver{
+						Protocol: "http",
+						Enabled:  false,
+						Address:  "example.com",
+						Port:     8888,
+					},
+					ExtraSetting: "extra string 1",
+				},
+				{
+					ProtocolReceiver: models.ProtocolReceiver{
+						Protocol: "tcp",
+						Enabled:  false,
+						Address:  "omnition.com",
+						Port:     9999,
+					},
+					ExtraSetting: "extra string 2",
+				},
+			},
+		}, "Did not load receiver 0 config correctly")
+
+	assertEqual(t, config.Receivers[1],
+		&MultiProtoReceiverCfg{
+			MultiReceiverCommon: models.MultiReceiverCommon{
+				Type: "multireceiver",
+				Name: "myreceiver",
+			},
+			Protocols: []MultiProtoReceiverOneCfg{
+				{
+					ProtocolReceiver: models.ProtocolReceiver{
+						Protocol: "http",
+						Enabled:  true,
+						Address:  "127.0.0.1",
+						Port:     12345,
+					},
+					ExtraSetting: "some string 1",
+				},
+				{
+					ProtocolReceiver: models.ProtocolReceiver{
+						Protocol: "tcp",
+						Enabled:  true,
+						Address:  "0.0.0.0",
+						Port:     4567,
+					},
+					ExtraSetting: "some string 2",
+				},
+			},
+		}, "Did not load receiver 1 config correctly")
+}
+
+func TestDecodeConfig_Invalid(t *testing.T) {
+
+	var testCases = []struct {
+		failMsg  string          // message to print if test case fails
+		expected configErrorCode // expected error (if nil any error is acceptable)
+		yaml     string          // input config
+	}{
+		{
+			failMsg: "empty config",
+			yaml:    ``,
+		},
+
+		{
+			failMsg: "missing all sections",
+			yaml: `
+receivers:
+exporters:
+options:
+pipeline:
+`,
+		},
+
+		{
+			failMsg: "missing receivers",
+			yaml: `
+receivers:
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+`,
+		},
+
+		{
+			failMsg: "missing exporters",
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: invalidreceivername
+`,
+		},
+
+		{
+			failMsg: "missing options",
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: invalidreceivername
+`,
+		},
+
+		{
+			failMsg:  "invalid receiver reference",
+			expected: errPipelineReceiverNotExists,
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: invalidreceivername
+`,
+		},
+
+		{
+			failMsg:  "missing receiver type",
+			expected: errMissingReceiverType,
+			yaml: `
+receivers:
+  - name: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: somereceiver
+`,
+		},
+
+		{
+			failMsg:  "missing exporter type",
+			expected: errMissingExporterType,
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - name: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: somereceiver
+`,
+		},
+
+		{
+			failMsg:  "missing option type",
+			expected: errMissingOptionType,
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+  - name: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: somereceiver
+`,
+		},
+
+		{
+			expected: errMissingPipelineName,
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - receivers:
+        - name: multireceiver
+`,
+		},
+
+		{
+			expected: errMissingPipelines,
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+`,
+		},
+
+		{
+			expected: errPipelineMustHaveExporter,
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: multireceiver
+`,
+		},
+
+		{
+			expected: errPipelineMustHaveExporter,
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  metrics:
+    - name: default
+      receivers:
+        - name: multireceiver
+`,
+		},
+
+		{
+			expected: errPipelineMustHaveReceiver,
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  metrics:
+    - name: default
+      exporters:
+        - name: exampleexporter
+`,
+		},
+
+		{
+			expected: errPipelineExporterNotExists,
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  metrics:
+    - name: default
+      receivers:
+        - name: multireceiver
+      exporters:
+        - name: nosuchexporter
+`,
+		},
+
+		{
+			expected: errPipelineOptionNotExists,
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: multireceiver
+      ordered-operations:
+        - name: nosuchoption
+      exporters:
+        - name: exampleexporter
+`,
+		},
+
+		{
+			expected: errPipelineMustHaveOperations,
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: multireceiver
+      exporters:
+        - name: exampleexporter
+`,
+		},
+
+		{
+			expected: errMetricPipelineCannotHaveOperations,
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  metrics:
+    - name: default
+      receivers:
+        - name: multireceiver
+      exporters:
+        - name: exampleexporter
+      ordered-operations:
+        - name: exampleoption
+`,
+		},
+
+		{
+			failMsg: "invalid receiver name",
+			yaml: `
+receivers:
+  - type: multireceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: [1,2,3]
+      exporters:
+        - name: exampleexporter
+      ordered-operations:
+        - name: exampleoption
+`,
+		},
+
+		{
+			expected: errUnknownReceiverType,
+			failMsg:  "unknown receiver type",
+			yaml: `
+receivers:
+  - type: nosuchreceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: multireceiver
+      exporters:
+        - name: exampleexporter
+      ordered-operations:
+        - name: exampleoption
+`,
+		},
+
+		{
+			expected: errUnknownExporterType,
+			failMsg:  "unknown exporter type",
+			yaml: `
+receivers:
+  - type: examplereceiver
+exporters:
+  - type: nosuchexporter
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: multireceiver
+      exporters:
+        - name: exampleexporter
+      ordered-operations:
+        - name: exampleoption
+`,
+		},
+
+		{
+			expected: errUnmarshalError,
+			failMsg:  "invalid receiver port",
+			yaml: `
+receivers:
+  - type: examplereceiver
+    port: "string for port"
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: examplereceiver
+      exporters:
+        - name: exampleexporter
+      ordered-operations:
+        - name: exampleoption
+`,
+		},
+
+		{
+			expected: errUnmarshalError,
+			failMsg:  "invalid enabled bool value",
+			yaml: `
+receivers:
+  - type: examplereceiver
+exporters:
+  - type: exampleexporter
+    enabled: "string for bool"
+options:
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: examplereceiver
+      exporters:
+        - name: exampleexporter
+      ordered-operations:
+        - name: exampleoption
+`,
+		},
+
+		{
+			expected: errUnknownOptionType,
+			failMsg:  "unknown option type",
+			yaml: `
+receivers:
+  - type: examplereceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: nosuchoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: examplereceiver
+      exporters:
+        - name: exampleexporter
+      ordered-operations:
+        - name: exampleoption
+`,
+		},
+
+		{
+			expected: errUnmarshalError,
+			failMsg:  "invalid bool value",
+			yaml: `
+receivers:
+  - type: examplereceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+    enabled: [2,3]
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: examplereceiver
+      exporters:
+        - name: exampleexporter
+      ordered-operations:
+        - name: exampleoption
+`,
+		},
+
+		{
+			expected: errDuplicateReceiverName,
+			failMsg:  "duplicate receiver",
+			yaml: `
+receivers:
+  - type: examplereceiver
+  - type: examplereceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+    enabled: true
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: examplereceiver
+      exporters:
+        - name: exampleexporter
+      ordered-operations:
+        - name: exampleoption
+`,
+		},
+
+		{
+			expected: errDuplicateExporterName,
+			failMsg:  "duplicate exporter",
+			yaml: `
+receivers:
+  - type: examplereceiver
+exporters:
+  - type: exampleexporter
+  - type: exampleexporter
+options:
+  - type: exampleoption
+    enabled: true
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: examplereceiver
+      exporters:
+        - name: exampleexporter
+      ordered-operations:
+        - name: exampleoption
+`,
+		},
+
+		{
+			expected: errDuplicateOptionName,
+			failMsg:  "duplicate option",
+			yaml: `
+receivers:
+  - type: examplereceiver
+exporters:
+  - type: exampleexporter
+options:
+  - type: exampleoption
+    enabled: true
+  - type: exampleoption
+pipelines:
+  traces:
+    - name: default
+      receivers:
+        - name: examplereceiver
+      exporters:
+        - name: exampleexporter
+      ordered-operations:
+        - name: exampleoption
+`,
+		},
+	}
+
+	for _, test := range testCases {
+		v, err := readConfigFromYamlStr(test.yaml)
+		if err != nil {
+			t.Fatalf("unable to read yaml, %v", err)
+		}
+
+		_, err = Load(v)
+		if err == nil {
+			t.Errorf("expected error but succedded on invalid config case: %s", test.failMsg)
+		} else if test.expected != 0 {
+			cfgErr, ok := err.(*configError)
+			if !ok {
+				t.Errorf("expected config error code %v but got a different error '%v' on invalid config case: %s", test.expected, err, test.failMsg)
+			} else {
+				if cfgErr.code != test.expected {
+					t.Errorf("expected config error code %v but got error code %v on invalid config case: %s", test.expected, cfgErr.code, test.failMsg)
+				}
+
+				if cfgErr.msg == "" {
+					t.Errorf("returned config error %v with empty msg field", cfgErr.code)
+				}
+			}
+		}
+	}
+}

--- a/internal/configv2/viperutils.go
+++ b/internal/configv2/viperutils.go
@@ -1,0 +1,80 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configv2
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+// readConfigFromYamlStr reads a Viper config from a string in YAML format.
+func readConfigFromYamlStr(str string) (*viper.Viper, error) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	err := v.ReadConfig(bytes.NewBuffer([]byte(str)))
+	if err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// getViperSubSequenceOfMaps extracts a subsequence of maps from a configuration
+// It is expected that v has the following structure:
+//
+// key:
+//   - key1: val1
+//     key2: val2
+//     ... more key/values
+//   - key1: val1
+//     key2: val2
+//     ... more key/values
+//
+// Each sequence element is returned as a sub Viper that can be used normally
+// to query containing key/values.
+func getViperSubSequenceOfMaps(v *viper.Viper, key string) ([]*viper.Viper, error) {
+	subs := make([]*viper.Viper, 0)
+	childData := v.Get(key)
+	if childData == nil {
+		// There is no children with specified key
+		return nil, fmt.Errorf("cannot find key %q", key)
+	}
+
+	childDataIterable, ok := childData.([]interface{})
+	if !ok {
+		// The children is not a sequence
+		return nil, fmt.Errorf("key %q must be a sequence", key)
+	}
+
+	for i, item := range childDataIterable {
+		itemAsMap, ok := item.(map[interface{}]interface{})
+		if !ok {
+			// Value is not a map, ignore it
+			return nil, fmt.Errorf("element at index %d under key %q is not a key/value map", i, key)
+		}
+
+		// Create a new sub Viper for this element of sequence
+		sub := viper.New()
+
+		// Add all key/value pairs of this element to the sub Viper
+		for key, val := range itemAsMap {
+			keyStr := key.(string)
+			sub.Set(keyStr, val)
+		}
+		subs = append(subs, sub)
+	}
+	return subs, nil
+}

--- a/internal/configv2/viperutils_test.go
+++ b/internal/configv2/viperutils_test.go
@@ -1,0 +1,102 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configv2
+
+import (
+	"testing"
+)
+
+func TestValidGetViperSubSequenceOfMaps(t *testing.T) {
+	var yaml = `
+receivers:
+  - type: opencensus
+    name: myreceiver
+    address: "127.0.0.1"
+    port: 12345
+    enabled: true
+  - type: opencensus2
+    protocols:
+    - protocol: proto1
+      address: "127.0.0.1"
+      port: 2345
+      enabled: false
+    - protocol: proto2
+      address: "localhost"
+      port: 3456
+      enabled: true
+`
+
+	v, err := readConfigFromYamlStr(yaml)
+	if err != nil {
+		t.Fatalf("Unable to read yaml: %v", err)
+	}
+
+	subs, err := getViperSubSequenceOfMaps(v, "receivers")
+	if err != nil {
+		t.Fatalf("Unable to decode yaml: %v", err)
+	}
+	if len(subs) != 2 {
+		t.Fatalf("Expected 2 receivers sections")
+	}
+
+	protocols, err := getViperSubSequenceOfMaps(subs[1], "protocols")
+	if err != nil {
+		t.Fatalf("Unable to decode yaml: %v", err)
+	}
+	if len(protocols) != 2 {
+		t.Fatalf("Unable to decode yaml")
+	}
+}
+
+func TestInvalidGetViperSubSequenceOfMaps(t *testing.T) {
+	var testCases = []string{
+		`
+receivers:
+  - scalar
+`,
+		`
+receivers:
+  key: value
+`,
+	}
+
+	for _, testCase := range testCases {
+		v, err := readConfigFromYamlStr(testCase)
+		if err != nil {
+			t.Fatalf("Unable to read yaml: %v", err)
+		}
+
+		_, err = getViperSubSequenceOfMaps(v, "receivers")
+		if err == nil {
+			t.Fatalf("Expected to fail decoding invalid subsequence of maps")
+		}
+	}
+}
+
+func TestInvalidReadConfigFromYamlStr(t *testing.T) {
+	var yaml = `
+receivers:
+  - type: jaeger
+    - protocol: thrift-tchannel
+      enabled: true
+    - protocol: thrift-http
+      enabled: true
+`
+
+	_, err := readConfigFromYamlStr(yaml)
+	if err == nil {
+		t.Fatalf("Must fail on invalid yaml")
+	}
+}

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -1,0 +1,171 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package models defines the data models for entities. This file defines the
+// models for V2 configuration format. The defined entities are:
+// ConfigV2 (the top-level structure), Receivers, Exporters, Options, Pipelines.
+package models
+
+/*
+Receivers, Exporters and Options typically have common configuration settings, however
+sometimes specific implementations (e.g. StackDriver) will have extra configuration settings.
+This requires the configuration data for these entities to be polymorphic.
+
+To satisfy these requirements we declare interfaces ReceiverCfg, ExporterCfg, OptionCfg,
+which define the behavior. We also provide helper structs ReceiverCommon, ExporterCommon,
+OptionCommon, which define the common settings and un-marshaling from config files.
+
+Specific Receivers/Exporters/Options are expected to at the minimum implement the
+corresponding interface and if they have additional settings they must also extend
+the corresponding common settings struct (the easiest approach is to embed the common struct).
+
+For example usage see tests.
+*/
+
+// ConfigV2 defines the configuration V2 for the various elements of collector or agent.
+type ConfigV2 struct {
+	Receivers []ReceiverCfg `mapstructure:"-"`
+	Exporters []ExporterCfg `mapstructure:"-"`
+	Options   []OptionCfg   `mapstructure:"-"`
+	Pipelines Pipelines     `mapstructure:"pipelines"`
+}
+
+// ReceiversKeyName is the configuration key name for receivers section.
+const ReceiversKeyName = "receivers"
+
+// ExportersKeyName is the configuration key name for exporters section.
+const ExportersKeyName = "exporters"
+
+// OptionsKeyName is the configuration key name for options section.
+const OptionsKeyName = "options"
+
+// Pipelines defines the pipelines section of configuration.
+type Pipelines struct {
+	Traces  []*Pipeline `mapstructure:"traces"`
+	Metrics []*Pipeline `mapstructure:"metrics"`
+}
+
+// Pipeline defines a single pipeline
+type Pipeline struct {
+	Name       string              `mapstructure:"name"`
+	Receivers  []PipelineReceiver  `mapstructure:"receivers"`
+	Operations []PipelineOperation `mapstructure:"ordered-operations"`
+	Exporters  []PipelineExporter  `mapstructure:"exporters"`
+}
+
+// PipelineReceiver defines a receiver of a pipeline.
+type PipelineReceiver struct {
+	Name string `mapstructure:"name"`
+}
+
+// PipelineOperation defines an operation of a pipeline.
+type PipelineOperation struct {
+	Name string `mapstructure:"name"`
+}
+
+// PipelineExporter defines an exporter of a pipeline.
+type PipelineExporter struct {
+	Name string `mapstructure:"name"`
+}
+
+// NamedEntity defines a configuration entity that has a name.
+type NamedEntity interface {
+	GetName() string
+}
+
+// ReceiverCfg is the configuration of a receiver. Specific receivers
+// must implement this interface and will typically embed ReceiverCommon
+// struct or a struct that extends it.
+type ReceiverCfg interface {
+	NamedEntity
+}
+
+// TypeKeyName must match Type field key names for Receiver and Exporter.
+const TypeKeyName = "type"
+
+// ExporterCfg is the configuration of an exporter. Specific exporters
+// must implement this interface and will typically embed ExporterCommon
+// struct or a struct that extends it.
+type ExporterCfg interface {
+	NamedEntity
+}
+
+// OptionCfg is the configuration of a processing option. Specific options
+// must implement this interface and will typically embed OptionCommon
+// struct or a struct that extends it.
+type OptionCfg interface {
+	NamedEntity
+}
+
+// Below are common setting structs for Receivers, Exporters and Options.
+// These are helper structs which you can use to implement your specific
+// receiver/exporter/option config storage.
+
+// ReceiverCommon defines common settings for a single-protocol receiver configuration
+// Specific receivers can embed this struct and extend it with more fields if needed.
+type ReceiverCommon struct {
+	Type    string `mapstructure:"type"`
+	Enabled bool   `mapstructure:"enabled"`
+	Name    string `mapstructure:"name"`
+	Address string `mapstructure:"address"`
+	Port    int    `mapstructure:"port"`
+}
+
+// GetName returns receiver name
+func (cfg *ReceiverCommon) GetName() string {
+	return cfg.Name
+}
+
+// ExporterCommon defines common settings for an exporter configuration
+// Specific exporters can embed this struct and extend it with more fields if needed.
+type ExporterCommon struct {
+	Type    string `mapstructure:"type"`
+	Enabled bool   `mapstructure:"enabled"`
+	Name    string `mapstructure:"name"`
+}
+
+// MultiReceiverCommon defines common settings for a multi-protocol receiver configuration
+// Specific receivers can embed this struct and extend it with more fields. Note that
+// Protocols field is not defined, you need to define it with a specific type.
+type MultiReceiverCommon struct {
+	Type string `mapstructure:"type"`
+	Name string `mapstructure:"name"`
+}
+
+// GetName returns receiver name
+func (cfg *MultiReceiverCommon) GetName() string {
+	return cfg.Name
+}
+
+// ProtocolReceiver defines a protocol of multi-protocol receiver
+// Specific receivers can embed this struct and extend it with more fields if needed.
+type ProtocolReceiver struct {
+	Protocol string `mapstructure:"protocol"`
+	Enabled  bool   `mapstructure:"enabled"`
+	Address  string `mapstructure:"address"`
+	Port     int    `mapstructure:"port"`
+}
+
+// OptionCommon defines common settings for an option configuration
+// Specific options can embed this struct and extend it with more fields if needed.
+type OptionCommon struct {
+	Type    string `mapstructure:"type"`
+	Enabled bool   `mapstructure:"enabled"`
+	Name    string `mapstructure:"name"`
+}
+
+// GetName returns option name
+func (cfg *OptionCommon) GetName() string {
+	return cfg.Name
+}

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -56,7 +56,7 @@ type Pipelines struct {
 	Metrics []*Pipeline `mapstructure:"metrics"`
 }
 
-// Pipeline defines a single pipeline
+// Pipeline defines a single pipeline.
 type Pipeline struct {
 	Name       string              `mapstructure:"name"`
 	Receivers  []PipelineReceiver  `mapstructure:"receivers"`
@@ -112,7 +112,7 @@ type OptionCfg interface {
 // These are helper structs which you can use to implement your specific
 // receiver/exporter/option config storage.
 
-// ReceiverCommon defines common settings for a single-protocol receiver configuration
+// ReceiverCommon defines common settings for a single-protocol receiver configuration.
 // Specific receivers can embed this struct and extend it with more fields if needed.
 type ReceiverCommon struct {
 	Type    string `mapstructure:"type"`
@@ -122,12 +122,12 @@ type ReceiverCommon struct {
 	Port    int    `mapstructure:"port"`
 }
 
-// GetName returns receiver name
+// GetName returns receiver name.
 func (cfg *ReceiverCommon) GetName() string {
 	return cfg.Name
 }
 
-// ExporterCommon defines common settings for an exporter configuration
+// ExporterCommon defines common settings for an exporter configuration.
 // Specific exporters can embed this struct and extend it with more fields if needed.
 type ExporterCommon struct {
 	Type    string `mapstructure:"type"`
@@ -135,7 +135,7 @@ type ExporterCommon struct {
 	Name    string `mapstructure:"name"`
 }
 
-// MultiReceiverCommon defines common settings for a multi-protocol receiver configuration
+// MultiReceiverCommon defines common settings for a multi-protocol receiver configuration.
 // Specific receivers can embed this struct and extend it with more fields. Note that
 // Protocols field is not defined, you need to define it with a specific type.
 type MultiReceiverCommon struct {
@@ -143,12 +143,12 @@ type MultiReceiverCommon struct {
 	Name string `mapstructure:"name"`
 }
 
-// GetName returns receiver name
+// GetName returns receiver name.
 func (cfg *MultiReceiverCommon) GetName() string {
 	return cfg.Name
 }
 
-// ProtocolReceiver defines a protocol of multi-protocol receiver
+// ProtocolReceiver defines a protocol of multi-protocol receiver.
 // Specific receivers can embed this struct and extend it with more fields if needed.
 type ProtocolReceiver struct {
 	Protocol string `mapstructure:"protocol"`
@@ -165,7 +165,7 @@ type OptionCommon struct {
 	Name    string `mapstructure:"name"`
 }
 
-// GetName returns option name
+// GetName returns option name.
 func (cfg *OptionCommon) GetName() string {
 	return cfg.Name
 }

--- a/internal/models/empty_test.go
+++ b/internal/models/empty_test.go
@@ -1,0 +1,15 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models

--- a/internal/models/factories.go
+++ b/internal/models/factories.go
@@ -1,0 +1,149 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"fmt"
+
+	"github.com/census-instrumentation/opencensus-service/exporter"
+	"github.com/census-instrumentation/opencensus-service/processor"
+	"github.com/census-instrumentation/opencensus-service/receiver"
+)
+
+// Note: logically factories do not belong to models package and must be moved to
+// receiver,exporter,options packages. However doing so will require extensive changes
+// to multiple source code files. I plan to do it in a separate commit when I start
+// implementing specific factories and when I will have to touch that part of
+// the code anyway.
+
+///////////////////////////////////////////////////////////////////////////////
+// Receiver factory and its registry
+
+// ReceiverFactory is factory interface for receivers.
+type ReceiverFactory interface {
+	// Type gets the type of the Receiver created by this factory.
+	Type() string
+
+	// CreateDefaultConfig creates the default configuration for the Receiver.
+	CreateDefaultConfig() ReceiverCfg
+
+	// CreateTraceReceiver creates a trace receiver based on this config.
+	// If the receiver type does not support tracing or if the config is not valid
+	// error will be returned instead.
+	CreateTraceReceiver(cfg ReceiverCfg) (*receiver.TraceReceiver, error)
+
+	// CreateMetricsReceiver creates a metrics receiver based on this config.
+	// If the receiver type does not support metrics or if the config is not valid
+	// error will be returned instead.
+	CreateMetricsReceiver(cfg ReceiverCfg) (*receiver.MetricsReceiver, error)
+}
+
+// List of registered receiver factories.
+var receiverFactories = make(map[string]ReceiverFactory)
+
+// RegisterReceiverFactory registers a receiver factory.
+func RegisterReceiverFactory(factory ReceiverFactory) error {
+	if receiverFactories[factory.Type()] != nil {
+		panic(fmt.Sprintf("duplicate receiver factory %q", factory.Type()))
+	}
+
+	receiverFactories[factory.Type()] = factory
+	return nil
+}
+
+// GetReceiverFactory gets a receiver factory by type string.
+func GetReceiverFactory(typeStr string) ReceiverFactory {
+	return receiverFactories[typeStr]
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Exporter factory and its registry
+
+// ExporterFactory is is factory interface for exporters
+type ExporterFactory interface {
+	// Type gets the type of the Exporter created by this factory.
+	Type() string
+
+	// CreateDefaultConfig creates the default configuration for the Exporter.
+	CreateDefaultConfig() ExporterCfg
+
+	// CreateTraceExporter creates a trace exporter based on this config.
+	// If the exporter type does not support trace or if the config is not valid
+	// error will be returned instead.
+	CreateTraceExporter(cfg ExporterCfg) (*exporter.TraceExporter, error)
+
+	// CreateMetricsExporter creates a metrics exporter based on this config.
+	// If the exporter type does not support metrics or if the config is not valid
+	// error will be returned instead.
+	CreateMetricsExporter(cfg ExporterCfg) (*exporter.MetricsExporter, error)
+}
+
+// List of registered exporter factories.
+var exporterFactories = make(map[string]ExporterFactory)
+
+// RegisterExporterFactory registers a exporter factory
+func RegisterExporterFactory(factory ExporterFactory) error {
+	if exporterFactories[factory.Type()] != nil {
+		panic(fmt.Sprintf("duplicate exporter factory %q", factory.Type()))
+	}
+
+	exporterFactories[factory.Type()] = factory
+	return nil
+}
+
+// GetExporterFactory gets a exporter factory by type string
+func GetExporterFactory(typeStr string) ExporterFactory {
+	return exporterFactories[typeStr]
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Option factory and its registry
+
+// OptionFactory is is factory interface for options.
+type OptionFactory interface {
+	// Type gets the type of the Option created by this factory.
+	Type() string
+
+	// CreateDefaultConfig creates the default configuration for the Option.
+	CreateDefaultConfig() OptionCfg
+
+	// CreateTraceProcessor creates a trace processor based on this config.
+	// If the option type does not support trace or if the config is not valid
+	// error will be returned instead.
+	CreateTraceProcessor(cfg OptionCfg) (*processor.TraceProcessor, error)
+
+	// CreateMetricsProcessor creates a metrics processor based on this config.
+	// If the option type does not support metrics or if the config is not valid
+	// error will be returned instead.
+	CreateMetricsProcessor(cfg OptionCfg) (*processor.MetricsProcessor, error)
+}
+
+// List of registered option factories.
+var optionFactories = make(map[string]OptionFactory)
+
+// RegisterOptionFactory registers a option factory.
+func RegisterOptionFactory(factory OptionFactory) error {
+	if optionFactories[factory.Type()] != nil {
+		panic(fmt.Sprintf("duplicate option factory %q", factory.Type()))
+	}
+
+	optionFactories[factory.Type()] = factory
+	return nil
+}
+
+// GetOptionFactory gets a option factory by type string.
+func GetOptionFactory(typeStr string) OptionFactory {
+	return optionFactories[typeStr]
+}

--- a/internal/models/factories_test.go
+++ b/internal/models/factories_test.go
@@ -1,0 +1,162 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/census-instrumentation/opencensus-service/exporter"
+	"github.com/census-instrumentation/opencensus-service/processor"
+	"github.com/census-instrumentation/opencensus-service/receiver"
+)
+
+type ExampleReceiverFactory struct {
+}
+
+// Type gets the type of the Receiver config created by this factory.
+func (f *ExampleReceiverFactory) Type() string {
+	return "examplereceiver"
+}
+
+// CreateDefaultConfig creates the default configuration for the Receiver.
+func (f *ExampleReceiverFactory) CreateDefaultConfig() ReceiverCfg {
+	return nil
+}
+
+func (f *ExampleReceiverFactory) CreateTraceReceiver(cfg ReceiverCfg) (*receiver.TraceReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+func (f *ExampleReceiverFactory) CreateMetricsReceiver(cfg ReceiverCfg) (*receiver.MetricsReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+func TestRegisterReceiverFactory(t *testing.T) {
+	f := ExampleReceiverFactory{}
+	err := RegisterReceiverFactory(&f)
+	if err != nil {
+		t.Fatalf("cannot register factory")
+	}
+
+	if &f != GetReceiverFactory(f.Type()) {
+		t.Fatalf("cannot find factory")
+	}
+
+	// Verify that attempt to register a factory with duplicate name panics
+	paniced := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				paniced = true
+			}
+		}()
+
+		err = RegisterReceiverFactory(&f)
+	}()
+
+	if !paniced {
+		t.Fatalf("must panic on double registration")
+	}
+}
+
+type ExampleExporterFactory struct {
+}
+
+// Type gets the type of the Exporter config created by this factory.
+func (f *ExampleExporterFactory) Type() string {
+	return "exampleexporter"
+}
+
+// CreateDefaultConfig creates the default configuration for the Exporter.
+func (f *ExampleExporterFactory) CreateDefaultConfig() ExporterCfg {
+	return nil
+}
+
+func (f *ExampleExporterFactory) CreateTraceExporter(cfg ExporterCfg) (*exporter.TraceExporter, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+func (f *ExampleExporterFactory) CreateMetricsExporter(cfg ExporterCfg) (*exporter.MetricsExporter, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+func TestRegisterExporterFactory(t *testing.T) {
+	f := ExampleExporterFactory{}
+	err := RegisterExporterFactory(&f)
+	if err != nil {
+		t.Fatalf("cannot register factory")
+	}
+
+	if &f != GetExporterFactory(f.Type()) {
+		t.Fatalf("cannot find factory")
+	}
+
+	// Verify that attempt to register a factory with duplicate name panics
+	paniced := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				paniced = true
+			}
+		}()
+
+		err = RegisterExporterFactory(&f)
+	}()
+
+	if !paniced {
+		t.Fatalf("must panic on double registration")
+	}
+}
+
+type ExampleOptionFactory struct {
+}
+
+// Type gets the type of the Option config created by this factory.
+func (f *ExampleOptionFactory) Type() string {
+	return "exampleoption"
+}
+
+// CreateDefaultConfig creates the default configuration for the Option.
+func (f *ExampleOptionFactory) CreateDefaultConfig() OptionCfg {
+	return nil
+}
+
+func (f *ExampleOptionFactory) CreateTraceProcessor(cfg OptionCfg) (*processor.TraceProcessor, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+func (f *ExampleOptionFactory) CreateMetricsProcessor(cfg OptionCfg) (*processor.MetricsProcessor, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+func TestRegisterOptionFactory(t *testing.T) {
+	f := ExampleOptionFactory{}
+	err := RegisterOptionFactory(&f)
+	if err != nil {
+		t.Fatalf("cannot register factory")
+	}
+
+	if &f != GetOptionFactory(f.Type()) {
+		t.Fatalf("cannot find factory")
+	}
+
+	// Verify that attempt to register a factory with duplicate name panics
+	paniced := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				paniced = true
+			}
+		}()
+
+		err = RegisterOptionFactory(&f)
+	}()
+
+	if !paniced {
+		t.Fatalf("must panic on double registration")
+	}
+}

--- a/internal/models/factories_test.go
+++ b/internal/models/factories_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package models
 
 import (
@@ -43,18 +57,18 @@ func TestRegisterReceiverFactory(t *testing.T) {
 	}
 
 	// Verify that attempt to register a factory with duplicate name panics
-	paniced := false
+	panicked := false
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
-				paniced = true
+				panicked = true
 			}
 		}()
 
 		err = RegisterReceiverFactory(&f)
 	}()
 
-	if !paniced {
+	if !panicked {
 		t.Fatalf("must panic on double registration")
 	}
 }


### PR DESCRIPTION
This PR is the first in the series of planned PRs that implement Configuration V2 support. For full support of config V2 I plan to submit several additional PRs after this one is reviewed and merged.

## Changes in this PR:

- Added configuration models.
- Implemented generic parts of configuration loading and validation code.
- Added global factory registry for receivers, exporters and options.
- Support single- and multi- protocol receivers.

All new code is only active in tests, it is not reachable from main code.

## Testing done
Automated tests covering close to 100% of all new code.

## Future Plans
The next planned PR is the implementation of configuration loading for specific receivers/exporters/options (e.g. Jaeger receiver, OpenCensus exporter, etc). More detailed release plan can be found in the [design doc](https://docs.google.com/document/d/1GWOzV0H0RTN1adiwo7fTmkjfCATDDFGuOB4jp3ldCc8/edit#).

## Note to Reviewers
This is my first PR against this repo. Any improvement suggestions are highly welcome.

I signed the CLA via Omnition.

## References
The Configuration Format V2 design doc:
https://docs.google.com/document/d/1GWOzV0H0RTN1adiwo7fTmkjfCATDDFGuOB4jp3ldCc8/edit#