### PR TITLE
Follow golang/wiki recommendation for tool dependencies and reduce install tools set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,7 @@ vet:
 
 .PHONY: install-tools
 install-tools:
-	go get -u golang.org/x/lint/golint
-	go get -u github.com/google/go-cmp/cmp
-	go get contrib.go.opencensus.io/exporter/jaeger@v0.1.1-0.20190430175949-e8b55949d948
-	go get contrib.go.opencensus.io/exporter/prometheus
-	go get contrib.go.opencensus.io/exporter/zipkin
+	go get golang.org/x/lint/golint
 
 .PHONY: agent
 agent:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # More exclusions can be added similar with: -not -path './vendor/*'
 ALL_SRC := $(shell find . -name '*.go' \
                                 -not -path './vendor/*' \
+                                -not -path './tools/*' \
                                 -type f | sort)
 
 # ALL_PKGS is used with 'go cover'

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ vet:
 
 .PHONY: install-tools
 install-tools:
-	go get golang.org/x/lint/golint
+	go install golang.org/x/lint/golint
 
 .PHONY: agent
 agent:

--- a/go.mod
+++ b/go.mod
@@ -57,11 +57,7 @@ require (
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1
-	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 // indirect
-	golang.org/x/lint v0.0.0-20190409202823-959b441ac422 // indirect
-	golang.org/x/net v0.0.0-20190611141213-3f473d35a33a // indirect
-	golang.org/x/sys v0.0.0-20190610200419-93c9922d18ae // indirect
-	golang.org/x/tools v0.0.0-20190612180059-59534d075a87 // indirect
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3
 	google.golang.org/api v0.5.0
 	google.golang.org/grpc v1.21.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.12.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -420,6 +420,7 @@ golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
+golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 h1:XQyxROzUlZH+WIQwySDgnISgOivlhjIEwaQaJEJrrN0=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422 h1:QzoH/1pFpZguR8NrRHLcO6jKqfv2zpuSqZLgdm7ZmjI=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -487,6 +488,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190312170243-e65039ee4138 h1:H3uGjxCR/6Ds0Mjgyp7LMK81+LvmbvWWEnJhzk1Pi9E=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190612180059-59534d075a87 h1:RZgRBvCwrKVLcEd+O/QbyISA6RAPPLTYHdPw4Nk0Wz0=
 golang.org/x/tools v0.0.0-20190612180059-59534d075a87/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,0 +1,25 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// +build tools
+
+// Package tools follows the recommendation at
+// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// on how to add tooling dependencies.
+package tools
+
+import (
+	_ "golang.org/x/lint/golint"
+)


### PR DESCRIPTION
From original change by @owais 

Reduces the set of install-tool dependencies and user the recommended to ensure that every build is using the same version of golint, we will have to manually update it when appropriate, but, this happens in a controlled fashion (ie.: no surprises by this being updated).

This way to control dependencies follows the recommendation at https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module on how to add tooling dependencies that was pointed by @owais.