### PR TITLE
Add implementation of OpenCensus exporter config

### DIFF
--- a/exporter/opencensusexporter/config.go
+++ b/exporter/opencensusexporter/config.go
@@ -15,6 +15,8 @@
 package opencensusexporter
 
 import (
+	"time"
+
 	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
 )
 
@@ -26,4 +28,7 @@ type ConfigV2 struct {
 	Headers                       map[string]string        `mapstructure:"headers"`
 	NumWorkers                    int                      `mapstructure:"num-workers"`
 	CertPemFile                   string                   `mapstructure:"cert-pem-file"`
+	UseSecure                     bool                     `mapstructure:"secure,omitempty"`
+	ReconnectionDelay             time.Duration            `mapstructure:"reconnection-delay,omitempty"`
+	KeepaliveParameters           *keepaliveConfig         `mapstructure:"keepalive,omitempty"`
 }

--- a/exporter/opencensusexporter/config.go
+++ b/exporter/opencensusexporter/config.go
@@ -1,0 +1,29 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opencensusexporter
+
+import (
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
+)
+
+// ConfigV2 defines configuration for OpenCensus exporter.
+type ConfigV2 struct {
+	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	Endpoint                      string                   `mapstructure:"endpoint"`
+	Compression                   string                   `mapstructure:"compression"`
+	Headers                       map[string]string        `mapstructure:"headers"`
+	NumWorkers                    int                      `mapstructure:"num-workers"`
+	CertPemFile                   string                   `mapstructure:"cert-pem-file"`
+}

--- a/exporter/opencensusexporter/config_test.go
+++ b/exporter/opencensusexporter/config_test.go
@@ -1,0 +1,57 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opencensusexporter
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
+	"github.com/census-instrumentation/opencensus-service/internal/configv2"
+	"github.com/census-instrumentation/opencensus-service/internal/factories"
+)
+
+var _ = configv2.RegisterTestFactories()
+
+func TestLoadConfig(t *testing.T) {
+	factory := factories.GetExporterFactory(typeStr)
+
+	config, err := configv2.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"))
+
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	e0 := config.Exporters["opencensus"]
+	assert.Equal(t, e0, factory.CreateDefaultConfig())
+
+	e1 := config.Exporters["opencensus/2"]
+	assert.Equal(t, e1,
+		&ConfigV2{
+			ExporterSettings: configmodels.ExporterSettings{
+				Enabled: true,
+			},
+			Headers: map[string]string{
+				"header1": "234",
+				"another": "somevalue",
+			},
+			Endpoint:    "1.2.3.4:1234",
+			Compression: "on",
+			NumWorkers:  123,
+			CertPemFile: "/var/lib/mycert.pem",
+		})
+}

--- a/exporter/opencensusexporter/config_test.go
+++ b/exporter/opencensusexporter/config_test.go
@@ -46,12 +46,20 @@ func TestLoadConfig(t *testing.T) {
 				Enabled: true,
 			},
 			Headers: map[string]string{
-				"header1": "234",
-				"another": "somevalue",
+				"can you have a . here?": "F0000000-0000-0000-0000-000000000000",
+				"header1":                "234",
+				"another":                "somevalue",
 			},
-			Endpoint:    "1.2.3.4:1234",
-			Compression: "on",
-			NumWorkers:  123,
-			CertPemFile: "/var/lib/mycert.pem",
+			Endpoint:          "1.2.3.4:1234",
+			Compression:       "on",
+			NumWorkers:        123,
+			CertPemFile:       "/var/lib/mycert.pem",
+			UseSecure:         true,
+			ReconnectionDelay: 15,
+			KeepaliveParameters: &keepaliveConfig{
+				Time:                20,
+				PermitWithoutStream: true,
+				Timeout:             30,
+			},
 		})
 }

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -1,0 +1,44 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opencensusexporter
+
+import (
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
+	"github.com/census-instrumentation/opencensus-service/internal/factories"
+)
+
+var _ = factories.RegisterExporterFactory(&ExporterFactory{})
+
+const (
+	// The value of "type" key in configuration.
+	typeStr = "opencensus"
+)
+
+// ExporterFactory is the factory for OpenCensus exporter.
+type ExporterFactory struct {
+}
+
+// Type gets the type of the Exporter config created by this factory.
+func (f *ExporterFactory) Type() string {
+	return typeStr
+}
+
+// CreateDefaultConfig creates the default configuration for exporter.
+func (f *ExporterFactory) CreateDefaultConfig() configmodels.Exporter {
+	return &ConfigV2{
+		ExporterSettings: configmodels.ExporterSettings{},
+		Headers:          map[string]string{},
+	}
+}

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -19,24 +19,24 @@ import (
 	"github.com/census-instrumentation/opencensus-service/internal/factories"
 )
 
-var _ = factories.RegisterExporterFactory(&ExporterFactory{})
+var _ = factories.RegisterExporterFactory(&exporterFactory{})
 
 const (
 	// The value of "type" key in configuration.
 	typeStr = "opencensus"
 )
 
-// ExporterFactory is the factory for OpenCensus exporter.
-type ExporterFactory struct {
+// exporterFactory is the factory for OpenCensus exporter.
+type exporterFactory struct {
 }
 
 // Type gets the type of the Exporter config created by this factory.
-func (f *ExporterFactory) Type() string {
+func (f *exporterFactory) Type() string {
 	return typeStr
 }
 
 // CreateDefaultConfig creates the default configuration for exporter.
-func (f *ExporterFactory) CreateDefaultConfig() configmodels.Exporter {
+func (f *exporterFactory) CreateDefaultConfig() configmodels.Exporter {
 	return &ConfigV2{
 		ExporterSettings: configmodels.ExporterSettings{},
 		Headers:          map[string]string{},

--- a/exporter/opencensusexporter/factory_test.go
+++ b/exporter/opencensusexporter/factory_test.go
@@ -1,0 +1,32 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opencensusexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/census-instrumentation/opencensus-service/internal/factories"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := factories.GetExporterFactory(typeStr)
+	require.NotNil(t, factory)
+
+	cfg := factory.CreateDefaultConfig()
+	assert.NotNil(t, cfg, "failed to create default config")
+}

--- a/exporter/opencensusexporter/testdata/config.yaml
+++ b/exporter/opencensusexporter/testdata/config.yaml
@@ -13,8 +13,15 @@ exporters:
     num-workers: 123
     cert-pem-file: /var/lib/mycert.pem
     headers:
+      "can you have a . here?": "F0000000-0000-0000-0000-000000000000"
       header1: 234
       another: "somevalue"
+    secure: true
+    reconnection-delay: 15
+    keepalive:
+      time: 20
+      timeout: 30
+      permit-without-stream: true
 
 pipelines:
   traces:

--- a/exporter/opencensusexporter/testdata/config.yaml
+++ b/exporter/opencensusexporter/testdata/config.yaml
@@ -1,0 +1,23 @@
+receivers:
+  examplereceiver:
+
+processors:
+  exampleprocessor:
+
+exporters:
+  opencensus:
+  opencensus/2:
+    enabled: true
+    endpoint: "1.2.3.4:1234"
+    compression: "on"
+    num-workers: 123
+    cert-pem-file: /var/lib/mycert.pem
+    headers:
+      header1: 234
+      another: "somevalue"
+
+pipelines:
+  traces:
+    receivers: [examplereceiver]
+    processors: [exampleprocessor]
+    exporters: [opencensus]


### PR DESCRIPTION
- Added factory and config loading for OpenCensus exporter.

Note: the factory is not compelte yet. We will need to add ability to
create the exporter based on its config. It will be done in a future PR.

Testing done: automated tests