### PR TITLE
Set g.co/agent in Stackdriver exported via Node info

### DIFF
--- a/exporter/exporterwrapper/exporterwrapper.go
+++ b/exporter/exporterwrapper/exporterwrapper.go
@@ -34,6 +34,12 @@ import (
 	spandatatranslator "github.com/census-instrumentation/opencensus-service/translator/trace/spandata"
 )
 
+// OCSpanExporter is an interface for the ExportSpan function of trace.Exporter.
+// This enables passing in fake exporters in unit tests.
+type OCSpanExporter interface {
+	ExportSpan(sd *trace.SpanData)
+}
+
 // NewExporterWrapper returns a consumer.TraceConsumer that converts OpenCensus Proto TraceData
 // to OpenCensus-Go SpanData and calls into the given trace.Exporter.
 //
@@ -42,7 +48,7 @@ import (
 // by various vendors and contributors. Eventually the goal is to
 // get those exporters converted to directly receive
 // OpenCensus Proto TraceData.
-func NewExporterWrapper(exporterName string, spanName string, ocExporter trace.Exporter) (exporter.TraceExporter, error) {
+func NewExporterWrapper(exporterName string, spanName string, ocExporter OCSpanExporter) (exporter.TraceExporter, error) {
 	return exporterhelper.NewTraceExporter(
 		exporterName,
 		func(ctx context.Context, td data.TraceData) (int, error) {
@@ -57,7 +63,7 @@ func NewExporterWrapper(exporterName string, spanName string, ocExporter trace.E
 
 // PushOcProtoSpansToOCTraceExporter pushes TraceData to the given trace.Exporter by converting the
 // protos to trace.SpanData.
-func PushOcProtoSpansToOCTraceExporter(ocExporter trace.Exporter, td data.TraceData) (int, error) {
+func PushOcProtoSpansToOCTraceExporter(ocExporter OCSpanExporter, td data.TraceData) (int, error) {
 	var errs []error
 	var goodSpans []*tracepb.Span
 	for _, span := range td.Spans {

--- a/exporter/stackdriverexporter/stackdriverexporter_test.go
+++ b/exporter/stackdriverexporter/stackdriverexporter_test.go
@@ -25,12 +25,13 @@ import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/census-instrumentation/opencensus-service/data"
-	"github.com/census-instrumentation/opencensus-service/exporter/exportertest"
-	"github.com/census-instrumentation/opencensus-service/internal/config/viperutils"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/spf13/viper"
 	"go.opencensus.io/trace"
+
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/exporter/exportertest"
+	"github.com/census-instrumentation/opencensus-service/internal/config/viperutils"
 )
 
 type fakeStackdriverExporter struct {
@@ -55,83 +56,175 @@ func fakeStackdriverNewExporter(opts stackdriver.Options) (*stackdriver.Exporter
 }
 
 func TestStackriverExporter(t *testing.T) {
-	v := viper.New()
-	configYAML := []byte(`
+	tests := []struct {
+		name      string
+		traceData data.TraceData
+		want      []*trace.SpanData
+	}{
+		{name: "full span with node and library info, check that agentLabel gets set",
+			traceData: data.TraceData{
+				Node: &commonpb.Node{
+					LibraryInfo: &commonpb.LibraryInfo{
+						Language:           commonpb.LibraryInfo_PYTHON,
+						ExporterVersion:    "0.4.1",
+						CoreLibraryVersion: "0.3.2",
+					},
+				},
+				Spans: []*tracepb.Span{
+					{
+						TraceId:   []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x80},
+						SpanId:    []byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8},
+						Name:      &tracepb.TruncatableString{Value: "DBSearch"},
+						StartTime: &timestamp.Timestamp{Seconds: 1550000001, Nanos: 1},
+						EndTime:   &timestamp.Timestamp{Seconds: 1550000002, Nanos: 1},
+						Attributes: &tracepb.Span_Attributes{
+							AttributeMap: map[string]*tracepb.AttributeValue{
+								"cache_hit": {Value: &tracepb.AttributeValue_BoolValue{BoolValue: true}},
+							},
+						},
+					},
+				},
+				SourceFormat: "oc_trace",
+			},
+			want: []*trace.SpanData{
+				{
+					Name: "DBSearch",
+					SpanContext: trace.SpanContext{
+						TraceID: trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 128},
+						SpanID:  trace.SpanID{175, 174, 173, 172, 171, 170, 169, 168},
+					},
+					StartTime: time.Unix(1550000001, 1),
+					EndTime:   time.Unix(1550000002, 1),
+					// Check that the agent label is correctly formed based on the library
+					// info given in the Node structure above.
+					Attributes: map[string]interface{}{
+						"cache_hit": true,
+						agentLabel:  "opencensus-python 0.3.2; ocagent-exporter 0.4.1",
+					},
+				},
+			},
+		},
+		{name: "no node specified, so agentLabel not set",
+			traceData: data.TraceData{
+				Spans: []*tracepb.Span{
+					{
+						Attributes: &tracepb.Span_Attributes{
+							AttributeMap: map[string]*tracepb.AttributeValue{
+								"cache_hit": {Value: &tracepb.AttributeValue_BoolValue{BoolValue: true}},
+							},
+						},
+					},
+				},
+			},
+			want: []*trace.SpanData{{Attributes: map[string]interface{}{"cache_hit": true}}},
+		},
+		{name: "no library info specified, so agentLabel not set",
+			traceData: data.TraceData{
+				Node: &commonpb.Node{
+					Attributes: map[string]string{"attr1": "val1"},
+				},
+				Spans: []*tracepb.Span{
+					{
+						Attributes: &tracepb.Span_Attributes{
+							AttributeMap: map[string]*tracepb.AttributeValue{
+								"cache_hit": {Value: &tracepb.AttributeValue_BoolValue{BoolValue: true}},
+							},
+						},
+					},
+				},
+			},
+			want: []*trace.SpanData{{Attributes: map[string]interface{}{"cache_hit": true}}},
+		},
+		{name: "empty library info, so agentLabel gets empty default",
+			traceData: data.TraceData{
+				Node: &commonpb.Node{
+					LibraryInfo: &commonpb.LibraryInfo{},
+				},
+				Spans: []*tracepb.Span{
+					{
+						Attributes: &tracepb.Span_Attributes{
+							AttributeMap: map[string]*tracepb.AttributeValue{
+								"cache_hit": {Value: &tracepb.AttributeValue_BoolValue{BoolValue: true}},
+							},
+						},
+					},
+				},
+			},
+			want: []*trace.SpanData{{Attributes: map[string]interface{}{
+				"cache_hit": true,
+				agentLabel:  "opencensus-language_unspecified ; ocagent-exporter ",
+			}}},
+		},
+		{name: "no attributes set, still assigns agentLabel",
+			traceData: data.TraceData{
+				Node: &commonpb.Node{
+					LibraryInfo: &commonpb.LibraryInfo{
+						Language:           commonpb.LibraryInfo_WEB_JS,
+						CoreLibraryVersion: "0.0.2",
+						ExporterVersion:    "0.0.3",
+					},
+				},
+				Spans: []*tracepb.Span{{}},
+			},
+			want: []*trace.SpanData{{Attributes: map[string]interface{}{
+				agentLabel: "opencensus-web_js 0.0.2; ocagent-exporter 0.0.3",
+			}}},
+		},
+		{name: "no attributes map set, still assigns agentLabel",
+			traceData: data.TraceData{
+				Node: &commonpb.Node{
+					LibraryInfo: &commonpb.LibraryInfo{
+						Language:           commonpb.LibraryInfo_WEB_JS,
+						CoreLibraryVersion: "0.0.2",
+						ExporterVersion:    "0.0.3",
+					},
+				},
+				Spans: []*tracepb.Span{{Attributes: &tracepb.Span_Attributes{}}},
+			},
+			want: []*trace.SpanData{{Attributes: map[string]interface{}{
+				agentLabel: "opencensus-web_js 0.0.2; ocagent-exporter 0.0.3",
+			}}},
+		},
+	}
+
+	for _, tt := range tests {
+		v := viper.New()
+		configYAML := []byte(`
 stackdriver:
   project: 'test-project'
   enable_tracing: true
   enable_metrics: true
   metric_prefix: 'test-metric-prefix'`)
-	err := viperutils.LoadYAMLBytes(v, configYAML)
-	exp := fakeStackdriverExporter{}
-	tps, mps, doneFns, err := stackdriverTraceExportersFromViperInternal(v, func(opts stackdriver.Options) (stackdriverExporterInterface, error) {
-		if opts.ProjectID != "test-project" {
-			t.Errorf("Unexpected ProjectID: %v", opts.ProjectID)
+		err := viperutils.LoadYAMLBytes(v, configYAML)
+		exp := fakeStackdriverExporter{}
+		tps, mps, doneFns, err := stackdriverTraceExportersFromViperInternal(v, func(opts stackdriver.Options) (stackdriverExporterInterface, error) {
+			if opts.ProjectID != "test-project" {
+				t.Errorf("Unexpected ProjectID: %v", opts.ProjectID)
+			}
+			if opts.MetricPrefix != "test-metric-prefix" {
+				t.Errorf("Unexpected MetricPrefix: %v", opts.MetricPrefix)
+			}
+			return &exp, nil
+		})
+		if len(tps) != 1 {
+			t.Errorf("Unexpected TraceConsumer count: %v", len(tps))
 		}
-		if opts.MetricPrefix != "test-metric-prefix" {
-			t.Errorf("Unexpected MetricPrefix: %v", opts.MetricPrefix)
+		if len(mps) != 1 {
+			t.Errorf("Unexpected MetricsConsumer count: %v", len(mps))
 		}
-		return &exp, nil
-	})
-	if len(tps) != 1 {
-		t.Errorf("Unexpected TraceConsumer count: %v", len(tps))
-	}
-	if len(mps) != 1 {
-		t.Errorf("Unexpected MetricsConsumer count: %v", len(mps))
-	}
-	if len(doneFns) != 1 {
-		t.Errorf("Unexpected doneFns count: %v", len(doneFns))
-	}
-	if err != nil {
-		t.Errorf("Expected nil erorr, got %v", err)
-	}
+		if len(doneFns) != 1 {
+			t.Errorf("Unexpected doneFns count: %v", len(doneFns))
+		}
+		if err != nil {
+			t.Errorf("Expected nil erorr, got %v", err)
+		}
 
-	td := data.TraceData{
-		Node: &commonpb.Node{
-			LibraryInfo: &commonpb.LibraryInfo{
-				Language:           commonpb.LibraryInfo_PYTHON,
-				ExporterVersion:    "0.4.1",
-				CoreLibraryVersion: "0.3.2",
-			},
-		},
-		Spans: []*tracepb.Span{
-			{
-				TraceId:   []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x80},
-				SpanId:    []byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8},
-				Name:      &tracepb.TruncatableString{Value: "DBSearch"},
-				StartTime: &timestamp.Timestamp{Seconds: 1550000001, Nanos: 1},
-				EndTime:   &timestamp.Timestamp{Seconds: 1550000002, Nanos: 1},
-				Attributes: &tracepb.Span_Attributes{
-					AttributeMap: map[string]*tracepb.AttributeValue{
-						"cache_hit": {Value: &tracepb.AttributeValue_BoolValue{BoolValue: true}},
-					},
-				},
-			},
-		},
-		SourceFormat: "oc_trace",
-	}
-	tps[0].ConsumeTraceData(context.Background(), td)
+		tps[0].ConsumeTraceData(context.Background(), tt.traceData)
 
-	want := []*trace.SpanData{
-		{
-			Name: "DBSearch",
-			SpanContext: trace.SpanContext{
-				TraceID: trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 128},
-				SpanID:  trace.SpanID{175, 174, 173, 172, 171, 170, 169, 168},
-			},
-			StartTime: time.Unix(1550000001, 1),
-			EndTime:   time.Unix(1550000002, 1),
-			// Check that the agent label is correctly formed based on the library
-			// info given in the Node structure above.
-			Attributes: map[string]interface{}{
-				"cache_hit": true,
-				agentLabel:  "opencensus-python 0.3.2; ocagent-exporter 0.4.1",
-			},
-		},
-	}
-	got := exp.spanData
-	if !reflect.DeepEqual(got, want) {
-		gj, wj := exportertest.ToJSON(got), exportertest.ToJSON(want)
-		t.Errorf("Incorrect exported SpanData\nGot:\n\t%s\nWant:\n\t%s", gj, wj)
+		got := exp.spanData
+		if !reflect.DeepEqual(got, tt.want) {
+			gj, wj := exportertest.ToJSON(got), exportertest.ToJSON(tt.want)
+			t.Errorf("Test %s: Incorrect exported SpanData\nGot:\n\t%s\nWant:\n\t%s", tt.name, gj, wj)
+		}
 	}
 }

--- a/exporter/stackdriverexporter/stackdriverexporter_test.go
+++ b/exporter/stackdriverexporter/stackdriverexporter_test.go
@@ -14,4 +14,124 @@
 
 package stackdriverexporter
 
-// TODO: Add tests.
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"contrib.go.opencensus.io/exporter/stackdriver"
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/census-instrumentation/opencensus-service/data"
+	"github.com/census-instrumentation/opencensus-service/exporter/exportertest"
+	"github.com/census-instrumentation/opencensus-service/internal/config/viperutils"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/spf13/viper"
+	"go.opencensus.io/trace"
+)
+
+type fakeStackdriverExporter struct {
+	spanData []*trace.SpanData
+}
+
+var _ stackdriverExporterInterface = (*fakeStackdriverExporter)(nil)
+
+func (*fakeStackdriverExporter) ExportMetricsProto(ctx context.Context, node *commonpb.Node, rsc *resourcepb.Resource, metrics []*metricspb.Metric) error {
+	return nil
+}
+
+func (exp *fakeStackdriverExporter) ExportSpan(sd *trace.SpanData) {
+	exp.spanData = append(exp.spanData, sd)
+}
+
+func (*fakeStackdriverExporter) Flush() {
+}
+
+func fakeStackdriverNewExporter(opts stackdriver.Options) (*stackdriver.Exporter, error) {
+	return nil, nil
+}
+
+func TestStackriverExporter(t *testing.T) {
+	v := viper.New()
+	configYAML := []byte(`
+stackdriver:
+  project: 'test-project'
+  enable_tracing: true
+  enable_metrics: true
+  metric_prefix: 'test-metric-prefix'`)
+	err := viperutils.LoadYAMLBytes(v, configYAML)
+	exp := fakeStackdriverExporter{}
+	tps, mps, doneFns, err := stackdriverTraceExportersFromViperInternal(v, func(opts stackdriver.Options) (stackdriverExporterInterface, error) {
+		if opts.ProjectID != "test-project" {
+			t.Errorf("Unexpected ProjectID: %v", opts.ProjectID)
+		}
+		if opts.MetricPrefix != "test-metric-prefix" {
+			t.Errorf("Unexpected MetricPrefix: %v", opts.MetricPrefix)
+		}
+		return &exp, nil
+	})
+	if len(tps) != 1 {
+		t.Errorf("Unexpected TraceConsumer count: %v", len(tps))
+	}
+	if len(mps) != 1 {
+		t.Errorf("Unexpected MetricsConsumer count: %v", len(mps))
+	}
+	if len(doneFns) != 1 {
+		t.Errorf("Unexpected doneFns count: %v", len(doneFns))
+	}
+	if err != nil {
+		t.Errorf("Expected nil erorr, got %v", err)
+	}
+
+	td := data.TraceData{
+		Node: &commonpb.Node{
+			LibraryInfo: &commonpb.LibraryInfo{
+				Language:           commonpb.LibraryInfo_PYTHON,
+				ExporterVersion:    "0.4.1",
+				CoreLibraryVersion: "0.3.2",
+			},
+		},
+		Spans: []*tracepb.Span{
+			{
+				TraceId:   []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x80},
+				SpanId:    []byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8},
+				Name:      &tracepb.TruncatableString{Value: "DBSearch"},
+				StartTime: &timestamp.Timestamp{Seconds: 1550000001, Nanos: 1},
+				EndTime:   &timestamp.Timestamp{Seconds: 1550000002, Nanos: 1},
+				Attributes: &tracepb.Span_Attributes{
+					AttributeMap: map[string]*tracepb.AttributeValue{
+						"cache_hit": {Value: &tracepb.AttributeValue_BoolValue{BoolValue: true}},
+					},
+				},
+			},
+		},
+		SourceFormat: "oc_trace",
+	}
+	tps[0].ConsumeTraceData(context.Background(), td)
+
+	want := []*trace.SpanData{
+		{
+			Name: "DBSearch",
+			SpanContext: trace.SpanContext{
+				TraceID: trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 128},
+				SpanID:  trace.SpanID{175, 174, 173, 172, 171, 170, 169, 168},
+			},
+			StartTime: time.Unix(1550000001, 1),
+			EndTime:   time.Unix(1550000002, 1),
+			// Check that the agent label is correctly formed based on the library
+			// info given in the Node structure above.
+			Attributes: map[string]interface{}{
+				"cache_hit": true,
+				agentLabel:  "opencensus-python 0.3.2; ocagent-exporter 0.4.1",
+			},
+		},
+	}
+	got := exp.spanData
+	if !reflect.DeepEqual(got, want) {
+		gj, wj := exportertest.ToJSON(got), exportertest.ToJSON(want)
+		t.Errorf("Incorrect exported SpanData\nGot:\n\t%s\nWant:\n\t%s", gj, wj)
+	}
+}


### PR DESCRIPTION
This uses the `Language`, `CoreLibraryVersion` and `ExporterVersion` fields of the `LibraryInfo` message on `Node` to set the `g.co/agent` span label in the Stackdriver exporter.

Because this code is running in the OpenCensus service (agent/collector) it's safe to assume that the exporter type in the application library code must have been the `ocagent-exporter`. Hence, it sets the `g.co/agent` string as follows: `opencensus-[Language] [CoreLibraryVersion]; ocagent-exporter [ExporterVersion]`, e.g. `opencensus-python 0.0.1; ocagent-exporter 0.0.2`

Fixes https://github.com/census-instrumentation/opencensus-service/issues/525.