### PR TITLE
Build pipeline processors based on new configuration

### DIFF
--- a/cmd/occollector/app/builder/exporters_builder_test.go
+++ b/cmd/occollector/app/builder/exporters_builder_test.go
@@ -94,7 +94,7 @@ func TestExportersBuilder_StopAll(t *testing.T) {
 	exporters := make(Exporters)
 	expCfg := &configmodels.ExporterSettings{}
 	stopCalled := false
-	exporters[expCfg] = &exporterImpl{
+	exporters[expCfg] = &builtExporter{
 		stop: func() error {
 			stopCalled = true
 			return nil

--- a/cmd/occollector/app/builder/pipelines_builder.go
+++ b/cmd/occollector/app/builder/pipelines_builder.go
@@ -1,0 +1,164 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/census-instrumentation/opencensus-service/consumer"
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
+	"github.com/census-instrumentation/opencensus-service/internal/factories"
+	"github.com/census-instrumentation/opencensus-service/processor/multiconsumer"
+)
+
+// builtProcessor is a processor that is built based on a config.
+// It can have a trace and/or a metrics consumer.
+type builtProcessor struct {
+	tc consumer.TraceConsumer
+	mc consumer.MetricsConsumer
+}
+
+// PipelineProcessors is a map of entry-point processors created from pipeline configs.
+// Each element of the map points to the first processor of the pipeline.
+type PipelineProcessors map[*configmodels.Pipeline]*builtProcessor
+
+// PipelinesBuilder builds pipelines from config.
+type PipelinesBuilder struct {
+	logger    *zap.Logger
+	config    *configmodels.ConfigV2
+	exporters Exporters
+}
+
+// NewPipelinesBuilder creates a new PipelinesBuilder. Requires exporters to be already
+// built via ExportersBuilder. Call Build() on the returned value.
+func NewPipelinesBuilder(
+	logger *zap.Logger,
+	config *configmodels.ConfigV2,
+	exporters Exporters,
+) *PipelinesBuilder {
+	return &PipelinesBuilder{logger, config, exporters}
+}
+
+// Build pipeline processors from config.
+func (eb *PipelinesBuilder) Build() (PipelineProcessors, error) {
+	pipelineProcessors := make(PipelineProcessors)
+
+	for _, pipeline := range eb.config.Pipelines {
+		firstProcessor, err := eb.buildPipeline(pipeline)
+		if err != nil {
+			return nil, err
+		}
+		pipelineProcessors[pipeline] = firstProcessor
+	}
+
+	return pipelineProcessors, nil
+}
+
+// Builds a pipeline of processors. Returns the first processor in the pipeline.
+// The last processor in the pipeline will be plugged to fan out the data into exporters
+// that are configured for this pipeline.
+func (eb *PipelinesBuilder) buildPipeline(
+	pipelineCfg *configmodels.Pipeline,
+) (*builtProcessor, error) {
+
+	// Build the pipeline backwards.
+
+	// First create a consumer junction point that fans out the data to all exporters.
+	var tc consumer.TraceConsumer
+	var mc consumer.MetricsConsumer
+
+	switch pipelineCfg.InputType {
+	case configmodels.TracesDataType:
+		tc = eb.buildFanoutExportersTraceConsumer(pipelineCfg.Exporters)
+	case configmodels.MetricsDataType:
+		mc = eb.buildFanoutExportersMetricsConsumer(pipelineCfg.Exporters)
+	}
+
+	// Now build the processors backwards, starting from the last one.
+	// The last processor points to consumer which fans out to exporters, then
+	// the processor itself becomes a consumer for the one that precedes it in
+	// in the pipeline and so on.
+	for i := len(pipelineCfg.Processors) - 1; i >= 0; i-- {
+		procName := pipelineCfg.Processors[i]
+		procCfg := eb.config.Processors[procName]
+
+		factory := factories.GetProcessorFactory(procCfg.Type())
+
+		// This processor must point to the next consumer and then
+		// it becomes the next for the previous one (previous in the pipeline,
+		// which we will build in the next loop iteration).
+		var err error
+		switch pipelineCfg.InputType {
+		case configmodels.TracesDataType:
+			tc, err = factory.CreateTraceProcessor(tc, procCfg)
+		case configmodels.MetricsDataType:
+			mc, err = factory.CreateMetricsProcessor(mc, procCfg)
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("error creating processor %q in pipeline %q: %v",
+				procName, pipelineCfg.Name, err)
+		}
+	}
+
+	return &builtProcessor{tc, mc}, nil
+}
+
+// Converts the list of exporter names to a list of corresponding builtExporters.
+func (eb *PipelinesBuilder) getBuiltExportersByNames(exporterNames []string) []*builtExporter {
+	var result []*builtExporter
+	for _, name := range exporterNames {
+		exporter := eb.exporters[eb.config.Exporters[name]]
+		result = append(result, exporter)
+	}
+
+	return result
+}
+
+func (eb *PipelinesBuilder) buildFanoutExportersTraceConsumer(exporterNames []string) consumer.TraceConsumer {
+	builtExporters := eb.getBuiltExportersByNames(exporterNames)
+
+	var exporterConsumers []consumer.TraceConsumer
+	for _, impl := range builtExporters {
+		exporterConsumers = append(exporterConsumers, impl.tc)
+	}
+
+	// Optimize for the case when there is only one exporter, no need to create junction point.
+	if len(exporterConsumers) == 1 {
+		return exporterConsumers[0]
+	}
+
+	// Create a junction point that fans out to all exporters.
+	return multiconsumer.NewTraceProcessor(exporterConsumers)
+}
+
+func (eb *PipelinesBuilder) buildFanoutExportersMetricsConsumer(exporterNames []string) consumer.MetricsConsumer {
+	builtExporters := eb.getBuiltExportersByNames(exporterNames)
+
+	var exporters []consumer.MetricsConsumer
+	for _, impl := range builtExporters {
+		exporters = append(exporters, impl.mc)
+	}
+
+	// Optimize for the case when there is only one exporter, no need to create junction point.
+	if len(exporters) == 1 {
+		return exporters[0]
+	}
+
+	// Create a junction point that fans out to all exporters.
+	return multiconsumer.NewMetricsProcessor(exporters)
+}

--- a/cmd/occollector/app/builder/pipelines_builder.go
+++ b/cmd/occollector/app/builder/pipelines_builder.go
@@ -132,31 +132,31 @@ func (eb *PipelinesBuilder) getBuiltExportersByNames(exporterNames []string) []*
 func (eb *PipelinesBuilder) buildFanoutExportersTraceConsumer(exporterNames []string) consumer.TraceConsumer {
 	builtExporters := eb.getBuiltExportersByNames(exporterNames)
 
-	var exporterConsumers []consumer.TraceConsumer
-	for _, impl := range builtExporters {
-		exporterConsumers = append(exporterConsumers, impl.tc)
+	// Optimize for the case when there is only one exporter, no need to create junction point.
+	if len(builtExporters) == 1 {
+		return builtExporters[0].tc
 	}
 
-	// Optimize for the case when there is only one exporter, no need to create junction point.
-	if len(exporterConsumers) == 1 {
-		return exporterConsumers[0]
+	var exporters []consumer.TraceConsumer
+	for _, builtExp := range builtExporters {
+		exporters = append(exporters, builtExp.tc)
 	}
 
 	// Create a junction point that fans out to all exporters.
-	return multiconsumer.NewTraceProcessor(exporterConsumers)
+	return multiconsumer.NewTraceProcessor(exporters)
 }
 
 func (eb *PipelinesBuilder) buildFanoutExportersMetricsConsumer(exporterNames []string) consumer.MetricsConsumer {
 	builtExporters := eb.getBuiltExportersByNames(exporterNames)
 
-	var exporters []consumer.MetricsConsumer
-	for _, impl := range builtExporters {
-		exporters = append(exporters, impl.mc)
+	// Optimize for the case when there is only one exporter, no need to create junction point.
+	if len(builtExporters) == 1 {
+		return builtExporters[0].mc
 	}
 
-	// Optimize for the case when there is only one exporter, no need to create junction point.
-	if len(exporters) == 1 {
-		return exporters[0]
+	var exporters []consumer.MetricsConsumer
+	for _, builtExp := range builtExporters {
+		exporters = append(exporters, builtExp.mc)
 	}
 
 	// Create a junction point that fans out to all exporters.

--- a/cmd/occollector/app/builder/pipelines_builder_test.go
+++ b/cmd/occollector/app/builder/pipelines_builder_test.go
@@ -1,0 +1,143 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
+	"github.com/census-instrumentation/opencensus-service/internal/configv2"
+	"github.com/census-instrumentation/opencensus-service/processor/addattributesprocessor"
+)
+
+// Ensure attributes processor is registered.
+var _ = addattributesprocessor.ConfigV2{}
+
+// Register test factories used in the pipelines_builder.yaml test config.
+var _ = configv2.RegisterTestFactories()
+
+func TestPipelinesBuilder_Build(t *testing.T) {
+	tests := []struct {
+		name          string
+		pipelineName  string
+		exporterNames []string
+	}{
+		{
+			name:          "one-exporter",
+			pipelineName:  "traces",
+			exporterNames: []string{"exampleexporter"},
+		},
+		{
+			name:          "multi-exporter",
+			pipelineName:  "traces/2",
+			exporterNames: []string{"exampleexporter", "exampleexporter/2"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testPipeline(t, test.pipelineName, test.exporterNames)
+		})
+	}
+}
+
+func testPipeline(t *testing.T, pipelineName string, exporterNames []string) {
+	// Load the config
+	config, err := configv2.LoadConfigFile(t, "testdata/pipelines_builder.yaml")
+	require.Nil(t, err)
+
+	// Build the pipeline
+	allExporters, err := NewExportersBuilder(zap.NewNop(), config).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), config, allExporters).Build()
+
+	assert.NoError(t, err)
+	require.NotNil(t, pipelineProcessors)
+
+	processor := pipelineProcessors[config.Pipelines[pipelineName]]
+
+	// Ensure pipeline has its fields correctly populated.
+	require.NotNil(t, processor)
+	assert.NotNil(t, processor.tc)
+	assert.Nil(t, processor.mc)
+
+	// Compose the list of created exporters.
+	var exporters []*builtExporter
+	for _, name := range exporterNames {
+		// Ensure exporter is created.
+		exp := allExporters[config.Exporters[name]]
+		require.NotNil(t, exp)
+		exporters = append(exporters, exp)
+	}
+
+	// Send TraceData via processor and verify that all exporters of the pipeline receive it.
+
+	// First check that there are no traces in the exporters yet.
+	var exporterConsumers []*configv2.ExampleExporterConsumer
+	for _, exporter := range exporters {
+		consumer := exporter.tc.(*configv2.ExampleExporterConsumer)
+		exporterConsumers = append(exporterConsumers, consumer)
+		require.Equal(t, len(consumer.Traces), 0)
+	}
+
+	// Send one trace.
+	name := tracepb.TruncatableString{Value: "testspanname"}
+	traceData := data.TraceData{
+		SourceFormat: "test-source-format",
+		Spans: []*tracepb.Span{
+			{Name: &name},
+		},
+	}
+	processor.tc.ConsumeTraceData(context.Background(), traceData)
+
+	// Now verify received data.
+	for _, consumer := range exporterConsumers {
+		// Check that the trace is received by exporter.
+		require.Equal(t, 1, len(consumer.Traces))
+		assert.Equal(t, traceData, consumer.Traces[0])
+
+		// Check that the span was processed by "attributes" processor and an
+		// attribute was added.
+		assert.Equal(t, int64(12345),
+			consumer.Traces[0].Spans[0].Attributes.AttributeMap["attr1"].GetIntValue())
+	}
+}
+
+func TestPipelinesBuilder_Error(t *testing.T) {
+	config, err := configv2.LoadConfigFile(t, "testdata/pipelines_builder.yaml")
+	require.Nil(t, err)
+
+	// Corrupt the pipeline, change data type to metrics. We have to forcedly do it here
+	// since there is no way to have such config loaded by LoadConfigFile, it would not
+	// pass validation. We are doing this to test failure mode of PipelinesBuilder.
+	pipeline := config.Pipelines["traces"]
+	pipeline.InputType = configmodels.MetricsDataType
+
+	exporters, err := NewExportersBuilder(zap.NewNop(), config).Build()
+
+	// This should fail because "attributes" processor defined in the config does
+	// not support metrics data type.
+	_, err = NewPipelinesBuilder(zap.NewNop(), config, exporters).Build()
+
+	assert.NotNil(t, err)
+}

--- a/cmd/occollector/app/builder/testdata/pipelines_builder.yaml
+++ b/cmd/occollector/app/builder/testdata/pipelines_builder.yaml
@@ -1,0 +1,26 @@
+receivers:
+  examplereceiver:
+    enabled: true
+
+processors:
+  attributes:
+    values:
+      attr1: 12345
+
+exporters:
+  exampleexporter:
+    enabled: true
+
+  exampleexporter/2:
+    enabled: true
+
+pipelines:
+  traces:
+    receivers: [examplereceiver]
+    processors: [attributes]
+    exporters: [exampleexporter]
+
+  traces/2:
+    receivers: [examplereceiver]
+    processors: [attributes]
+    exporters: [exampleexporter, exampleexporter/2]

--- a/cmd/occollector/app/collector/collector.go
+++ b/cmd/occollector/app/collector/collector.go
@@ -237,8 +237,12 @@ func (app *Application) setupPipelines() {
 		log.Fatalf("Cannot load configuration: %v", err)
 	}
 
-	// TODO: create pipelines and their processors and plug exporters to the
+	// Create pipelines and their processors and plug exporters to the
 	// end of the pipelines.
+	_, err = builder.NewPipelinesBuilder(app.logger, config, app.exporters).Build()
+	if err != nil {
+		log.Fatalf("Cannot load configuration: %v", err)
+	}
 
 	// TODO: create receivers and plug them into the start of the pipelines.
 }

--- a/cmd/occollector/app/collector/collector_test.go
+++ b/cmd/occollector/app/collector/collector_test.go
@@ -20,6 +20,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/census-instrumentation/opencensus-service/internal/testutils"
+
 	"github.com/census-instrumentation/opencensus-service/internal/zpagesserver"
 )
 
@@ -112,18 +114,7 @@ func isAppAvailable(t *testing.T, healthCheckEndPoint string) bool {
 func getMultipleAvailableLocalAddresses(t *testing.T, numAddresses uint) []string {
 	addresses := make([]string, numAddresses, numAddresses)
 	for i := uint(0); i < numAddresses; i++ {
-		addresses[i] = getAvailableLocalAddress(t)
+		addresses[i] = testutils.GetAvailableLocalAddress(t)
 	}
 	return addresses
-}
-
-func getAvailableLocalAddress(t *testing.T) string {
-	ln, err := net.Listen("tcp", ":0")
-	if err != nil {
-		t.Fatalf("failed to get a free local port: %v", err)
-	}
-	// There is a possible race if something else takes this same port before
-	// the test uses it, however, that is unlikely in practice.
-	defer ln.Close()
-	return ln.Addr().String()
 }

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -35,3 +35,9 @@ type MetricsConsumer interface {
 type TraceConsumer interface {
 	ConsumeTraceData(ctx context.Context, td data.TraceData) error
 }
+
+// DataConsumer is a union type that can accept traces and/or metrics.
+type DataConsumer interface {
+	TraceConsumer
+	MetricsConsumer
+}

--- a/internal/configmodels/configmodels.go
+++ b/internal/configmodels/configmodels.go
@@ -62,6 +62,8 @@ type Exporters map[string]Exporter
 // Processor is the configuration of a processor. Specific processors must implement this
 // interface and will typically embed ProcessorSettings struct or a struct that extends it.
 type Processor interface {
+	Type() string
+	SetType(typeStr string)
 }
 
 // Processors is a map of names to Processors.
@@ -156,5 +158,18 @@ func (es *ExporterSettings) SetType(typeStr string) {
 // ProcessorSettings defines common settings for a processor configuration.
 // Specific processors can embed this struct and extend it with more fields if needed.
 type ProcessorSettings struct {
-	Enabled bool `mapstructure:"enabled"`
+	TypeVal string `mapstructure:"-"`
+	Enabled bool   `mapstructure:"enabled"`
 }
+
+// Type sets the processor type.
+func (proc *ProcessorSettings) Type() string {
+	return proc.TypeVal
+}
+
+// SetType sets the processor type.
+func (proc *ProcessorSettings) SetType(typeStr string) {
+	proc.TypeVal = typeStr
+}
+
+var _ Processor = (*ProcessorSettings)(nil)

--- a/internal/configv2/configv2.go
+++ b/internal/configv2/configv2.go
@@ -312,6 +312,7 @@ func loadProcessors(v *viper.Viper) (configmodels.Processors, error) {
 
 		// Create the default config for this processors
 		processorCfg := factory.CreateDefaultConfig()
+		processorCfg.SetType(typeStr)
 
 		// Now that the default config struct is created we can Unmarshal into it
 		// and it will apply user-defined config on top of the default.

--- a/internal/configv2/configv2_test.go
+++ b/internal/configv2/configv2_test.go
@@ -83,6 +83,7 @@ func TestDecodeConfig(t *testing.T) {
 	assert.Equal(t, config.Processors["exampleprocessor"],
 		&ExampleProcessor{
 			ProcessorSettings: configmodels.ProcessorSettings{
+				TypeVal: "exampleprocessor",
 				Enabled: false,
 			},
 			ExtraSetting: "some export string",

--- a/internal/configv2/example_factories.go
+++ b/internal/configv2/example_factories.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/census-instrumentation/opencensus-service/consumer"
+	"github.com/census-instrumentation/opencensus-service/data"
 	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
 	"github.com/census-instrumentation/opencensus-service/internal/factories"
 	"github.com/census-instrumentation/opencensus-service/processor"
@@ -169,12 +170,30 @@ func (f *ExampleExporterFactory) CreateDefaultConfig() configmodels.Exporter {
 
 // CreateTraceExporter creates a trace exporter based on this config.
 func (f *ExampleExporterFactory) CreateTraceExporter(cfg configmodels.Exporter) (consumer.TraceConsumer, factories.StopFunc, error) {
-	return nil, nil, nil
+	return &ExampleExporterConsumer{}, nil, nil
 }
 
 // CreateMetricsExporter creates a metrics exporter based on this config.
 func (f *ExampleExporterFactory) CreateMetricsExporter(cfg configmodels.Exporter) (consumer.MetricsConsumer, factories.StopFunc, error) {
-	return nil, nil, nil
+	return &ExampleExporterConsumer{}, nil, nil
+}
+
+// ExampleExporterConsumer stores consumed traces and metrics for testing purposes.
+type ExampleExporterConsumer struct {
+	Traces  []data.TraceData
+	Metrics []data.MetricsData
+}
+
+// ConsumeTraceData receives data.TraceData for processing by the TraceConsumer.
+func (exp *ExampleExporterConsumer) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+	exp.Traces = append(exp.Traces, td)
+	return nil
+}
+
+// ConsumeMetricsData receives data.MetricsData for processing by the MetricsConsumer.
+func (exp *ExampleExporterConsumer) ConsumeMetricsData(ctx context.Context, md data.MetricsData) error {
+	exp.Metrics = append(exp.Metrics, md)
+	return nil
 }
 
 // ExampleProcessor is for testing purposes. We are defining an example config and factory

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -16,6 +16,8 @@ package testutils
 
 import (
 	"encoding/json"
+	"net"
+	"testing"
 )
 
 // GenerateNormalizedJSON generates a normalized JSON from the string
@@ -27,4 +29,19 @@ func GenerateNormalizedJSON(j string) string {
 	json.Unmarshal([]byte(j), &i)
 	n, _ := json.Marshal(i)
 	return string(n)
+}
+
+// GetAvailableLocalAddress finds an available local port and returns an endpoint
+// describing it. The port is available for opening when this function returns
+// provided that there is no race by some other code to grab the same port
+// immediately.
+func GetAvailableLocalAddress(t *testing.T) string {
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("failed to get a free local port: %v", err)
+	}
+	// There is a possible race if something else takes this same port before
+	// the test uses it, however, that is unlikely in practice.
+	defer ln.Close()
+	return ln.Addr().String()
 }

--- a/processor/addattributesprocessor/config_test.go
+++ b/processor/addattributesprocessor/config_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/census-instrumentation/opencensus-service/internal/configmodels"
 	"github.com/census-instrumentation/opencensus-service/internal/configv2"
 	"github.com/census-instrumentation/opencensus-service/internal/factories"
 )
@@ -42,6 +43,9 @@ func TestLoadConfig(t *testing.T) {
 	p1 := config.Processors["attributes/2"]
 	assert.Equal(t, p1,
 		&ConfigV2{
+			ProcessorSettings: configmodels.ProcessorSettings{
+				TypeVal: "attributes",
+			},
 			Values: map[string]interface{}{
 				"attribute1":         123,
 				"string attribute":   "string value",

--- a/processor/addattributesprocessor/factory.go
+++ b/processor/addattributesprocessor/factory.go
@@ -40,6 +40,9 @@ func (f *processorFactory) Type() string {
 // CreateDefaultConfig creates the default configuration for exporter.
 func (f *processorFactory) CreateDefaultConfig() configmodels.Processor {
 	return &ConfigV2{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			TypeVal: typeStr,
+		},
 		Values: map[string]interface{}{},
 	}
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -31,3 +31,8 @@ type MetricsProcessor interface {
 
 	// TODO: Add processor specific functions.
 }
+
+// Processor is a data consumer.
+type Processor interface {
+	consumer.DataConsumer
+}

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/census-instrumentation/opencensus-service/internal/factories"
+	"github.com/census-instrumentation/opencensus-service/internal/testutils"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -32,6 +33,9 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateReceiver(t *testing.T) {
 	factory := factories.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
+
+	config := cfg.(*ConfigV2)
+	config.Endpoint = testutils.GetAvailableLocalAddress(t)
 
 	tReceiver, err := factory.CreateTraceReceiver(context.Background(), cfg, nil)
 	assert.NotNil(t, tReceiver)


### PR DESCRIPTION
- Build pipeline processors and plug them into exporters.
- Added tests to verify that single exporter and multiple exporter pipelines
  (fan out) work correctly.
- Minor cleanup in exporters_builder.go
- Fixed opencensus receiver TestCreateReceiver to find available port for
  testing (instead of fixed port which would fail if already listened).