### PR TITLE
fix: add missing tracing status from jaeger thirft

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,3 +61,5 @@ require (
 )
 
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ contrib.go.opencensus.io/exporter/zipkin v0.1.1 h1:PR+1zWqY8ceXs1qDQQIlgXe+sdiwC
 contrib.go.opencensus.io/exporter/zipkin v0.1.1/go.mod h1:GMvdSl3eJ2gapOaLKzTKE3qDgUkJ86k9k3yY2eqwkzc=
 contrib.go.opencensus.io/resource v0.1.2 h1:b4WFJV8u7/NzPWHeTqj3Ec2AW8OGhtJxC/hbphIOvbU=
 contrib.go.opencensus.io/resource v0.1.2/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
-git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999 h1:sihTnRgTOUSCQz0iS0pjZuFQy/z7GXCJgSBg3+rZKHw=
-git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/Azure/azure-sdk-for-go v0.0.0-20161028183111-bd73d950fa44 h1:L4fLiifszjLnCRGi6Xhp0MgUwjIMbVXKbayoRiVxkU8=
 github.com/Azure/azure-sdk-for-go v0.0.0-20161028183111-bd73d950fa44/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v10.8.1+incompatible h1:u0jVQf+a6k6x8A+sT60l6EY9XZu+kHdnZVPAYqpVRo0=

--- a/translator/trace/jaeger/protospan_to_jaegerthrift_test.go
+++ b/translator/trace/jaeger/protospan_to_jaegerthrift_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"go.opencensus.io/trace"
+
 	tracetranslator "github.com/census-instrumentation/opencensus-service/translator/trace"
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
@@ -111,6 +113,28 @@ func TestNilOCProtoNodeToJaegerThrift(t *testing.T) {
 	if got.Process != unknownProcess {
 		t.Fatalf("got unexpected Jaeger Process field")
 	}
+}
+
+func TestTestOCProtoToJagerSpans(t *testing.T) {
+	testSpans := []*tracepb.Span{
+		{
+			TraceId: []byte("0123456789abcdef"),
+			SpanId:  []byte("01234567"),
+			Status:  &tracepb.Status{Code: trace.StatusCodeNotFound, Message: "cache miss"},
+		},
+	}
+	spans, err := ocSpansToJaegerSpans(testSpans)
+	if err != nil {
+		t.Fatalf("error getting spans: %v", err)
+	}
+
+	if spans[0].Tags[0].Key != "status.code" {
+		t.Fatal("wrong key found for status.code")
+	}
+	if spans[0].Tags[1].Key != "status.message" {
+		t.Fatal("wrong key found for status.message")
+	}
+
 }
 
 func TestOCProtoToJaegerThrift(t *testing.T) {


### PR DESCRIPTION
`status.message`, `status.code` and `error` were missing from the opencensus collector when forwarding the request to jaeger over `jaeger-http-thift` which seems to be the default config.