### PR TITLE
Add implementation of OpenCensus receiver config

### DIFF
--- a/internal/configv2/configv2.go
+++ b/internal/configv2/configv2.go
@@ -200,7 +200,16 @@ func loadReceivers(v *viper.Viper) (configmodels.Receivers, error) {
 
 		// Now that the default config struct is created we can Unmarshal into it
 		// and it will apply user-defined config on top of the default.
-		if err := subViper.UnmarshalKey(key, receiverCfg); err != nil {
+		customUnmarshaler := factory.CustomUnmarshaler()
+		if customUnmarshaler != nil {
+			// This configuration requires a custom unmarshaler, use it.
+			err = customUnmarshaler(subViper, key, receiverCfg)
+		} else {
+			// Standard viper unmarshaler is fine.
+			err = subViper.UnmarshalKey(key, receiverCfg)
+		}
+
+		if err != nil {
 			return nil, &configError{
 				code: errUnmarshalError,
 				msg:  fmt.Sprintf("error reading settings for receiver type %q: %v", typeStr, err),

--- a/internal/configv2/example_factories.go
+++ b/internal/configv2/example_factories.go
@@ -1,0 +1,202 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configv2
+
+import (
+	"context"
+
+	"github.com/census-instrumentation/opencensus-service/consumer"
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
+	"github.com/census-instrumentation/opencensus-service/internal/factories"
+	"github.com/census-instrumentation/opencensus-service/receiver"
+)
+
+// ExampleReceiver is for testing purposes. We are defining an example config and factory
+// for "examplereceiver" receiver type.
+type ExampleReceiver struct {
+	configmodels.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	ExtraSetting                  string                   `mapstructure:"extra"`
+}
+
+// ExampleReceiverFactory is factory for ExampleReceiver.
+type ExampleReceiverFactory struct {
+}
+
+// Type gets the type of the Receiver config created by this factory.
+func (f *ExampleReceiverFactory) Type() string {
+	return "examplereceiver"
+}
+
+// CustomUnmarshaler returns nil because we don't need custom unmarshaling for this factory.
+func (f *ExampleReceiverFactory) CustomUnmarshaler() factories.CustomUnmarshaler {
+	return nil
+}
+
+// CreateDefaultConfig creates the default configuration for the Receiver.
+func (f *ExampleReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
+	return &ExampleReceiver{
+		ReceiverSettings: configmodels.ReceiverSettings{
+			Endpoint: "localhost:1000",
+			Enabled:  false,
+		},
+		ExtraSetting: "some string",
+	}
+}
+
+// CreateTraceReceiver creates a trace receiver based on this config.
+func (f *ExampleReceiverFactory) CreateTraceReceiver(
+	ctx context.Context,
+	cfg configmodels.Receiver,
+	nextConsumer consumer.TraceConsumer,
+) (receiver.TraceReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+// CreateMetricsReceiver creates a metrics receiver based on this config.
+func (f *ExampleReceiverFactory) CreateMetricsReceiver(
+	cfg configmodels.Receiver,
+	consumer consumer.MetricsConsumer,
+) (receiver.MetricsReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+// MultiProtoReceiver is for testing purposes. We are defining an example multi protocol
+// config and factory for "multireceiver" receiver type.
+type MultiProtoReceiver struct {
+	Protocols map[string]MultiProtoReceiverOneCfg `mapstructure:"protocols"`
+}
+
+var _ configmodels.Receiver = (*MultiProtoReceiver)(nil)
+
+// MultiProtoReceiverOneCfg is multi proto receiver config.
+type MultiProtoReceiverOneCfg struct {
+	Enabled      bool   `mapstructure:"enabled"`
+	Endpoint     string `mapstructure:"endpoint"`
+	ExtraSetting string `mapstructure:"extra"`
+}
+
+// MultiProtoReceiverFactory is factory for MultiProtoReceiver.
+type MultiProtoReceiverFactory struct {
+}
+
+// Type gets the type of the Receiver config created by this factory.
+func (f *MultiProtoReceiverFactory) Type() string {
+	return "multireceiver"
+}
+
+// CustomUnmarshaler returns nil because we don't need custom unmarshaling for this factory.
+func (f *MultiProtoReceiverFactory) CustomUnmarshaler() factories.CustomUnmarshaler {
+	return nil
+}
+
+// CreateDefaultConfig creates the default configuration for the Receiver.
+func (f *MultiProtoReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
+	return &MultiProtoReceiver{
+		Protocols: map[string]MultiProtoReceiverOneCfg{
+			"http": {
+				Enabled:      false,
+				Endpoint:     "example.com:8888",
+				ExtraSetting: "extra string 1",
+			},
+			"tcp": {
+				Enabled:      false,
+				Endpoint:     "omnition.com:9999",
+				ExtraSetting: "extra string 2",
+			},
+		},
+	}
+}
+
+// CreateTraceReceiver creates a trace receiver based on this config.
+func (f *MultiProtoReceiverFactory) CreateTraceReceiver(
+	ctx context.Context,
+	cfg configmodels.Receiver,
+	nextConsumer consumer.TraceConsumer,
+) (receiver.TraceReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+// CreateMetricsReceiver creates a metrics receiver based on this config.
+func (f *MultiProtoReceiverFactory) CreateMetricsReceiver(
+	cfg configmodels.Receiver,
+	consumer consumer.MetricsConsumer,
+) (receiver.MetricsReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+// ExampleExporter is for testing purposes. We are defining an example config and factory
+// for "exampleexporter" exporter type.
+type ExampleExporter struct {
+	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	ExtraSetting                  string                   `mapstructure:"extra"`
+}
+
+// ExampleExporterFactory is factory for ExampleExporter.
+type ExampleExporterFactory struct {
+}
+
+// Type gets the type of the Exporter config created by this factory.
+func (f *ExampleExporterFactory) Type() string {
+	return "exampleexporter"
+}
+
+// CreateDefaultConfig creates the default configuration for the Exporter.
+func (f *ExampleExporterFactory) CreateDefaultConfig() configmodels.Exporter {
+	return &ExampleExporter{
+		ExporterSettings: configmodels.ExporterSettings{
+			Enabled: false,
+		},
+		ExtraSetting: "some export string",
+	}
+}
+
+// ExampleProcessor is for testing purposes. We are defining an example config and factory
+// for "exampleprocessor" processor type.
+type ExampleProcessor struct {
+	configmodels.ProcessorSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	ExtraSetting                   string                   `mapstructure:"extra"`
+}
+
+// ExampleProcessorFactory is factory for ExampleProcessor.
+type ExampleProcessorFactory struct {
+}
+
+// Type gets the type of the Processor config created by this factory.
+func (f *ExampleProcessorFactory) Type() string {
+	return "exampleprocessor"
+}
+
+// CreateDefaultConfig creates the default configuration for the Processor.
+func (f *ExampleProcessorFactory) CreateDefaultConfig() configmodels.Processor {
+	return &ExampleProcessor{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			Enabled: false,
+		},
+		ExtraSetting: "some export string",
+	}
+}
+
+// RegisterTestFactories registers example factories. This is only used by tests.
+func RegisterTestFactories() error {
+	_ = factories.RegisterReceiverFactory(&ExampleReceiverFactory{})
+	_ = factories.RegisterReceiverFactory(&MultiProtoReceiverFactory{})
+	_ = factories.RegisterExporterFactory(&ExampleExporterFactory{})
+	_ = factories.RegisterProcessorFactory(&ExampleProcessorFactory{})
+	return nil
+}

--- a/internal/configv2/test_helpers.go
+++ b/internal/configv2/test_helpers.go
@@ -1,3 +1,17 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package configv2
 
 import (

--- a/internal/configv2/test_helpers.go
+++ b/internal/configv2/test_helpers.go
@@ -1,0 +1,31 @@
+package configv2
+
+import (
+	"os"
+	"testing"
+
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
+	"github.com/spf13/viper"
+)
+
+// LoadConfigFile loads a config from file.
+func LoadConfigFile(t *testing.T, fileName string) (*configmodels.ConfigV2, error) {
+	// Open the file for reading.
+	file, err := os.Open(fileName)
+	if err != nil {
+		t.Error(err)
+		return nil, err
+	}
+
+	// Read yaml config from file
+	v := viper.New()
+	v.SetConfigType("yaml")
+	err = v.ReadConfig(file)
+	if err != nil {
+		t.Errorf("unable to read yaml, %v", err)
+		return nil, err
+	}
+
+	// Load the config from viper
+	return Load(v)
+}

--- a/internal/factories/factories.go
+++ b/internal/factories/factories.go
@@ -15,7 +15,13 @@
 package factories
 
 import (
+	"context"
 	"fmt"
+
+	"github.com/census-instrumentation/opencensus-service/consumer"
+	"github.com/census-instrumentation/opencensus-service/receiver"
+
+	"github.com/spf13/viper"
 
 	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
 )
@@ -31,7 +37,28 @@ type ReceiverFactory interface {
 
 	// CreateDefaultConfig creates the default configuration for the Receiver.
 	CreateDefaultConfig() configmodels.Receiver
+
+	// CustomUnmarshaler returns a custom unmarshaler for the configuration or nil if
+	// there is no need for custom unmarshaling. This is typically used if viper.Unmarshal()
+	// is not sufficient to unmarshal correctly.
+	CustomUnmarshaler() CustomUnmarshaler
+
+	// CreateTraceReceiver creates a trace receiver based on this config.
+	// If the receiver type does not support tracing or if the config is not valid
+	// error will be returned instead (ErrReceiverTypeIsNotSupported).
+	CreateTraceReceiver(ctx context.Context, cfg configmodels.Receiver,
+		nextConsumer consumer.TraceConsumer) (receiver.TraceReceiver, error)
+
+	// CreateMetricsReceiver creates a metrics receiver based on this config.
+	// If the receiver type does not support metrics or if the config is not valid
+	// error will be returned instead (ErrReceiverTypeIsNotSupported).
+	CreateMetricsReceiver(cfg configmodels.Receiver,
+		consumer consumer.MetricsConsumer) (receiver.MetricsReceiver, error)
 }
+
+// CustomUnmarshaler is a function that un-marshals a viper data into a config struct
+// in a custom way.
+type CustomUnmarshaler func(v *viper.Viper, viperKey string, intoCfg interface{}) error
 
 // List of registered receiver factories.
 var receiverFactories = make(map[string]ReceiverFactory)

--- a/internal/factories/factories.go
+++ b/internal/factories/factories.go
@@ -45,13 +45,13 @@ type ReceiverFactory interface {
 
 	// CreateTraceReceiver creates a trace receiver based on this config.
 	// If the receiver type does not support tracing or if the config is not valid
-	// error will be returned instead (ErrReceiverTypeIsNotSupported).
+	// error will be returned instead.
 	CreateTraceReceiver(ctx context.Context, cfg configmodels.Receiver,
 		nextConsumer consumer.TraceConsumer) (receiver.TraceReceiver, error)
 
 	// CreateMetricsReceiver creates a metrics receiver based on this config.
 	// If the receiver type does not support metrics or if the config is not valid
-	// error will be returned instead (ErrReceiverTypeIsNotSupported).
+	// error will be returned instead.
 	CreateMetricsReceiver(cfg configmodels.Receiver,
 		consumer consumer.MetricsConsumer) (receiver.MetricsReceiver, error)
 }

--- a/internal/factories/factories_test.go
+++ b/internal/factories/factories_test.go
@@ -15,7 +15,11 @@
 package factories
 
 import (
+	"context"
 	"testing"
+
+	"github.com/census-instrumentation/opencensus-service/consumer"
+	"github.com/census-instrumentation/opencensus-service/receiver"
 
 	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
 )
@@ -28,9 +32,33 @@ func (f *ExampleReceiverFactory) Type() string {
 	return "examplereceiver"
 }
 
+// CustomUnmarshaler returns nil because we don't need custom unmarshaling for this factory.
+func (f *ExampleReceiverFactory) CustomUnmarshaler() CustomUnmarshaler {
+	return nil
+}
+
 // CreateDefaultConfig creates the default configuration for the Receiver.
 func (f *ExampleReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
 	return nil
+}
+
+// CreateTraceReceiver creates a trace receiver based on this config.
+func (f *ExampleReceiverFactory) CreateTraceReceiver(
+	ctx context.Context,
+	cfg configmodels.Receiver,
+	nextConsumer consumer.TraceConsumer,
+) (receiver.TraceReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+// CreateMetricsReceiver creates a metrics receiver based on this config.
+func (f *ExampleReceiverFactory) CreateMetricsReceiver(
+	cfg configmodels.Receiver,
+	consumer consumer.MetricsConsumer,
+) (receiver.MetricsReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
 }
 
 func TestRegisterReceiverFactory(t *testing.T) {

--- a/receiver/opencensusreceiver/config.go
+++ b/receiver/opencensusreceiver/config.go
@@ -1,0 +1,22 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opencensusreceiver
+
+import "github.com/census-instrumentation/opencensus-service/internal/configmodels"
+
+// ConfigV2 defines configuration for OpenCensus receiver.
+type ConfigV2 struct {
+	configmodels.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+}

--- a/receiver/opencensusreceiver/config_test.go
+++ b/receiver/opencensusreceiver/config_test.go
@@ -1,0 +1,51 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opencensusreceiver
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
+	"github.com/census-instrumentation/opencensus-service/internal/configv2"
+	"github.com/census-instrumentation/opencensus-service/internal/factories"
+)
+
+var _ = configv2.RegisterTestFactories()
+
+func TestLoadConfig(t *testing.T) {
+
+	factory := factories.GetReceiverFactory(typeStr)
+
+	config, err := configv2.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"))
+
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	assert.Equal(t, len(config.Receivers), 2)
+
+	r0 := config.Receivers["opencensus"]
+	assert.Equal(t, r0, factory.CreateDefaultConfig())
+
+	r1 := config.Receivers["opencensus/customname"].(*ConfigV2)
+	assert.Equal(t, r1.ReceiverSettings,
+		configmodels.ReceiverSettings{
+			Endpoint: "0.0.0.0:9090",
+			Enabled:  true,
+		})
+}

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -24,29 +24,29 @@ import (
 	"github.com/census-instrumentation/opencensus-service/receiver"
 )
 
-var _ = factories.RegisterReceiverFactory(&ReceiverFactory{})
+var _ = factories.RegisterReceiverFactory(&receiverFactory{})
 
 const (
 	// The value of "type" key in configuration.
 	typeStr = "opencensus"
 )
 
-// ReceiverFactory is the factory for receiver.
-type ReceiverFactory struct {
+// receiverFactory is the factory for receiver.
+type receiverFactory struct {
 }
 
 // Type gets the type of the Receiver config created by this factory.
-func (f *ReceiverFactory) Type() string {
+func (f *receiverFactory) Type() string {
 	return typeStr
 }
 
 // CustomUnmarshaler returns nil because we don't need custom unmarshaling for this config.
-func (f *ReceiverFactory) CustomUnmarshaler() factories.CustomUnmarshaler {
+func (f *receiverFactory) CustomUnmarshaler() factories.CustomUnmarshaler {
 	return nil
 }
 
 // CreateDefaultConfig creates the default configuration for receiver.
-func (f *ReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
+func (f *receiverFactory) CreateDefaultConfig() configmodels.Receiver {
 	return &ConfigV2{
 		ReceiverSettings: configmodels.ReceiverSettings{
 			Endpoint: "127.0.0.1:55678",
@@ -56,7 +56,7 @@ func (f *ReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
 }
 
 // CreateTraceReceiver creates a  trace receiver based on provided config.
-func (f *ReceiverFactory) CreateTraceReceiver(
+func (f *receiverFactory) CreateTraceReceiver(
 	ctx context.Context,
 	cfg configmodels.Receiver,
 	nextConsumer consumer.TraceConsumer,
@@ -73,7 +73,7 @@ func (f *ReceiverFactory) CreateTraceReceiver(
 }
 
 // CreateMetricsReceiver creates a metrics receiver based on provided config.
-func (f *ReceiverFactory) CreateMetricsReceiver(
+func (f *receiverFactory) CreateMetricsReceiver(
 	cfg configmodels.Receiver,
 	consumer consumer.MetricsConsumer,
 ) (receiver.MetricsReceiver, error) {
@@ -88,7 +88,7 @@ func (f *ReceiverFactory) CreateMetricsReceiver(
 	return r, nil
 }
 
-func (f *ReceiverFactory) createReceiver(cfg configmodels.Receiver) (*Receiver, error) {
+func (f *receiverFactory) createReceiver(cfg configmodels.Receiver) (*Receiver, error) {
 	rCfg := cfg.(*ConfigV2)
 
 	// There must be one receiver for both metrics and traces. We maintain a map of

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -1,0 +1,116 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opencensusreceiver
+
+import (
+	"context"
+
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
+	"github.com/census-instrumentation/opencensus-service/internal/factories"
+
+	"github.com/census-instrumentation/opencensus-service/consumer"
+	"github.com/census-instrumentation/opencensus-service/receiver"
+)
+
+var _ = factories.RegisterReceiverFactory(&ReceiverFactory{})
+
+const (
+	// The value of "type" key in configuration.
+	typeStr = "opencensus"
+)
+
+// ReceiverFactory is the factory for receiver.
+type ReceiverFactory struct {
+}
+
+// Type gets the type of the Receiver config created by this factory.
+func (f *ReceiverFactory) Type() string {
+	return typeStr
+}
+
+// CustomUnmarshaler returns nil because we don't need custom unmarshaling for this config.
+func (f *ReceiverFactory) CustomUnmarshaler() factories.CustomUnmarshaler {
+	return nil
+}
+
+// CreateDefaultConfig creates the default configuration for receiver.
+func (f *ReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
+	return &ConfigV2{
+		ReceiverSettings: configmodels.ReceiverSettings{
+			Endpoint: "127.0.0.1:55678",
+			Enabled:  true,
+		},
+	}
+}
+
+// CreateTraceReceiver creates a  trace receiver based on provided config.
+func (f *ReceiverFactory) CreateTraceReceiver(
+	ctx context.Context,
+	cfg configmodels.Receiver,
+	nextConsumer consumer.TraceConsumer,
+) (receiver.TraceReceiver, error) {
+
+	r, err := f.createReceiver(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	r.traceConsumer = nextConsumer
+
+	return r, nil
+}
+
+// CreateMetricsReceiver creates a metrics receiver based on provided config.
+func (f *ReceiverFactory) CreateMetricsReceiver(
+	cfg configmodels.Receiver,
+	consumer consumer.MetricsConsumer,
+) (receiver.MetricsReceiver, error) {
+
+	r, err := f.createReceiver(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	r.metricsConsumer = consumer
+
+	return r, nil
+}
+
+func (f *ReceiverFactory) createReceiver(cfg configmodels.Receiver) (*Receiver, error) {
+	rCfg := cfg.(*ConfigV2)
+
+	// There must be one receiver for both metrics and traces. We maintain a map of
+	// receivers per config.
+
+	// Check to see if there is already a receiver for this config.
+	receiver, ok := receivers[rCfg]
+	if !ok {
+		// We don't have a receiver, so create one.
+		var err error
+		receiver, err = New(rCfg.Endpoint, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		// Remember the receiver in the map
+		receivers[rCfg] = receiver
+	}
+	return receiver, nil
+}
+
+// This is the map of already created OpenCensus receivers for particular configurations.
+// We maintain this map because the factory is asked trace and metric receivers separately
+// when it gets CreateTraceReceiver() and CreateMetricsReceiver() but they must not
+// create separate objects, they must use one Receiver object per configuration.
+var receivers = map[*ConfigV2]*Receiver{}

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opencensusreceiver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/census-instrumentation/opencensus-service/internal/factories"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := factories.GetReceiverFactory(typeStr)
+	cfg := factory.CreateDefaultConfig()
+	assert.NotNil(t, cfg, "failed to create default config")
+}
+
+func TestCreateReceiver(t *testing.T) {
+	factory := factories.GetReceiverFactory(typeStr)
+	cfg := factory.CreateDefaultConfig()
+
+	tReceiver, err := factory.CreateTraceReceiver(context.Background(), cfg, nil)
+	assert.NotNil(t, tReceiver)
+	assert.Nil(t, err)
+
+	// The default config does not provide scrape_config so we expect that metrics receiver
+	// creation must also fail.
+	mReceiver, err := factory.CreateMetricsReceiver(cfg, nil)
+	assert.NotNil(t, mReceiver)
+	assert.Nil(t, err)
+}

--- a/receiver/opencensusreceiver/testdata/config.yaml
+++ b/receiver/opencensusreceiver/testdata/config.yaml
@@ -1,0 +1,17 @@
+receivers:
+  opencensus:
+  opencensus/customname:
+    endpoint: 0.0.0.0:9090
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+pipelines:
+  traces:
+      receivers: [opencensus]
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]
+


### PR DESCRIPTION
- Added factory and config loading for OpenCensus receiver.

- Added support for custom unmarshaling of receiver configuration.

- Added ability for factory to create trace and metric receivers
  based on configuration. This will be later required when building
  the pipeline based on the config.

- Moved example factories used in tests to example_factories.go to
  make it easier to reuse them in other tests.

Testing done: automated tests