### PR TITLE
Support environment variables when configuring exporters

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -477,6 +477,11 @@ func ExportersFromViperConfig(logger *zap.Logger, v *viper.Viper) ([]consumer.Tr
 	if exportersViper == nil {
 		return nil, nil, nil, nil
 	}
+
+	exportersViper.AutomaticEnv()
+	exportersViper.SetEnvPrefix("exporters")
+	exportersViper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+
 	for _, cfg := range parseFns {
 		tes, mes, tesDoneFns, err := cfg.fn(exportersViper)
 		if err != nil {


### PR DESCRIPTION
`viper.AutomaticEnv` is enabled and environment variable overrides works
for configuration sections outside of `exporters`. However, a Viper
limitation (https://github.com/spf13/viper/issues/507) prevents this
from working as expected in "sub" viper instances.

This work around allows environment variables to be used with exporter
configurations as well.