### PR TITLE
Fix bug in internal.CombineErrors

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -40,7 +40,7 @@ func CombineErrors(errs []error) error {
 	if numErrors == 1 {
 		return errs[0]
 	} else if numErrors > 1 {
-		errMsgs := make([]string, numErrors)
+		errMsgs := make([]string, 0, numErrors)
 		for _, err := range errs {
 			errMsgs = append(errMsgs, err.Error())
 		}

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -15,6 +15,7 @@
 package internal_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -36,5 +37,37 @@ func TestTimeConverters(t *testing.T) {
 	}
 	if g, w := t1.UnixNano(), t2.UnixNano(); g != w {
 		t.Errorf("Convertedback time does not match original time\nGot: %d\nWant:%d", g, w)
+	}
+}
+
+func TestCombineErrors(t *testing.T) {
+	testCases := []struct {
+		errors    []error
+		expected  string
+		expectNil bool
+	}{{
+		errors:    []error{},
+		expectNil: true,
+	}, {
+		errors: []error{
+			fmt.Errorf("foo"),
+		},
+		expected: "foo",
+	}, {
+		errors: []error{
+			fmt.Errorf("foo"),
+			fmt.Errorf("bar"),
+		},
+		expected: "[foo; bar]",
+	}}
+
+	for _, tc := range testCases {
+		got := internal.CombineErrors(tc.errors)
+		if (got == nil) != tc.expectNil {
+			t.Errorf("CombineErrors(%v) == nil? Got: %t. Want: %t", tc.errors, got == nil, tc.expectNil)
+		}
+		if got != nil && tc.expected != got.Error() {
+			t.Errorf("CombineErrors(%v) = %q. Want: %q", tc.errors, got, tc.expected)
+		}
 	}
 }


### PR DESCRIPTION
Previously, multiple errors would produce a bunch of leading "; "s because `make` was called with a length rather than capacity and then was appended.
e.g. CombineErrors([foo bar]) = "[; ; foo; bar]"