### PR TITLE
Allow specifying an address for all receivers

### DIFF
--- a/cmd/occollector/app/builder/builder.go
+++ b/cmd/occollector/app/builder/builder.go
@@ -74,6 +74,13 @@ func DebugTailSamplingEnabled(v *viper.Viper) bool {
 
 // JaegerReceiverCfg holds configuration for Jaeger receivers.
 type JaegerReceiverCfg struct {
+	// Address is an IP address or a name that can be resolved to a local address.
+	//
+	// It can use a name, but this is not recommended, because it will create
+	// a listener for at most one of the host's IP addresses.
+	//
+	// The default value bind to all available interfaces on the local computer.
+	Address string `mapstructure:"address"`
 	// ThriftTChannelPort is the port that the relay receives on for jaeger thrift tchannel requests
 	ThriftTChannelPort int `mapstructure:"jaeger-thrift-tchannel-port"`
 	// ThriftHTTPPort is the port that the relay receives on for jaeger thrift http requests
@@ -102,6 +109,13 @@ func (cfg *JaegerReceiverCfg) InitFromViper(v *viper.Viper) (*JaegerReceiverCfg,
 
 // OpenCensusReceiverCfg holds configuration for OpenCensus receiver.
 type OpenCensusReceiverCfg struct {
+	// Address is an IP address or a name that can be resolved to a local address.
+	//
+	// It can use a name, but this is not recommended, because it will create
+	// a listener for at most one of the host's IP addresses.
+	//
+	// The default value bind to all available interfaces on the local computer.
+	Address string `mapstructure:"address"`
 	// Port is the port that the receiver will use
 	Port int `mapstructure:"port"`
 
@@ -161,6 +175,13 @@ func (cfg *OpenCensusReceiverCfg) InitFromViper(v *viper.Viper) (*OpenCensusRece
 
 // ZipkinReceiverCfg holds configuration for Zipkin receiver.
 type ZipkinReceiverCfg struct {
+	// Address is an IP address or a name that can be resolved to a local address.
+	//
+	// It can use a name, but this is not recommended, because it will create
+	// a listener for at most one of the host's IP addresses.
+	//
+	// The default value bind to all available interfaces on the local computer.
+	Address string `mapstructure:"address"`
 	// Port is the port that the receiver will use
 	Port int `mapstructure:"port"`
 }

--- a/internal/collector/jaeger/receiver.go
+++ b/internal/collector/jaeger/receiver.go
@@ -43,6 +43,7 @@ func Start(logger *zap.Logger, v *viper.Viper, traceConsumer consumer.TraceConsu
 
 	ctx := context.Background()
 	config := &jaegerreceiver.Configuration{
+		Address:             rOpts.Address,
 		CollectorThriftPort: rOpts.ThriftTChannelPort,
 		CollectorHTTPPort:   rOpts.ThriftHTTPPort,
 	}

--- a/internal/collector/opencensus/receiver.go
+++ b/internal/collector/opencensus/receiver.go
@@ -74,7 +74,10 @@ func receiverOptions(v *viper.Viper) (addr string, opts []opencensusreceiver.Opt
 		opts = append(opts, opencensusreceiver.WithGRPCServerOptions(grpcServerOptions...))
 	}
 
-	addr = ":" + strconv.FormatInt(int64(rOpts.Port), 10)
+	addr = rOpts.Address + ":" + strconv.FormatInt(int64(rOpts.Port), 10)
+	if rOpts.Address != "" {
+		zapFields = append(zapFields, zap.String("address", rOpts.Address))
+	}
 	zapFields = append(zapFields, zap.Int("port", rOpts.Port))
 
 	return addr, opts, zapFields, err

--- a/internal/collector/opencensus/receiver_test.go
+++ b/internal/collector/opencensus/receiver_test.go
@@ -64,6 +64,7 @@ func TestStart(t *testing.T) {
 			name: "grpc_settings",
 			viperFn: func() *viper.Viper {
 				v := viper.New()
+				v.Set("receivers.opencensus.address", "127.0.0.1")
 				v.Set("receivers.opencensus.port", 55678)
 				v.Set("receivers.opencensus.max-recv-msg-size-mib", 32)
 				v.Set("receivers.opencensus.max-concurrent-streams", 64)

--- a/internal/collector/zipkin/receiver.go
+++ b/internal/collector/zipkin/receiver.go
@@ -37,7 +37,7 @@ func Start(logger *zap.Logger, v *viper.Viper, traceConsumer consumer.TraceConsu
 		return nil, err
 	}
 
-	addr := ":" + strconv.FormatInt(int64(rOpts.Port), 10)
+	addr := rOpts.Address + ":" + strconv.FormatInt(int64(rOpts.Port), 10)
 	zi, err := zipkinreceiver.New(addr, traceConsumer)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create the Zipkin receiver: %v", err)

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -46,8 +46,9 @@ import (
 // Configuration defines the behavior and the ports that
 // the Jaeger receiver will use.
 type Configuration struct {
-	CollectorThriftPort int `mapstructure:"tchannel_port"`
-	CollectorHTTPPort   int `mapstructure:"collector_http_port"`
+	Address             string `mapstructure:"address"`
+	CollectorThriftPort int    `mapstructure:"tchannel_port"`
+	CollectorHTTPPort   int    `mapstructure:"collector_http_port"`
 
 	AgentPort              int `mapstructure:"agent_port"`
 	AgentCompactThriftPort int `mapstructure:"agent_compact_thrift_port"`
@@ -118,7 +119,7 @@ func (jr *jReceiver) collectorAddr() string {
 	if port <= 0 {
 		port = defaultCollectorHTTPPort
 	}
-	return fmt.Sprintf(":%d", port)
+	return fmt.Sprintf("%s:%d", jr.config.Address, port)
 }
 
 const defaultAgentPort = 5778
@@ -131,7 +132,7 @@ func (jr *jReceiver) agentAddress() string {
 	if port <= 0 {
 		port = defaultAgentPort
 	}
-	return fmt.Sprintf(":%d", port)
+	return fmt.Sprintf("%s:%d", jr.config.Address, port)
 }
 
 func (jr *jReceiver) tchannelAddr() string {
@@ -142,7 +143,7 @@ func (jr *jReceiver) tchannelAddr() string {
 	if port <= 0 {
 		port = defaultTChannelPort
 	}
-	return fmt.Sprintf(":%d", port)
+	return fmt.Sprintf("%s:%d", jr.config.Address, port)
 }
 
 func (jr *jReceiver) AgentCompactThriftAddr() string {
@@ -153,7 +154,7 @@ func (jr *jReceiver) AgentCompactThriftAddr() string {
 	if port <= 0 {
 		port = defaultCompactThriftUDPPort
 	}
-	return fmt.Sprintf(":%d", port)
+	return fmt.Sprintf("%s:%d", jr.config.Address, port)
 }
 
 func (jr *jReceiver) agentBinaryThriftAddr() string {
@@ -164,7 +165,7 @@ func (jr *jReceiver) agentBinaryThriftAddr() string {
 	if port <= 0 {
 		port = defaultBinaryThriftUDPPort
 	}
-	return fmt.Sprintf(":%d", port)
+	return fmt.Sprintf("%s:%d", jr.config.Address, port)
 }
 
 func (jr *jReceiver) TraceSource() string {


### PR DESCRIPTION
Listening on all network interfaces is a security risk on our platform, as we can't easily restrict which ports are available to other components within the cluster.
In order to setup an authentication reverse proxy and have it really be enforced, we therefore need to be able to start the endpoints on the loopback network interface only.