### PR TITLE
add resource to vmreceiver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.2
 	contrib.go.opencensus.io/exporter/zipkin v0.1.1
+	contrib.go.opencensus.io/resource v0.1.1
 	github.com/DataDog/datadog-go v2.2.0+incompatible // indirect
 	github.com/DataDog/opencensus-go-exporter-datadog v0.0.0-20181026070331-e7c4bd17b329
 	github.com/VividCortex/gohistogram v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,7 @@ contrib.go.opencensus.io/exporter/stackdriver v0.12.2 h1:jU1p9F07ASK11wYgSTPKtFl
 contrib.go.opencensus.io/exporter/stackdriver v0.12.2/go.mod h1:iwB6wGarfphGGe/e5CWqyUk/cLzKnWsOKPVW3no6OTw=
 contrib.go.opencensus.io/exporter/zipkin v0.1.1 h1:PR+1zWqY8ceXs1qDQQIlgXe+sdiwCf0n32bH4+Epk8g=
 contrib.go.opencensus.io/exporter/zipkin v0.1.1/go.mod h1:GMvdSl3eJ2gapOaLKzTKE3qDgUkJ86k9k3yY2eqwkzc=
+contrib.go.opencensus.io/resource v0.1.1 h1:4r2CANuYhKGmYWP02+5E94rLRcS/YeD+KlxSrOsMxk0=
 contrib.go.opencensus.io/resource v0.1.1/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999 h1:sihTnRgTOUSCQz0iS0pjZuFQy/z7GXCJgSBg3+rZKHw=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=

--- a/receiver/vmmetricsreceiver/vm_metrics_collector.go
+++ b/receiver/vmmetricsreceiver/vm_metrics_collector.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sync"
 	"time"
 
+	"contrib.go.opencensus.io/resource/auto"
 	"github.com/prometheus/procfs"
 	"go.opencensus.io/trace"
 
@@ -29,6 +31,7 @@ import (
 	"github.com/census-instrumentation/opencensus-service/internal"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 )
 
 // VMMetricsCollector is a struct that collects and reports VM and process metrics (cpu, mem, etc).
@@ -50,6 +53,9 @@ const (
 	defaultMountPoint     = procfs.DefaultMountPoint // "/proc"
 	defaultScrapeInterval = 10 * time.Second
 )
+
+var rsc *resourcepb.Resource
+var resourceDetectorSync sync.Once
 
 // NewVMMetricsCollector creates a new set of VM and Process Metrics (mem, cpu).
 func NewVMMetricsCollector(si time.Duration, mountPoint, processMountPoint, prefix string, consumer consumer.MetricsConsumer) (*VMMetricsCollector, error) {
@@ -84,8 +90,28 @@ func NewVMMetricsCollector(si time.Duration, mountPoint, processMountPoint, pref
 	return vmc, nil
 }
 
+func detectResource() {
+	resourceDetectorSync.Do(func() {
+		res, err := auto.Detect(context.Background())
+		if err != nil {
+			panic(fmt.Sprintf("Resource detection failed, err:%v", err))
+		}
+		if res != nil {
+			rsc = &resourcepb.Resource{
+				Type:   res.Type,
+				Labels: make(map[string]string, len(res.Labels)),
+			}
+			for k, v := range res.Labels {
+				rsc.Labels[k] = v
+			}
+		}
+	})
+}
+
 // StartCollection starts a ticker'd goroutine that will scrape and export vm metrics periodically.
 func (vmc *VMMetricsCollector) StartCollection() {
+	detectResource()
+
 	go func() {
 		ticker := time.NewTicker(vmc.scrapeInterval)
 		for {
@@ -118,14 +144,17 @@ func (vmc *VMMetricsCollector) scrapeAndExport() {
 		metrics,
 		&metricspb.Metric{
 			MetricDescriptor: metricAllocMem,
+			Resource:         rsc,
 			Timeseries:       []*metricspb.TimeSeries{vmc.getInt64TimeSeries(ms.Alloc)},
 		},
 		&metricspb.Metric{
 			MetricDescriptor: metricTotalAllocMem,
+			Resource:         rsc,
 			Timeseries:       []*metricspb.TimeSeries{vmc.getInt64TimeSeries(ms.TotalAlloc)},
 		},
 		&metricspb.Metric{
 			MetricDescriptor: metricSysMem,
+			Resource:         rsc,
 			Timeseries:       []*metricspb.TimeSeries{vmc.getInt64TimeSeries(ms.Sys)},
 		},
 	)
@@ -140,6 +169,7 @@ func (vmc *VMMetricsCollector) scrapeAndExport() {
 				metrics,
 				&metricspb.Metric{
 					MetricDescriptor: metricProcessCPUSeconds,
+					Resource:         rsc,
 					Timeseries:       []*metricspb.TimeSeries{vmc.getDoubleTimeSeries(procStat.CPUTime(), nil)},
 				},
 			)
@@ -156,18 +186,22 @@ func (vmc *VMMetricsCollector) scrapeAndExport() {
 			metrics,
 			&metricspb.Metric{
 				MetricDescriptor: metricProcessesRunning,
+				Resource:         rsc,
 				Timeseries:       []*metricspb.TimeSeries{vmc.getInt64TimeSeries(stat.ProcessesRunning)},
 			},
 			&metricspb.Metric{
 				MetricDescriptor: metricProcessesBlocked,
+				Resource:         rsc,
 				Timeseries:       []*metricspb.TimeSeries{vmc.getInt64TimeSeries(stat.ProcessesBlocked)},
 			},
 			&metricspb.Metric{
 				MetricDescriptor: metricProcessesCreated,
+				Resource:         rsc,
 				Timeseries:       []*metricspb.TimeSeries{vmc.getInt64TimeSeries(stat.ProcessCreated)},
 			},
 			&metricspb.Metric{
 				MetricDescriptor: metricCPUSeconds,
+				Resource:         rsc,
 				Timeseries: []*metricspb.TimeSeries{
 					vmc.getDoubleTimeSeries(cpuStat.User, labelValueCPUUser),
 					vmc.getDoubleTimeSeries(cpuStat.System, labelValueCPUSystem),


### PR DESCRIPTION
porting [changes](https://github.com/open-telemetry/opentelemetry-service/pull/31) from open-telemetry.
Porting it here because SD exporter is removed from otelsvc in opentelemetry-service (equivalent of OcAgent in opencensus-service.

