### PR TITLE
Fix "vet" target in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,14 +73,8 @@ lint:
 
 .PHONY: vet
 vet:
-	@VETOUT=`$(GOVET) ./... 2>&1`; \
-	if [ "$$VETOUT" ]; then \
-		echo "$(GOVET) FAILED => clean the following vet errors:\n"; \
-		echo "$$VETOUT\n"; \
-		exit 1; \
-	else \
-	    echo "Vet finished successfully"; \
-	fi
+	@$(GOVET) ./...
+	@echo "Vet finished successfully"
 
 .PHONY: install-tools
 install-tools:


### PR DESCRIPTION
Previously "vet" target was coded to fail if govet produced any output,
which is not a correct assumption. Govet can produce output even in
case of success [1]. The correct way to know if govet is successful is
to rely on exit code, which is exactly what is done now after this change.

[1] - see for example https://travis-ci.org/census-instrumentation/opencensus-service/builds/536550187