### PR TITLE
Build exporters based on new configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,10 @@ agent:
 collector:
 	GO111MODULE=on CGO_ENABLED=0 go build -o ./bin/occollector_$(GOOS) $(BUILD_INFO) ./cmd/occollector
 
+.PHONY: unisvc
+unisvc:
+	GO111MODULE=on CGO_ENABLED=0 go build -o ./bin/unisvc_$(GOOS) $(BUILD_INFO) ./cmd/unisvc
+
 .PHONY: docker-component # Not intended to be used directly
 docker-component: check-component
 	GOOS=linux $(MAKE) $(COMPONENT)
@@ -113,9 +117,12 @@ docker-agent:
 docker-collector:
 	COMPONENT=collector $(MAKE) docker-component
 
+.PHONY: docker-unisvc
+docker-unisvc:
+	COMPONENT=unisvc $(MAKE) docker-component
 
 .PHONY: binaries
-binaries: agent collector
+binaries: agent collector unisvc
 
 .PHONY: binaries-all-sys
 binaries-all-sys:

--- a/cmd/occollector/app/builder/exporters_builder.go
+++ b/cmd/occollector/app/builder/exporters_builder.go
@@ -1,0 +1,252 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/census-instrumentation/opencensus-service/consumer"
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/exporter"
+	"github.com/census-instrumentation/opencensus-service/internal"
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
+	"github.com/census-instrumentation/opencensus-service/internal/configv2"
+	"github.com/census-instrumentation/opencensus-service/internal/factories"
+)
+
+// ExportersBuilder builds exporters from config.
+type ExportersBuilder struct {
+	logger *zap.Logger
+	config *configmodels.ConfigV2
+}
+
+// exporterImpl is a running exporter that is built based on a config. It can have
+// a trace and/or a metrics consumer and have a stop function.
+type exporterImpl struct {
+	tc   consumer.TraceConsumer
+	mc   consumer.MetricsConsumer
+	stop func() error
+}
+
+// Check that exporterImpl implements Exporter interface.
+var _ exporter.Exporter = (*exporterImpl)(nil)
+
+// ConsumeTraceData receives data.TraceData for processing by the TraceConsumer.
+func (exp *exporterImpl) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+	return exp.tc.ConsumeTraceData(ctx, td)
+}
+
+// ConsumeMetricsData receives data.MetricsData for processing by the MetricsConsumer.
+func (exp *exporterImpl) ConsumeMetricsData(ctx context.Context, md data.MetricsData) error {
+	return exp.mc.ConsumeMetricsData(ctx, md)
+}
+
+// TraceExportFormat is unneeded, we need to get rid of it after we cleanup
+// exporter.TraceExporter interface.
+func (exp *exporterImpl) TraceExportFormat() string {
+	return ""
+}
+
+// MetricsExportFormat is unneeded, we need to get rid of it after we cleanup
+// exporter.MetricsExporter interface.
+func (exp *exporterImpl) MetricsExportFormat() string {
+	return ""
+}
+
+// Stop the exporter.
+func (exp *exporterImpl) Stop() error {
+	return exp.stop()
+}
+
+// Exporters is a map of exporters created from exporter configs.
+type Exporters map[configmodels.Exporter]*exporterImpl
+
+// StopAll stops all exporters.
+func (exps Exporters) StopAll() {
+	for _, exp := range exps {
+		exp.Stop()
+	}
+}
+
+type dataTypeRequirement struct {
+	// Pipeline that requires the data type.
+	requiredBy *configmodels.Pipeline
+}
+
+// Map of data type requirements.
+type dataTypeRequirements map[configmodels.DataType]dataTypeRequirement
+
+// Data type requirements for all exporters.
+type exportersRequiredDataTypes map[configmodels.Exporter]dataTypeRequirements
+
+// NewExportersBuilder creates a new ExportersBuilder. Call Build() on the returned value.
+func NewExportersBuilder(logger *zap.Logger, config *configmodels.ConfigV2) *ExportersBuilder {
+	return &ExportersBuilder{logger, config}
+}
+
+// Build exporters from config.
+func (eb *ExportersBuilder) Build() (Exporters, error) {
+	exporters := make(Exporters)
+
+	// We need to calculate required input data types for each exporter so that we know
+	// which data type must be started for each exporter.
+	exporterInputDataTypes := eb.calcExportersRequiredDataTypes()
+
+	// Build exporters based on configuration and required input data types.
+	for _, cfg := range eb.config.Exporters {
+		exp, err := eb.buildExporter(cfg, exporterInputDataTypes)
+		if err != nil {
+			return nil, err
+		}
+		exporters[cfg] = exp
+	}
+
+	return exporters, nil
+}
+
+func (eb *ExportersBuilder) calcExportersRequiredDataTypes() exportersRequiredDataTypes {
+
+	// Go over all pipelines. The data type of the pipeline defines what data type
+	// each exporter is expected to receive. Collect all required types for each
+	// exporter.
+	//
+	// We also remember the last pipeline that requested the particular data type.
+	// This is only needed for logging purposes in error cases when we need to
+	// print that a particular exporter does not support the data type required for
+	// a particular pipeline.
+
+	result := make(exportersRequiredDataTypes)
+
+	// Iterate over pipelines.
+	for _, pipeline := range eb.config.Pipelines {
+		// Iterate over all exporters for this pipeline.
+		for _, expName := range pipeline.Exporters {
+			// Find the exporter config by name.
+			exporter := eb.config.Exporters[expName]
+
+			// Create the data type requirement for the exporter if it does not exist.
+			if result[exporter] == nil {
+				result[exporter] = make(dataTypeRequirements)
+			}
+
+			// Remember that this data type is required for the exporter and also which
+			// pipeline the requirement is coming from.
+			result[exporter][pipeline.InputType] = dataTypeRequirement{pipeline}
+		}
+	}
+	return result
+}
+
+// Convert data type enum to string.
+func getDataTypeStr(dataType configmodels.DataType) string {
+	switch dataType {
+	case configmodels.TracesDataType:
+		return configv2.TracesDataTypeStr
+	case configmodels.MetricsDataType:
+		return configv2.MetricsDataTypeStr
+	default:
+		panic("unknown data type")
+	}
+}
+
+// combineStopFunc combines 2 functions and returns one function
+// that can be called and which in turn will call both functions
+// and then combine any errors that the 2 functions return.
+// Safe to use if any of the 2 functions are nil. If both functions
+// are nil then returns nil.
+func combineStopFunc(f1, f2 factories.StopFunc) factories.StopFunc {
+	if f1 == nil {
+		return f2
+	}
+	if f2 == nil {
+		return f1
+	}
+
+	return func() error {
+		var errs []error
+		if err := f1(); err != nil {
+			errs = append(errs, err)
+		}
+		if err := f2(); err != nil {
+			errs = append(errs, err)
+		}
+		return internal.CombineErrors(errs)
+	}
+}
+
+func (eb *ExportersBuilder) buildExporter(
+	config configmodels.Exporter,
+	exportersInputDataTypes exportersRequiredDataTypes,
+) (*exporterImpl, error) {
+
+	factory := factories.GetExporterFactory(config.Type())
+
+	exporter := &exporterImpl{}
+
+	inputDataTypes := exportersInputDataTypes[config]
+	if inputDataTypes == nil {
+		// No data types where requested for this exporter. This can only happen
+		// if there are no pipelines associated with the exporter.
+		eb.logger.Info("Exporter " + config.Name() +
+			" is not associated with any pipeline and will not export data.")
+		return exporter, nil
+	}
+
+	if requirement, ok := inputDataTypes[configmodels.TracesDataType]; ok {
+		// Traces data type is required. Create a trace exporter based on config.
+		tc, stopFunc, err := factory.CreateTraceExporter(config)
+		if err != nil {
+			if err == factories.ErrDataTypeIsNotSupported {
+				// Could not create because this exporter does not support this data type.
+				return nil, typeMismatchErr(config, requirement.requiredBy, configmodels.TracesDataType)
+			}
+			return nil, fmt.Errorf("error creating %q exporter: %v", config.Name(), err)
+		}
+
+		exporter.tc = tc
+		exporter.stop = stopFunc
+	}
+
+	if requirement, ok := inputDataTypes[configmodels.MetricsDataType]; ok {
+		// Metrics data type is required. Create a trace exporter based on config.
+		mc, stopFunc, err := factory.CreateMetricsExporter(config)
+		if err != nil {
+			if err == factories.ErrDataTypeIsNotSupported {
+				// Could not create because this exporter does not support this data type.
+				return nil, typeMismatchErr(config, requirement.requiredBy, configmodels.MetricsDataType)
+			}
+			return nil, fmt.Errorf("error creating %q exporter: %v", config.Name(), err)
+		}
+
+		exporter.mc = mc
+		exporter.stop = combineStopFunc(exporter.stop, stopFunc)
+	}
+
+	return exporter, nil
+}
+
+func typeMismatchErr(
+	config configmodels.Exporter,
+	requiredByPipeline *configmodels.Pipeline,
+	dataType configmodels.DataType,
+) error {
+	return fmt.Errorf("pipeline %q produces %q to exporter "+
+		"%s which does not support %q telemetry data. "+
+		"exporter will be detached from pipeline", requiredByPipeline.Name,
+		getDataTypeStr(dataType), config.Name(), getDataTypeStr(dataType))
+}

--- a/cmd/occollector/app/builder/exporters_builder_test.go
+++ b/cmd/occollector/app/builder/exporters_builder_test.go
@@ -1,0 +1,166 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/census-instrumentation/opencensus-service/exporter/opencensusexporter"
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
+)
+
+func TestExportersBuilder_Build(t *testing.T) {
+	config := &configmodels.ConfigV2{
+		Exporters: map[string]configmodels.Exporter{
+			"opencensus": &opencensusexporter.ConfigV2{
+				ExporterSettings: configmodels.ExporterSettings{
+					NameVal: "opencensus",
+					TypeVal: "opencensus",
+					Enabled: true,
+				},
+				Endpoint: "0.0.0.0:12345",
+			},
+		},
+
+		Pipelines: map[string]*configmodels.Pipeline{
+			"trace": {
+				Name:      "trace",
+				InputType: configmodels.TracesDataType,
+				Exporters: []string{"opencensus"},
+			},
+		},
+	}
+
+	exporters, err := NewExportersBuilder(zap.NewNop(), config).Build()
+
+	assert.NoError(t, err)
+	require.NotNil(t, exporters)
+
+	e1 := exporters[config.Exporters["opencensus"]]
+
+	// Ensure exporter has its fields correctly populated.
+	require.NotNil(t, e1)
+	assert.NotNil(t, e1.tc)
+	assert.Nil(t, e1.mc)
+	assert.NotNil(t, e1.stop)
+
+	// Ensure it can be stopped.
+	assert.NoError(t, e1.Stop())
+
+	// Now change only pipeline data type to "metrics" and make sure exporter builder
+	// now fails (because opencensus exporter does not currently support metrics).
+	config.Pipelines["trace"].InputType = configmodels.MetricsDataType
+	_, err = NewExportersBuilder(zap.NewNop(), config).Build()
+	assert.NotNil(t, err)
+
+	// Remove the pipeline so that the exporter is not attached to any pipeline.
+	// This should result in creating an exporter that has none of consumption
+	// functions set.
+	delete(config.Pipelines, "trace")
+	exporters, err = NewExportersBuilder(zap.NewNop(), config).Build()
+	assert.NotNil(t, exporters)
+	assert.Nil(t, err)
+
+	e1 = exporters[config.Exporters["opencensus"]]
+
+	// Ensure exporter has its fields correctly populated.
+	require.NotNil(t, e1)
+	assert.Nil(t, e1.tc)
+	assert.Nil(t, e1.mc)
+	assert.Nil(t, e1.stop)
+
+	// TODO: once we have an exporter that supports metrics data type test it too.
+}
+
+func TestExportersBuilder_StopAll(t *testing.T) {
+	exporters := make(Exporters)
+	expCfg := &configmodels.ExporterSettings{}
+	stopCalled := false
+	exporters[expCfg] = &exporterImpl{
+		stop: func() error {
+			stopCalled = true
+			return nil
+		},
+	}
+
+	exporters.StopAll()
+
+	assert.Equal(t, stopCalled, true)
+}
+
+func Test_combineStopFunc(t *testing.T) {
+	f := combineStopFunc(nil, nil)
+	assert.Nil(t, f)
+
+	err1 := errors.New("err1")
+	f1called := false
+	f1 := func() error {
+		f1called = true
+		return err1
+	}
+
+	err2 := errors.New("err2")
+	f2called := false
+	f2 := func() error {
+		f2called = true
+		return err2
+	}
+
+	f = combineStopFunc(f1, nil)
+	assert.Equal(t, f(), err1)
+	assert.Equal(t, f1called, true)
+	assert.Equal(t, f2called, false)
+
+	f1called = false
+	f2called = false
+	f = combineStopFunc(nil, f2)
+	assert.Equal(t, f(), err2)
+	assert.Equal(t, f1called, false)
+	assert.Equal(t, f2called, true)
+
+	// When 2 functions are combined ensure both functions are called.
+	f1called = false
+	f2called = false
+	f = combineStopFunc(f1, f2)
+	assert.NotNil(t, f())
+	assert.Equal(t, f1called, true)
+	assert.Equal(t, f2called, true)
+
+	// If first function does not return error the result should be equal to what
+	// second function returns.
+	err1 = nil
+	f = combineStopFunc(f1, f2)
+	assert.Equal(t, f(), err2)
+
+	// If second function does not return error the result should be equal to what
+	// first function returns.
+	err1 = errors.New("err1")
+	err2 = nil
+	f = combineStopFunc(f1, f2)
+	assert.Equal(t, f(), err1)
+
+	// If none of the functions returns an error then combined should also not return
+	// an error.
+	err1 = nil
+	err2 = nil
+	f = combineStopFunc(f1, f2)
+	assert.Equal(t, f(), nil)
+}

--- a/cmd/occollector/app/collector/telemetry.go
+++ b/cmd/occollector/app/collector/telemetry.go
@@ -38,13 +38,22 @@ const (
 	metricsLevelCfg = "metrics-level"
 )
 
+var (
+	// AppTelemetry is application's own telemetry.
+	AppTelemetry = &appTelemetry{}
+)
+
+type appTelemetry struct {
+	views []*view.View
+}
+
 func telemetryFlags(flags *flag.FlagSet) {
 	flags.String(metricsLevelCfg, "BASIC", "Output level of telemetry metrics (NONE, BASIC, NORMAL, DETAILED)")
 	// At least until we can use a generic, i.e.: OpenCensus, metrics exporter we default to Prometheus at port 8888, if not otherwise specified.
 	flags.Uint(metricsPortCfg, 8888, "Port exposing collector telemetry.")
 }
 
-func initTelemetry(asyncErrorChannel chan<- error, v *viper.Viper, logger *zap.Logger) error {
+func (tel *appTelemetry) init(asyncErrorChannel chan<- error, v *viper.Viper, logger *zap.Logger) error {
 	level, err := telemetry.ParseLevel(v.GetString(metricsLevelCfg))
 	if err != nil {
 		log.Fatalf("Failed to parse metrics level: %v", err)
@@ -63,6 +72,7 @@ func initTelemetry(asyncErrorChannel chan<- error, v *viper.Viper, logger *zap.L
 	views = append(views, tailsampling.SamplingProcessorMetricViews(level)...)
 	processMetricsViews := telemetry.NewProcessMetricsViews()
 	views = append(views, processMetricsViews.Views()...)
+	tel.views = views
 	if err := view.Register(views...); err != nil {
 		return err
 	}
@@ -91,4 +101,8 @@ func initTelemetry(asyncErrorChannel chan<- error, v *viper.Viper, logger *zap.L
 	}()
 
 	return nil
+}
+
+func (tel *appTelemetry) shutdown() {
+	view.Unregister(tel.views...)
 }

--- a/cmd/occollector/app/collector/testdata/unisvc-config.yaml
+++ b/cmd/occollector/app/collector/testdata/unisvc-config.yaml
@@ -1,0 +1,18 @@
+receivers:
+  jaeger:
+    enabled: true
+
+exporters:
+  opencensus:
+    endpoint: "locahost:55678"
+    enabled: true
+
+processors:
+  attributes:
+    enabled: true
+
+pipelines:
+  traces:
+    receivers: [jaeger]
+    processors: [attributes]
+    exporters: [opencensus]

--- a/cmd/unisvc/main.go
+++ b/cmd/unisvc/main.go
@@ -1,0 +1,23 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Program unisvc is the Open Telemetry Service that collects stats
+// and traces and exports to a configured backend.
+package main
+
+import "github.com/census-instrumentation/opencensus-service/unisvc"
+
+func main() {
+	unisvc.Run()
+}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -37,3 +37,10 @@ type MetricsExporter interface {
 	// as suffix (e.g. "oc_metrics").
 	MetricsExportFormat() string
 }
+
+// Exporter is union of trace and/or metrics exporter.
+type Exporter interface {
+	TraceExporter
+	MetricsExporter
+	Stop() error
+}

--- a/exporter/opencensusexporter/config_test.go
+++ b/exporter/opencensusexporter/config_test.go
@@ -43,6 +43,8 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, e1,
 		&ConfigV2{
 			ExporterSettings: configmodels.ExporterSettings{
+				NameVal: "opencensus/2",
+				TypeVal: "opencensus",
 				Enabled: true,
 			},
 			Headers: map[string]string{

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -16,7 +16,6 @@ package opencensusexporter
 
 import (
 	"crypto/x509"
-	"errors"
 	"fmt"
 
 	"google.golang.org/grpc"
@@ -63,9 +62,6 @@ func (f *exporterFactory) CreateDefaultConfig() configmodels.Exporter {
 // CreateTraceExporter creates a trace exporter based on this config.
 func (f *exporterFactory) CreateTraceExporter(config configmodels.Exporter) (consumer.TraceConsumer, factories.StopFunc, error) {
 	ocac := config.(*ConfigV2)
-	if ocac == nil {
-		return nil, nil, errors.New("Internal error")
-	}
 
 	if ocac.Endpoint == "" {
 		return nil, nil, &ocTraceExporterError{

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -15,6 +15,20 @@
 package opencensusexporter
 
 import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
+
+	"contrib.go.opencensus.io/exporter/ocagent"
+
+	"github.com/census-instrumentation/opencensus-service/consumer"
+	"github.com/census-instrumentation/opencensus-service/exporter/exporterhelper"
+	"github.com/census-instrumentation/opencensus-service/internal/compression"
+	compressiongrpc "github.com/census-instrumentation/opencensus-service/internal/compression/grpc"
 	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
 	"github.com/census-instrumentation/opencensus-service/internal/factories"
 )
@@ -38,7 +52,105 @@ func (f *exporterFactory) Type() string {
 // CreateDefaultConfig creates the default configuration for exporter.
 func (f *exporterFactory) CreateDefaultConfig() configmodels.Exporter {
 	return &ConfigV2{
-		ExporterSettings: configmodels.ExporterSettings{},
-		Headers:          map[string]string{},
+		ExporterSettings: configmodels.ExporterSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+		Headers: map[string]string{},
 	}
+}
+
+// CreateTraceExporter creates a trace exporter based on this config.
+func (f *exporterFactory) CreateTraceExporter(config configmodels.Exporter) (consumer.TraceConsumer, factories.StopFunc, error) {
+	ocac := config.(*ConfigV2)
+	if ocac == nil {
+		return nil, nil, errors.New("Internal error")
+	}
+
+	if ocac.Endpoint == "" {
+		return nil, nil, &ocTraceExporterError{
+			code: errEndpointRequired,
+			msg:  "OpenCensus exporter config requires an Endpoint",
+		}
+	}
+
+	opts := []ocagent.ExporterOption{ocagent.WithAddress(ocac.Endpoint)}
+	if ocac.Compression != "" {
+		if compressionKey := compressiongrpc.GetGRPCCompressionKey(ocac.Compression); compressionKey != compression.Unsupported {
+			opts = append(opts, ocagent.UseCompressor(compressionKey))
+		} else {
+			return nil, nil, &ocTraceExporterError{
+				code: errUnsupportedCompressionType,
+				msg:  fmt.Sprintf("OpenCensus exporter unsupported compression type %q", ocac.Compression),
+			}
+		}
+	}
+	if ocac.CertPemFile != "" {
+		creds, err := credentials.NewClientTLSFromFile(ocac.CertPemFile, "")
+		if err != nil {
+			return nil, nil, &ocTraceExporterError{
+				code: errUnableToGetTLSCreds,
+				msg:  fmt.Sprintf("OpenCensus exporter unable to read TLS credentials from pem file %q: %v", ocac.CertPemFile, err),
+			}
+		}
+		opts = append(opts, ocagent.WithTLSCredentials(creds))
+	} else if ocac.UseSecure {
+		certPool, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, nil, &ocTraceExporterError{
+				code: errUnableToGetTLSCreds,
+				msg: fmt.Sprintf(
+					"OpenCensus exporter unable to read certificates from system pool: %v", err),
+			}
+		}
+		creds := credentials.NewClientTLSFromCert(certPool, "")
+		opts = append(opts, ocagent.WithTLSCredentials(creds))
+	} else {
+		opts = append(opts, ocagent.WithInsecure())
+	}
+	if len(ocac.Headers) > 0 {
+		opts = append(opts, ocagent.WithHeaders(ocac.Headers))
+	}
+	if ocac.ReconnectionDelay > 0 {
+		opts = append(opts, ocagent.WithReconnectionPeriod(ocac.ReconnectionDelay))
+	}
+	if ocac.KeepaliveParameters != nil {
+		opts = append(opts, ocagent.WithGRPCDialOption(grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                ocac.KeepaliveParameters.Time,
+			Timeout:             ocac.KeepaliveParameters.Timeout,
+			PermitWithoutStream: ocac.KeepaliveParameters.PermitWithoutStream,
+		})))
+	}
+
+	numWorkers := defaultNumWorkers
+	if ocac.NumWorkers > 0 {
+		numWorkers = ocac.NumWorkers
+	}
+
+	exportersChan := make(chan *ocagent.Exporter, numWorkers)
+	for exporterIndex := 0; exporterIndex < numWorkers; exporterIndex++ {
+		exporter, serr := ocagent.NewExporter(opts...)
+		if serr != nil {
+			return nil, nil, fmt.Errorf("cannot configure OpenCensus Trace exporter: %v", serr)
+		}
+		exportersChan <- exporter
+	}
+
+	oce := &ocagentExporter{exporters: exportersChan}
+	oexp, err := exporterhelper.NewTraceExporter(
+		"oc_trace",
+		oce.PushTraceData,
+		exporterhelper.WithSpanName("ocservice.exporter.OpenCensus.ConsumeTraceData"),
+		exporterhelper.WithRecordMetrics(true))
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return oexp, oce.stop, nil
+}
+
+// CreateMetricsExporter creates a metrics exporter based on this config.
+func (f *exporterFactory) CreateMetricsExporter(cfg configmodels.Exporter) (consumer.MetricsConsumer, factories.StopFunc, error) {
+	return nil, nil, factories.ErrDataTypeIsNotSupported
 }

--- a/exporter/opencensusexporter/factory_test.go
+++ b/exporter/opencensusexporter/factory_test.go
@@ -16,10 +16,12 @@ package opencensusexporter
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/census-instrumentation/opencensus-service/internal/compression"
 	"github.com/census-instrumentation/opencensus-service/internal/factories"
 )
 
@@ -29,4 +31,119 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+}
+
+func TestCreateMetricsExporter(t *testing.T) {
+	factory := factories.GetExporterFactory(typeStr)
+	cfg := factory.CreateDefaultConfig()
+
+	_, _, err := factory.CreateMetricsExporter(cfg)
+	assert.Error(t, err, factories.ErrDataTypeIsNotSupported)
+}
+
+func TestCreateTraceExporter(t *testing.T) {
+	const defaultTestEndPoint = "127.0.0.1:55678"
+	tests := []struct {
+		name     string
+		config   ConfigV2
+		mustFail bool
+	}{
+		{
+			name: "NoEndpoint",
+			config: ConfigV2{
+				Endpoint: "",
+			},
+			mustFail: true,
+		},
+		{
+			name: "UseSecure",
+			config: ConfigV2{
+				Endpoint:  defaultTestEndPoint,
+				UseSecure: true,
+			},
+		},
+		{
+			name: "ReconnectionDelay",
+			config: ConfigV2{
+				Endpoint:          defaultTestEndPoint,
+				ReconnectionDelay: 5 * time.Second,
+			},
+		},
+		{
+			name: "KeepaliveParameters",
+			config: ConfigV2{
+				Endpoint: defaultTestEndPoint,
+				KeepaliveParameters: &keepaliveConfig{
+					Time:                30 * time.Second,
+					Timeout:             25 * time.Second,
+					PermitWithoutStream: true,
+				},
+			},
+		},
+		{
+			name: "Compression",
+			config: ConfigV2{
+				Endpoint:    defaultTestEndPoint,
+				Compression: compression.Gzip,
+			},
+		},
+		{
+			name: "Headers",
+			config: ConfigV2{
+				Endpoint: defaultTestEndPoint,
+				Headers: map[string]string{
+					"hdr1": "val1",
+					"hdr2": "val2",
+				},
+			},
+		},
+		{
+			name: "NumWorkers",
+			config: ConfigV2{
+				Endpoint:   defaultTestEndPoint,
+				NumWorkers: 3,
+			},
+		},
+		{
+			name: "CompressionError",
+			config: ConfigV2{
+				Endpoint:    defaultTestEndPoint,
+				Compression: "unknown compression",
+			},
+			mustFail: true,
+		},
+		{
+			name: "CertPemFile",
+			config: ConfigV2{
+				Endpoint:    defaultTestEndPoint,
+				CertPemFile: "testdata/test_cert.pem",
+			},
+		},
+		{
+			name: "CertPemFileError",
+			config: ConfigV2{
+				Endpoint:    defaultTestEndPoint,
+				CertPemFile: "nosuchfile",
+			},
+			mustFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := factories.GetExporterFactory(typeStr)
+			consumer, stopFunc, err := factory.CreateTraceExporter(&tt.config)
+
+			if tt.mustFail {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.NotNil(t, consumer)
+				assert.NotNil(t, stopFunc)
+
+				err = stopFunc()
+				assert.Nil(t, err)
+			}
+		})
+	}
 }

--- a/internal/configmodels/configmodels.go
+++ b/internal/configmodels/configmodels.go
@@ -82,6 +82,24 @@ const (
 	MetricsDataType
 )
 
+// Data type strings.
+const (
+	TracesDataTypeStr  = "traces"
+	MetricsDataTypeStr = "metrics"
+)
+
+// GetDataTypeStr converts data type to string.
+func (dataType DataType) GetDataTypeStr() string {
+	switch dataType {
+	case TracesDataType:
+		return TracesDataTypeStr
+	case MetricsDataType:
+		return MetricsDataTypeStr
+	default:
+		panic("unknown data type")
+	}
+}
+
 // Pipeline defines a single pipeline.
 type Pipeline struct {
 	Name       string   `mapstructure:"-"`

--- a/internal/configmodels/configmodels.go
+++ b/internal/configmodels/configmodels.go
@@ -47,9 +47,13 @@ type Receiver interface {
 // Receivers is a map of names to Receivers.
 type Receivers map[string]Receiver
 
-// Exporter is the configuration of an exporter. Specific exporters must implement this
-// interface and will typically embed ExporterSettings struct or a struct that extends it.
+// Exporter is the configuration of an exporter.
 type Exporter interface {
+	Name() string
+	SetName(name string)
+
+	Type() string
+	SetType(typeStr string)
 }
 
 // Exporters is a map of names to Exporters.
@@ -104,7 +108,31 @@ type ReceiverSettings struct {
 // ExporterSettings defines common settings for an exporter configuration.
 // Specific exporters can embed this struct and extend it with more fields if needed.
 type ExporterSettings struct {
-	Enabled bool `mapstructure:"enabled"`
+	TypeVal string `mapstructure:"-"`
+	NameVal string `mapstructure:"-"`
+	Enabled bool   `mapstructure:"enabled"`
+}
+
+var _ Exporter = (*ExporterSettings)(nil)
+
+// Name gets the exporter name.
+func (es *ExporterSettings) Name() string {
+	return es.NameVal
+}
+
+// SetName sets the exporter name.
+func (es *ExporterSettings) SetName(name string) {
+	es.NameVal = name
+}
+
+// Type sets the exporter type.
+func (es *ExporterSettings) Type() string {
+	return es.TypeVal
+}
+
+// SetType sets the exporter type.
+func (es *ExporterSettings) SetType(typeStr string) {
+	es.TypeVal = typeStr
 }
 
 // ProcessorSettings defines common settings for a processor configuration.

--- a/internal/configv2/configv2.go
+++ b/internal/configv2/configv2.go
@@ -81,10 +81,10 @@ const (
 // typeAndNameSeparator is the separator that is used between type and name in type/name composite keys.
 const typeAndNameSeparator = "/"
 
-// Data type strings
+// Data type strings.
 const (
-	tracesDataTypeStr  = "traces"
-	metricsDataTypeStr = "metrics"
+	TracesDataTypeStr  = "traces"
+	MetricsDataTypeStr = "metrics"
 )
 
 // Load loads a ConfigV2 from Viper.
@@ -261,6 +261,8 @@ func loadExporters(v *viper.Viper) (configmodels.Exporters, error) {
 
 		// Create the default config for this exporter
 		exporterCfg := factory.CreateDefaultConfig()
+		exporterCfg.SetType(typeStr)
+		exporterCfg.SetName(fullName)
 
 		// Now that the default config struct is created we can Unmarshal into it
 		// and it will apply user-defined config on top of the default.
@@ -365,9 +367,9 @@ func loadPipelines(v *viper.Viper) (configmodels.Pipelines, error) {
 
 		// Set the type.
 		switch typeStr {
-		case tracesDataTypeStr:
+		case TracesDataTypeStr:
 			pipelineCfg.InputType = configmodels.TracesDataType
-		case metricsDataTypeStr:
+		case MetricsDataTypeStr:
 			pipelineCfg.InputType = configmodels.MetricsDataType
 		default:
 			return nil, &configError{

--- a/internal/configv2/configv2.go
+++ b/internal/configv2/configv2.go
@@ -81,12 +81,6 @@ const (
 // typeAndNameSeparator is the separator that is used between type and name in type/name composite keys.
 const typeAndNameSeparator = "/"
 
-// Data type strings.
-const (
-	TracesDataTypeStr  = "traces"
-	MetricsDataTypeStr = "metrics"
-)
-
 // Load loads a ConfigV2 from Viper.
 func Load(v *viper.Viper) (*configmodels.ConfigV2, error) {
 
@@ -367,9 +361,9 @@ func loadPipelines(v *viper.Viper) (configmodels.Pipelines, error) {
 
 		// Set the type.
 		switch typeStr {
-		case TracesDataTypeStr:
+		case configmodels.TracesDataTypeStr:
 			pipelineCfg.InputType = configmodels.TracesDataType
-		case MetricsDataTypeStr:
+		case configmodels.MetricsDataTypeStr:
 			pipelineCfg.InputType = configmodels.MetricsDataType
 		default:
 			return nil, &configError{

--- a/internal/configv2/configv2_test.go
+++ b/internal/configv2/configv2_test.go
@@ -60,6 +60,8 @@ func TestDecodeConfig(t *testing.T) {
 	assert.Equal(t, config.Exporters["exampleexporter"],
 		&ExampleExporter{
 			ExporterSettings: configmodels.ExporterSettings{
+				NameVal: "exampleexporter",
+				TypeVal: "exampleexporter",
 				Enabled: false,
 			},
 			ExtraSetting: "some export string",
@@ -68,6 +70,8 @@ func TestDecodeConfig(t *testing.T) {
 	assert.Equal(t, config.Exporters["exampleexporter/myexporter"],
 		&ExampleExporter{
 			ExporterSettings: configmodels.ExporterSettings{
+				NameVal: "exampleexporter/myexporter",
+				TypeVal: "exampleexporter",
 				Enabled: true,
 			},
 			ExtraSetting: "some export string 2",

--- a/internal/configv2/example_factories.go
+++ b/internal/configv2/example_factories.go
@@ -167,6 +167,16 @@ func (f *ExampleExporterFactory) CreateDefaultConfig() configmodels.Exporter {
 	}
 }
 
+// CreateTraceExporter creates a trace exporter based on this config.
+func (f *ExampleExporterFactory) CreateTraceExporter(cfg configmodels.Exporter) (consumer.TraceConsumer, factories.StopFunc, error) {
+	return nil, nil, nil
+}
+
+// CreateMetricsExporter creates a metrics exporter based on this config.
+func (f *ExampleExporterFactory) CreateMetricsExporter(cfg configmodels.Exporter) (consumer.MetricsConsumer, factories.StopFunc, error) {
+	return nil, nil, nil
+}
+
 // ExampleProcessor is for testing purposes. We are defining an example config and factory
 // for "exampleprocessor" processor type.
 type ExampleProcessor struct {

--- a/internal/factories/factories.go
+++ b/internal/factories/factories.go
@@ -86,6 +86,10 @@ func GetReceiverFactory(typeStr string) ReceiverFactory {
 ///////////////////////////////////////////////////////////////////////////////
 // Exporter factory and its registry.
 
+// StopFunc is a function that can be called to stop an exporter that
+// was created previously.
+type StopFunc func() error
+
 // ExporterFactory is factory interface for exporters. Note: only configuration-related
 // functionality exists for now. We will add more factory functionality in the future.
 type ExporterFactory interface {
@@ -94,6 +98,12 @@ type ExporterFactory interface {
 
 	// CreateDefaultConfig creates the default configuration for the Exporter.
 	CreateDefaultConfig() configmodels.Exporter
+
+	// CreateTraceExporter creates a trace exporter based on this config.
+	CreateTraceExporter(cfg configmodels.Exporter) (consumer.TraceConsumer, StopFunc, error)
+
+	// CreateMetricsExporter creates a metrics exporter based on this config.
+	CreateMetricsExporter(cfg configmodels.Exporter) (consumer.MetricsConsumer, StopFunc, error)
 }
 
 // List of registered exporter factories.

--- a/internal/factories/factories_test.go
+++ b/internal/factories/factories_test.go
@@ -104,6 +104,16 @@ func (f *ExampleExporterFactory) CreateDefaultConfig() configmodels.Exporter {
 	return nil
 }
 
+// CreateTraceExporter creates a trace exporter based on this config.
+func (f *ExampleExporterFactory) CreateTraceExporter(cfg configmodels.Exporter) (consumer.TraceConsumer, StopFunc, error) {
+	return nil, nil, nil
+}
+
+// CreateMetricsExporter creates a metrics exporter based on this config.
+func (f *ExampleExporterFactory) CreateMetricsExporter(cfg configmodels.Exporter) (consumer.MetricsConsumer, StopFunc, error) {
+	return nil, nil, nil
+}
+
 func TestRegisterExporterFactory(t *testing.T) {
 	f := ExampleExporterFactory{}
 	err := RegisterExporterFactory(&f)

--- a/unisvc/empty_test.go
+++ b/unisvc/empty_test.go
@@ -1,0 +1,1 @@
+package unisvc

--- a/unisvc/service.go
+++ b/unisvc/service.go
@@ -1,0 +1,30 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package unisvc implements Open Telemetry Service that collects stats
+// and traces and exports to a configured backend.
+package unisvc
+
+import (
+	"log"
+
+	"github.com/census-instrumentation/opencensus-service/cmd/occollector/app/collector"
+)
+
+// Run the unified telemetry service.
+func Run() {
+	if err := collector.App.StartUnified(); err != nil {
+		log.Fatalf("Failed to run the service: %v", err)
+	}
+}


### PR DESCRIPTION
- Introduced a new unisvc binary and make target. Unisvc is
  planned to be the implementation of the unified agent and collector
  that uses the new configuration format.

- Refactored existing Application.execute() code to make it more
  readable and also reusable.
  The functionality is not changed. Reviews: please check this carefully!

- Introduced new Application.executeUnified() function that will call
  all new agent/collector execution logic that is different from
  old logic.
  Application.executeUnified() is currently partial implementation,
  which only builds the exporters. I plan to add building of processor
  pipelines and receivers in future PRs.

- Introduced ExportersBuilder which builds runtime exporters based
  on provided configuration.

- Added ability for App telemetry shutdown. This is required to be able to
  run multiple tests that involve App start and shutdown. Previously
  there was only one test - TestApplication_Start - and it was not
  correctly cleaning up telemetry resources at the end, making impossible
  to add more tests against App.