### PR TITLE
Add global factory registry for receivers, exporters and processors

### DIFF
--- a/internal/factories/factories.go
+++ b/internal/factories/factories.go
@@ -1,0 +1,114 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package factories
+
+import (
+	"fmt"
+
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// Receiver factory and its registry.
+
+// ReceiverFactory is factory interface for receivers. Note: only configuration-related
+// functionality exists for now. We will add more factory functionality in the future.
+type ReceiverFactory interface {
+	// Type gets the type of the Receiver created by this factory.
+	Type() string
+
+	// CreateDefaultConfig creates the default configuration for the Receiver.
+	CreateDefaultConfig() configmodels.Receiver
+}
+
+// List of registered receiver factories.
+var receiverFactories = make(map[string]ReceiverFactory)
+
+// RegisterReceiverFactory registers a receiver factory.
+func RegisterReceiverFactory(factory ReceiverFactory) error {
+	if receiverFactories[factory.Type()] != nil {
+		panic(fmt.Sprintf("duplicate receiver factory %q", factory.Type()))
+	}
+
+	receiverFactories[factory.Type()] = factory
+	return nil
+}
+
+// GetReceiverFactory gets a receiver factory by type string.
+func GetReceiverFactory(typeStr string) ReceiverFactory {
+	return receiverFactories[typeStr]
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Exporter factory and its registry.
+
+// ExporterFactory is factory interface for exporters. Note: only configuration-related
+// functionality exists for now. We will add more factory functionality in the future.
+type ExporterFactory interface {
+	// Type gets the type of the Exporter created by this factory.
+	Type() string
+
+	// CreateDefaultConfig creates the default configuration for the Exporter.
+	CreateDefaultConfig() configmodels.Exporter
+}
+
+// List of registered exporter factories.
+var exporterFactories = make(map[string]ExporterFactory)
+
+// RegisterExporterFactory registers a exporter factory.
+func RegisterExporterFactory(factory ExporterFactory) error {
+	if exporterFactories[factory.Type()] != nil {
+		panic(fmt.Sprintf("duplicate exporter factory %q", factory.Type()))
+	}
+
+	exporterFactories[factory.Type()] = factory
+	return nil
+}
+
+// GetExporterFactory gets a exporter factory by type string.
+func GetExporterFactory(typeStr string) ExporterFactory {
+	return exporterFactories[typeStr]
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Option factory and its registry.
+
+// OptionFactory is factory interface for options. Note: only configuration-related
+// functionality exists for now. We will add more factory functionality in the future.
+type OptionFactory interface {
+	// Type gets the type of the Option created by this factory.
+	Type() string
+
+	// CreateDefaultConfig creates the default configuration for the Option.
+	CreateDefaultConfig() configmodels.Processor
+}
+
+// List of registered option factories.
+var optionFactories = make(map[string]OptionFactory)
+
+// RegisterProcessorFactory registers a option factory.
+func RegisterProcessorFactory(factory OptionFactory) error {
+	if optionFactories[factory.Type()] != nil {
+		panic(fmt.Sprintf("duplicate option factory %q", factory.Type()))
+	}
+
+	optionFactories[factory.Type()] = factory
+	return nil
+}
+
+// GetProcessorFactory gets a option factory by type string.
+func GetProcessorFactory(typeStr string) OptionFactory {
+	return optionFactories[typeStr]
+}

--- a/internal/factories/factories_test.go
+++ b/internal/factories/factories_test.go
@@ -1,0 +1,144 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package factories
+
+import (
+	"testing"
+
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
+)
+
+type ExampleReceiverFactory struct {
+}
+
+// Type gets the type of the Receiver config created by this factory.
+func (f *ExampleReceiverFactory) Type() string {
+	return "examplereceiver"
+}
+
+// CreateDefaultConfig creates the default configuration for the Receiver.
+func (f *ExampleReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
+	return nil
+}
+
+func TestRegisterReceiverFactory(t *testing.T) {
+	f := ExampleReceiverFactory{}
+	err := RegisterReceiverFactory(&f)
+	if err != nil {
+		t.Fatalf("cannot register factory")
+	}
+
+	if &f != GetReceiverFactory(f.Type()) {
+		t.Fatalf("cannot find factory")
+	}
+
+	// Verify that attempt to register a factory with duplicate name panics
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+
+		err = RegisterReceiverFactory(&f)
+	}()
+
+	if !panicked {
+		t.Fatalf("must panic on double registration")
+	}
+}
+
+type ExampleExporterFactory struct {
+}
+
+// Type gets the type of the Exporter config created by this factory.
+func (f *ExampleExporterFactory) Type() string {
+	return "exampleexporter"
+}
+
+// CreateDefaultConfig creates the default configuration for the Exporter.
+func (f *ExampleExporterFactory) CreateDefaultConfig() configmodels.Exporter {
+	return nil
+}
+
+func TestRegisterExporterFactory(t *testing.T) {
+	f := ExampleExporterFactory{}
+	err := RegisterExporterFactory(&f)
+	if err != nil {
+		t.Fatalf("cannot register factory")
+	}
+
+	if &f != GetExporterFactory(f.Type()) {
+		t.Fatalf("cannot find factory")
+	}
+
+	// Verify that attempt to register a factory with duplicate name panics
+	paniced := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				paniced = true
+			}
+		}()
+
+		err = RegisterExporterFactory(&f)
+	}()
+
+	if !paniced {
+		t.Fatalf("must panic on double registration")
+	}
+}
+
+type ExampleOptionFactory struct {
+}
+
+// Type gets the type of the Option config created by this factory.
+func (f *ExampleOptionFactory) Type() string {
+	return "exampleoption"
+}
+
+// CreateDefaultConfig creates the default configuration for the Processor.
+func (f *ExampleOptionFactory) CreateDefaultConfig() configmodels.Processor {
+	return nil
+}
+
+func TestRegisterOptionFactory(t *testing.T) {
+	f := ExampleOptionFactory{}
+	err := RegisterProcessorFactory(&f)
+	if err != nil {
+		t.Fatalf("cannot register factory")
+	}
+
+	if &f != GetProcessorFactory(f.Type()) {
+		t.Fatalf("cannot find factory")
+	}
+
+	// Verify that attempt to register a factory with duplicate name panics
+	paniced := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				paniced = true
+			}
+		}()
+
+		err = RegisterProcessorFactory(&f)
+	}()
+
+	if !paniced {
+		t.Fatalf("must panic on double registration")
+	}
+}


### PR DESCRIPTION
The registry allows to register and retrieve factories for receivers, exporters and
processors by type. The factories will be used during configuration loading and during
pipeline building (only configuration related code is currently present, the rest
will be added gradually).

Testing done: automated tests.
